### PR TITLE
fix(cli): handle empty schema.prisma without engine panic

### DIFF
--- a/packages/cli/src/__tests__/incomplete-schemas.test.ts
+++ b/packages/cli/src/__tests__/incomplete-schemas.test.ts
@@ -294,11 +294,7 @@ describe('[normalized library/binary] incomplete-schemas', () => {
       try {
         await DbPull.new().parse([], await ctx.config(), ctx.configDir())
       } catch (e) {
-        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`
-          "There is no datasource in the schema.
-
-          "
-        `)
+        expect(stripVTControlCharacters(e.message)).toMatchInlineSnapshot(`"Schema must contain a datasource block"`)
       }
     })
 

--- a/packages/migrate/src/__tests__/DbPull/postgresql.test.ts
+++ b/packages/migrate/src/__tests__/DbPull/postgresql.test.ts
@@ -90,16 +90,9 @@ describeMatrix(postgresOnly, 'postgresql', () => {
       ctx.fixture('empty-schema')
       const introspect = new DbPull()
       const result = introspect.parse(['--print'], await ctx.config(), ctx.configDir())
-      await expect(result).rejects.toMatchInlineSnapshot(`
-        "There is no datasource in the schema.
+      await expect(result).rejects.toMatchInlineSnapshot(`"Schema must contain a datasource block"`)
 
-        "
-      `)
-
-      expect(ctx.normalizedCapturedStdout()).toMatchInlineSnapshot(`
-        "
-        "
-      `)
+      expect(ctx.normalizedCapturedStdout()).toMatchInlineSnapshot(`""`)
       expect(ctx.normalizedCapturedStderr()).toMatchInlineSnapshot(`""`)
     })
 
@@ -107,16 +100,9 @@ describeMatrix(postgresOnly, 'postgresql', () => {
       ctx.fixture('generator-only')
       const introspect = new DbPull()
       const result = introspect.parse(['--print'], await ctx.config(), ctx.configDir())
-      await expect(result).rejects.toMatchInlineSnapshot(`
-        "There is no datasource in the schema.
+      await expect(result).rejects.toMatchInlineSnapshot(`"Schema must contain a datasource block"`)
 
-        "
-      `)
-
-      expect(ctx.normalizedCapturedStdout()).toMatchInlineSnapshot(`
-        "
-        "
-      `)
+      expect(ctx.normalizedCapturedStdout()).toMatchInlineSnapshot(`""`)
       expect(ctx.normalizedCapturedStderr()).toMatchInlineSnapshot(`""`)
     })
 

--- a/packages/migrate/src/commands/DbPull.ts
+++ b/packages/migrate/src/commands/DbPull.ts
@@ -9,6 +9,7 @@ import {
   formatms,
   getCommandWithExecutor,
   getConfig,
+  getSchemaDatasourceProvider,
   HelpError,
   inferDirectoryConfig,
   link,
@@ -147,6 +148,8 @@ Set composite types introspection depth to 2 levels
     if (!schemaContext) {
       throw new NoSchemaFoundError()
     }
+
+    getSchemaDatasourceProvider(schemaContext)
 
     const firstDatasource = schemaContext.primaryDatasource
     const schema = schemaContext.schemaFiles

--- a/packages/migrate/src/commands/DbPush.ts
+++ b/packages/migrate/src/commands/DbPush.ts
@@ -111,6 +111,7 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd, validatedConfig })
 
+    const datasourceProvider = getSchemaDatasourceProvider(schemaContext)
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource, validatedConfig)
     printDatasource({ datasourceInfo })
     const schemaFilter: MigrateTypes.SchemaFilter = {
@@ -129,11 +130,7 @@ ${bold('Examples')}
 
     try {
       // Automatically create the database if it doesn't exist
-      const successMessage = await ensureDatabaseExists(
-        baseDir,
-        getSchemaDatasourceProvider(schemaContext),
-        validatedConfig,
-      )
+      const successMessage = await ensureDatabaseExists(baseDir, datasourceProvider, validatedConfig)
       if (successMessage) {
         process.stdout.write('\n' + successMessage + '\n')
       }

--- a/packages/migrate/src/commands/MigrateDev.ts
+++ b/packages/migrate/src/commands/MigrateDev.ts
@@ -121,6 +121,7 @@ ${bold('Examples')}
 
     checkUnsupportedDataProxy({ cmd, validatedConfig })
 
+    const datasourceProvider = getSchemaDatasourceProvider(schemaContext)
     const datasourceInfo = parseDatasourceInfo(schemaContext.primaryDatasource, validatedConfig)
     printDatasource({ datasourceInfo })
 
@@ -131,11 +132,7 @@ ${bold('Examples')}
 
     // TODO: check why the output and error handling here is different than in `MigrateDeploy`.
     // Automatically create the database if it doesn't exist
-    const successMessage = await ensureDatabaseExists(
-      baseDir,
-      getSchemaDatasourceProvider(schemaContext),
-      validatedConfig,
-    )
+    const successMessage = await ensureDatabaseExists(baseDir, datasourceProvider, validatedConfig)
     if (successMessage) {
       process.stdout.write(successMessage + '\n\n')
     }


### PR DESCRIPTION
Fixes #7186

## Summary

- validate that the loaded Prisma schema contains a datasource before starting the schema engine
- reuse the existing `getSchemaDatasourceProvider` validation path for `db push`, `migrate dev`, and `db pull`
- keep empty-schema failures consistent and user-facing across these commands

This prevents an empty `schema.prisma` from reaching schema engine operations that may panic. The commands now exit non-zero with `Schema must contain a datasource block`.

## Testing

- `pnpm --filter prisma test incomplete-schemas`
- `pnpm build` (44/44 tasks successful)
- direct CLI verification for `prisma db push`, `prisma migrate dev`, and `prisma db pull` with the empty-schema fixture
- Prettier and ESLint via the pre-commit hook

No documentation update is required because this changes error handling without changing CLI syntax or documented behavior.
