### PR TITLE
TML-2956: migrate Mongo family attributes to declarative specs

### DIFF
--- a/examples/retail-store/migrations/app/20260513T0505_initial/contract.prisma
+++ b/examples/retail-store/migrations/app/20260513T0505_initial/contract.prisma
@@ -58,7 +58,7 @@ model Product {
   price          Price
   image          Image
   @@map("products")
-  @@textIndex([name, description], weights: "{\"name\": 10, \"description\": 1}")
+  @@textIndex([name, description], weights: { name: 10, description: 1 })
   @@index([brand, subCategory])
   @@index([code], type: "hashed")
 }

--- a/examples/retail-store/migrations/app/20260513T0507_add_product_category_index/contract.prisma
+++ b/examples/retail-store/migrations/app/20260513T0507_add_product_category_index/contract.prisma
@@ -58,7 +58,7 @@ model Product {
   price          Price
   image          Image
   @@map("products")
-  @@textIndex([name, description], weights: "{\"name\": 10, \"description\": 1}")
+  @@textIndex([name, description], weights: { name: 10, description: 1 })
   @@index([brand, subCategory])
   @@index([primaryCategory, articleType])
   @@index([code], type: "hashed")

--- a/examples/retail-store/migrations/app/20260513T0508_backfill_product_status/contract.prisma
+++ b/examples/retail-store/migrations/app/20260513T0508_backfill_product_status/contract.prisma
@@ -60,7 +60,7 @@ model Product {
   embedding      Float[]?
   status         String   @default("active")
   @@map("products")
-  @@textIndex([name, description], weights: "{\"name\": 10, \"description\": 1}")
+  @@textIndex([name, description], weights: { name: 10, description: 1 })
   @@index([brand, subCategory])
   @@index([primaryCategory, articleType])
   @@index([code], type: "hashed")

--- a/examples/retail-store/migrations/app/20260628T0931_add_product_status_order_type_enums/contract.prisma
+++ b/examples/retail-store/migrations/app/20260628T0931_add_product_status_order_type_enums/contract.prisma
@@ -73,7 +73,7 @@ model Product {
   embedding      Float[]?
   status         ProductStatus @default(Active)
   @@map("products")
-  @@textIndex([name, description], weights: "{\"name\": 10, \"description\": 1}")
+  @@textIndex([name, description], weights: { name: 10, description: 1 })
   @@index([brand, subCategory])
   @@index([primaryCategory, articleType])
   @@index([code], type: "hashed")

--- a/examples/retail-store/src/contract.prisma
+++ b/examples/retail-store/src/contract.prisma
@@ -73,7 +73,7 @@ model Product {
   embedding      Float[]?
   status         ProductStatus @default(Active)
   @@map("products")
-  @@textIndex([name, description], weights: "{\"name\": 10, \"description\": 1}")
+  @@textIndex([name, description], weights: { name: 10, description: 1 })
   @@index([brand, subCategory])
   @@index([primaryCategory, articleType])
   @@index([code], type: "hashed")

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
@@ -1,0 +1,38 @@
+import type { PslDiagnostic } from '@prisma-next/framework-components/psl-ast';
+import { blindCast } from '@prisma-next/utils/casts';
+import { notOk, ok, type Result } from '@prisma-next/utils/result';
+import { StringLiteralExprAst } from '../../syntax/ast/expressions';
+import type { ArgType } from '../types';
+import { leafDiagnostic } from './diagnostic';
+
+// Reads an opaque JSON object from a quoted JSON string — the ADR's one text-encoded surface
+// exception (e.g. an index `filter` / `weights` argument). The string is decoded by the parser,
+// then JSON-parsed; a non-object (array/scalar) or invalid JSON is a diagnostic.
+export function json(): ArgType<Record<string, unknown>> {
+  return {
+    kind: 'json',
+    label: 'JSON object',
+    parse: (arg, ctx): Result<Record<string, unknown>, readonly PslDiagnostic[]> => {
+      if (!(arg instanceof StringLiteralExprAst)) {
+        return notOk([leafDiagnostic(ctx, arg, 'Expected a JSON object string')]);
+      }
+      const raw = arg.value();
+      if (raw !== undefined) {
+        try {
+          const parsed: unknown = JSON.parse(raw);
+          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            return ok(
+              blindCast<
+                Record<string, unknown>,
+                'JSON.parse of a validated non-array object literal is a string-keyed record'
+              >(parsed),
+            );
+          }
+        } catch {
+          // fall through to the diagnostic
+        }
+      }
+      return notOk([leafDiagnostic(ctx, arg, 'Expected a valid JSON object')]);
+    },
+  };
+}

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
@@ -1,6 +1,6 @@
-import type { PslDiagnostic } from '@prisma-next/framework-components/psl-ast';
-import { blindCast } from '@prisma-next/utils/casts';
-import { notOk, ok, type Result } from '@prisma-next/utils/result';
+import type { PslDiagnostic } from '@internal/framework-components/psl-ast';
+import { blindCast } from '@internal/utils/casts';
+import { notOk, ok, type Result } from '@internal/utils/result';
 import { StringLiteralExprAst } from '../../syntax/ast/expressions';
 import type { ArgType } from '../types';
 import { leafDiagnostic } from './diagnostic';

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
@@ -5,9 +5,11 @@ import { StringLiteralExprAst } from '../../syntax/ast/expressions';
 import type { ArgType } from '../types';
 import { leafDiagnostic } from './diagnostic';
 
-// Reads an opaque JSON object from a quoted JSON string — the ADR's one text-encoded surface
-// exception (e.g. an index `filter` / `weights` argument). The string is decoded by the parser,
-// then JSON-parsed; a non-object (array/scalar) or invalid JSON is a diagnostic.
+/**
+ * Reads an opaque JSON object from a quoted JSON string — the ADR's one text-encoded surface
+ * exception (e.g. an index `filter` / `weights` argument). The string is decoded by the parser,
+ * then JSON-parsed; a non-object (array/scalar) or invalid JSON is a diagnostic.
+ */
 export function json(): ArgType<Record<string, unknown>> {
   return {
     kind: 'json',

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/num.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/num.ts
@@ -4,20 +4,20 @@ import { NumberLiteralExprAst } from '../../syntax/ast/expressions';
 import type { ArgType } from '../types';
 import { leafDiagnostic } from './diagnostic';
 
-// A general number literal — any number, including floats — reduced to its numeric value.
-// Passing `value` pins the combinator to that single literal (`num(4)` matches only `4`),
-// mirroring how `identifier(name)` pins a bare identifier. Use `int()` when only integer
-// literals are allowed.
+/** The pinned form retains its value as the output literal type. */
 export function num(): ArgType<number>;
-export function num(value: number): ArgType<number>;
-export function num(value?: number): ArgType<number> {
+export function num<const T extends number>(value: T): ArgType<T>;
+export function num<const T extends number>(value?: T): ArgType<number | T> {
   return {
     kind: 'num',
     label: value === undefined ? 'number' : String(value),
-    parse: (arg, ctx): Result<number, readonly PslDiagnostic[]> => {
+    parse: (arg, ctx): Result<number | T, readonly PslDiagnostic[]> => {
       if (arg instanceof NumberLiteralExprAst) {
         const parsed = arg.value();
-        if (parsed !== undefined && (value === undefined || parsed === value)) return ok(parsed);
+        if (parsed !== undefined) {
+          if (value === undefined) return ok(parsed);
+          if (parsed === value) return ok(value);
+        }
       }
       const message = value === undefined ? 'Expected a number literal' : `Expected ${value}`;
       return notOk([leafDiagnostic(ctx, arg, message)]);

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/record.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/record.ts
@@ -13,7 +13,8 @@ export function record<T>(of: ArgType<T>): ArgType<Record<string, T>> {
         return notOk([leafDiagnostic(ctx, arg, 'Expected an object literal')]);
       }
       const diagnostics: PslDiagnostic[] = [];
-      const result: Record<string, T> = {};
+      const entries: [string, T][] = [];
+      const keys = new Set<string>();
       for (const field of arg.fields()) {
         const key = field.keyName();
         if (key === undefined) {
@@ -30,14 +31,15 @@ export function record<T>(of: ArgType<T>): ArgType<Record<string, T>> {
           diagnostics.push(...parsed.failure);
           continue;
         }
-        if (Object.hasOwn(result, key)) {
+        if (keys.has(key)) {
           diagnostics.push(leafDiagnostic(ctx, field, `Duplicate key "${key}"`));
           continue;
         }
-        result[key] = parsed.value;
+        keys.add(key);
+        entries.push([key, parsed.value]);
       }
       if (diagnostics.length > 0) return notOk(diagnostics);
-      return ok(result);
+      return ok(Object.fromEntries(entries));
     },
   };
 }

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
@@ -4,16 +4,24 @@ import { StringLiteralExprAst } from '../../syntax/ast/expressions';
 import type { ArgType } from '../types';
 import { leafDiagnostic } from './diagnostic';
 
-export function str(): ArgType<string> {
+// A general string literal reduced to its decoded value. Passing `value` pins the
+// combinator to that single literal (`str('hashed')` matches only `"hashed"`),
+// mirroring how `num(value)`/`identifier(name)` pin their literal. Use the pinned
+// form for digit-leading tokens that cannot be bare identifiers.
+export function str(): ArgType<string>;
+export function str(value: string): ArgType<string>;
+export function str(value?: string): ArgType<string> {
   return {
     kind: 'str',
-    label: 'string',
+    label: value === undefined ? 'string' : JSON.stringify(value),
     parse: (arg, ctx): Result<string, readonly PslDiagnostic[]> => {
       if (arg instanceof StringLiteralExprAst) {
-        const value = arg.value();
-        if (value !== undefined) return ok(value);
+        const parsed = arg.value();
+        if (parsed !== undefined && (value === undefined || parsed === value)) return ok(parsed);
       }
-      return notOk([leafDiagnostic(ctx, arg, 'Expected a string literal')]);
+      const message =
+        value === undefined ? 'Expected a string literal' : `Expected ${JSON.stringify(value)}`;
+      return notOk([leafDiagnostic(ctx, arg, message)]);
     },
   };
 }

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
@@ -4,22 +4,20 @@ import { StringLiteralExprAst } from '../../syntax/ast/expressions';
 import type { ArgType } from '../types';
 import { leafDiagnostic } from './diagnostic';
 
-/**
- * A general string literal reduced to its decoded value. Passing `value` pins the
- * combinator to that single literal (`str('hashed')` matches only `"hashed"`),
- * mirroring how `num(value)`/`identifier(name)` pin their literal. Use the pinned
- * form for digit-leading tokens that cannot be bare identifiers.
- */
+/** The pinned form retains its value as the output literal type. */
 export function str(): ArgType<string>;
-export function str(value: string): ArgType<string>;
-export function str(value?: string): ArgType<string> {
+export function str<const T extends string>(value: T): ArgType<T>;
+export function str<const T extends string>(value?: T): ArgType<string | T> {
   return {
     kind: 'str',
     label: value === undefined ? 'string' : JSON.stringify(value),
-    parse: (arg, ctx): Result<string, readonly PslDiagnostic[]> => {
+    parse: (arg, ctx): Result<string | T, readonly PslDiagnostic[]> => {
       if (arg instanceof StringLiteralExprAst) {
         const parsed = arg.value();
-        if (parsed !== undefined && (value === undefined || parsed === value)) return ok(parsed);
+        if (parsed !== undefined) {
+          if (value === undefined) return ok(parsed);
+          if (parsed === value) return ok(value);
+        }
       }
       const message =
         value === undefined ? 'Expected a string literal' : `Expected ${JSON.stringify(value)}`;

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
@@ -4,10 +4,12 @@ import { StringLiteralExprAst } from '../../syntax/ast/expressions';
 import type { ArgType } from '../types';
 import { leafDiagnostic } from './diagnostic';
 
-// A general string literal reduced to its decoded value. Passing `value` pins the
-// combinator to that single literal (`str('hashed')` matches only `"hashed"`),
-// mirroring how `num(value)`/`identifier(name)` pin their literal. Use the pinned
-// form for digit-leading tokens that cannot be bare identifiers.
+/**
+ * A general string literal reduced to its decoded value. Passing `value` pins the
+ * combinator to that single literal (`str('hashed')` matches only `"hashed"`),
+ * mirroring how `num(value)`/`identifier(name)` pin their literal. Use the pinned
+ * form for digit-leading tokens that cannot be bare identifiers.
+ */
 export function str(): ArgType<string>;
 export function str(value: string): ArgType<string>;
 export function str(value?: string): ArgType<string> {

--- a/packages/1-framework/2-authoring/psl-parser/src/exports/index.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/exports/index.ts
@@ -45,6 +45,7 @@ export type { FuncCallSig, TypedFuncCall } from '../attribute-spec/combinators/f
 export { funcCall } from '../attribute-spec/combinators/func-call';
 export { identifier } from '../attribute-spec/combinators/identifier';
 export { int } from '../attribute-spec/combinators/int';
+export { json } from '../attribute-spec/combinators/json';
 export type { ListOptions } from '../attribute-spec/combinators/list';
 export { list } from '../attribute-spec/combinators/list';
 export { num } from '../attribute-spec/combinators/num';

--- a/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test-d.ts
+++ b/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, test } from 'vitest';
-import type { ArgType } from '../src/exports';
-import { identifier, list, oneOf, str } from '../src/exports';
+import type { ArgType, OutOf } from '../src/exports';
+import { identifier, list, num, oneOf, str } from '../src/exports';
 
 test('identifier pins its name as the output literal type', () => {
   expectTypeOf(identifier('NoAction')).toEqualTypeOf<ArgType<'NoAction'>>();
@@ -10,6 +10,24 @@ test('oneOf infers the union of its alternatives output types', () => {
   expectTypeOf(oneOf(identifier('NoAction'), identifier('Cascade'))).toEqualTypeOf<
     ArgType<'NoAction' | 'Cascade'>
   >();
+});
+
+test('pinned str preserves its output literal type', () => {
+  const pinned = str('hashed');
+
+  expectTypeOf<OutOf<typeof pinned>>().toEqualTypeOf<'hashed'>();
+});
+
+test('pinned num preserves its output literal type', () => {
+  const pinned = num(-1);
+
+  expectTypeOf<OutOf<typeof pinned>>().toEqualTypeOf<-1>();
+});
+
+test('oneOf preserves pinned string and number literal alternatives', () => {
+  const pinned = oneOf(str('hashed'), str('2dsphere'), num(-1));
+
+  expectTypeOf<OutOf<typeof pinned>>().toEqualTypeOf<'hashed' | '2dsphere' | -1>();
 });
 
 test('oneOf with no alternatives is a compile error', () => {

--- a/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
+++ b/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
@@ -10,6 +10,7 @@ import {
   identifier,
   int,
   interpretAttribute,
+  json,
   list,
   modelAttribute,
   nodePslSpan,
@@ -81,6 +82,45 @@ describe('str', () => {
       expect(result.failure).toHaveLength(1);
       expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
     }
+  });
+
+  it('matches only the pinned string literal', () => {
+    const { expr, ctx } = argOf('"hashed"');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe('hashed');
+  });
+
+  it('rejects a string literal other than the pinned value', () => {
+    const { expr, ctx } = argOf('"2dsphere"');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
+  });
+
+  it('rejects a bare identifier carrying the pinned characters', () => {
+    const { expr, ctx } = argOf('hashed');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+
+  it('rejects a number literal against the pinned value', () => {
+    const { expr, ctx } = argOf('2');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
   });
 });
 
@@ -273,6 +313,68 @@ describe('num', () => {
     const { expr, ctx } = argOf('"4"');
 
     const result = num(4).parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+});
+
+describe('json', () => {
+  it('parses a quoted JSON object string into a record', () => {
+    const { expr, ctx } = argOf('"{\\"a\\": 1}"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({ a: 1 });
+  });
+
+  it('rejects a JSON array string', () => {
+    const { expr, ctx } = argOf('"[1,2]"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
+  });
+
+  it('rejects a JSON scalar string', () => {
+    const { expr, ctx } = argOf('"5"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+
+  it('rejects an invalid-JSON string', () => {
+    const { expr, ctx } = argOf('"{not json}"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+
+  it('rejects a bare identifier', () => {
+    const { expr, ctx } = argOf('Cascade');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
+  });
+
+  it('rejects a number literal', () => {
+    const { expr, ctx } = argOf('5');
+
+    const result = json().parse(expr, ctx);
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.failure).toHaveLength(1);

--- a/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
+++ b/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
@@ -10,6 +10,7 @@ import {
   identifier,
   int,
   interpretAttribute,
+  json,
   list,
   modelAttribute,
   nodePslSpan,
@@ -82,6 +83,45 @@ describe('str', () => {
       expect(result.failure).toHaveLength(1);
       expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
     }
+  });
+
+  it('matches only the pinned string literal', () => {
+    const { expr, ctx } = argOf('"hashed"');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe('hashed');
+  });
+
+  it('rejects a string literal other than the pinned value', () => {
+    const { expr, ctx } = argOf('"2dsphere"');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
+  });
+
+  it('rejects a bare identifier carrying the pinned characters', () => {
+    const { expr, ctx } = argOf('hashed');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+
+  it('rejects a number literal against the pinned value', () => {
+    const { expr, ctx } = argOf('2');
+
+    const result = str('hashed').parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
   });
 });
 
@@ -274,6 +314,68 @@ describe('num', () => {
     const { expr, ctx } = argOf('"4"');
 
     const result = num(4).parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+});
+
+describe('json', () => {
+  it('parses a quoted JSON object string into a record', () => {
+    const { expr, ctx } = argOf('"{\\"a\\": 1}"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({ a: 1 });
+  });
+
+  it('rejects a JSON array string', () => {
+    const { expr, ctx } = argOf('"[1,2]"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
+  });
+
+  it('rejects a JSON scalar string', () => {
+    const { expr, ctx } = argOf('"5"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+
+  it('rejects an invalid-JSON string', () => {
+    const { expr, ctx } = argOf('"{not json}"');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure).toHaveLength(1);
+  });
+
+  it('rejects a bare identifier', () => {
+    const { expr, ctx } = argOf('Cascade');
+
+    const result = json().parse(expr, ctx);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
+  });
+
+  it('rejects a number literal', () => {
+    const { expr, ctx } = argOf('5');
+
+    const result = json().parse(expr, ctx);
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.failure).toHaveLength(1);

--- a/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
+++ b/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
@@ -202,13 +202,17 @@ describe('int', () => {
     if (!result.ok) expect(result.failure).toHaveLength(1);
   });
 
-  it('accepts an integer within the declared bounds', () => {
-    const { expr, ctx } = argOf('16');
+  it('accepts integers at both inclusive bounds', () => {
+    const minimum = argOf('2');
+    const maximum = argOf('255');
 
-    const result = int({ min: 2, max: 255 }).parse(expr, ctx);
+    const minimumResult = int({ min: 2, max: 255 }).parse(minimum.expr, minimum.ctx);
+    const maximumResult = int({ min: 2, max: 255 }).parse(maximum.expr, maximum.ctx);
 
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value).toBe(16);
+    expect(minimumResult.ok).toBe(true);
+    if (minimumResult.ok) expect(minimumResult.value).toBe(2);
+    expect(maximumResult.ok).toBe(true);
+    if (maximumResult.ok) expect(maximumResult.value).toBe(255);
   });
 
   it('rejects an integer below the minimum with a range message', () => {
@@ -676,6 +680,24 @@ describe('record', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.value).toEqual({});
+  });
+
+  it('preserves __proto__ as an own data property', () => {
+    const { expr, ctx } = argOf('{ __proto__: "value" }');
+
+    const result = record(str()).parse(expr, ctx);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(Object.hasOwn(result.value, '__proto__')).toBe(true);
+      expect(Object.getOwnPropertyDescriptor(result.value, '__proto__')).toEqual({
+        value: 'value',
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(Object.getPrototypeOf(result.value)).toBe(Object.prototype);
+    }
   });
 
   it('rejects a duplicate key', () => {

--- a/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
+++ b/packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts
@@ -111,7 +111,10 @@ describe('str', () => {
     const result = str('hashed').parse(expr, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.failure).toHaveLength(1);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
   });
 
   it('rejects a number literal against the pinned value', () => {
@@ -120,7 +123,10 @@ describe('str', () => {
     const result = str('hashed').parse(expr, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.failure).toHaveLength(1);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
   });
 });
 
@@ -347,7 +353,10 @@ describe('json', () => {
     const result = json().parse(expr, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.failure).toHaveLength(1);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
   });
 
   it('rejects an invalid-JSON string', () => {
@@ -356,7 +365,10 @@ describe('json', () => {
     const result = json().parse(expr, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.failure).toHaveLength(1);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
   });
 
   it('rejects a bare identifier', () => {
@@ -377,7 +389,10 @@ describe('json', () => {
     const result = json().parse(expr, ctx);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.failure).toHaveLength(1);
+    if (!result.ok) {
+      expect(result.failure).toHaveLength(1);
+      expect(result.failure[0]?.code).toBe('PSL_INVALID_ATTRIBUTE_SYNTAX');
+    }
   });
 });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -44,7 +44,6 @@ import type {
   NamespaceSymbol,
   PslExtensionBlock,
   PslSpan,
-  ResolvedAttribute,
   SymbolTable,
   TypedFuncCall,
 } from '@prisma-next/psl-parser';
@@ -58,6 +57,7 @@ import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-sch
 import {
   baseModelSpec,
   buildIndexModelSpec,
+  buildTextIndexModelSpec,
   discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
@@ -67,14 +67,7 @@ import {
   mapModelSpec,
   relationFieldSpec,
 } from './mongo-attribute-specs';
-import {
-  getAttribute,
-  getNamedArgument,
-  getPositionalArgument,
-  lowerFirst,
-  type ParsedIndexField,
-  parseIndexFieldList,
-} from './psl-helpers';
+import { getAttribute, lowerFirst, type ParsedIndexField } from './psl-helpers';
 
 /**
  * Encode an authored enum value to its codec-encoded JSON form via the codec resolved by id from the
@@ -532,9 +525,8 @@ function canonicalJson(value: unknown): string {
 }
 
 // The spec's pinned `type` combinators already constrain the value to the exact
-// index-direction alphabet at runtime; map it to the key-direction type,
-// defaulting to ascending (1) when absent. Replaces `parseIndexDirection` for
-// the `@@index`/`@@unique` spec path.
+// index-direction alphabet at runtime; normalize it to the Mongo key-direction
+// type, defaulting to ascending (1) when absent.
 function normalizeIndexType(value: number | string | undefined): MongoIndexKeyDirection {
   switch (value) {
     case -1:
@@ -572,10 +564,10 @@ function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField 
   return { name: element.fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 };
 }
 
-// Interpreted collation named-args of an `@@index`/`@@unique`. Mirrors
-// `parseCollation`'s semantics from spec values: `undefined` when no collation
-// arg is present, `null` when some are present but `collationLocale` is absent
-// (the semantic "collationLocale is required" rule), otherwise the options.
+// Interpreted collation named-args of an `@@index`/`@@unique`/`@@textIndex`.
+// Semantics from spec values: `undefined` when no collation arg is present,
+// `null` when some are present but `collationLocale` is absent (the semantic
+// "collationLocale is required" rule), otherwise the options.
 interface SpecCollationArgs {
   readonly collationLocale?: string;
   readonly collationStrength?: number;
@@ -617,70 +609,19 @@ function buildCollationFromSpec(args: SpecCollationArgs): CollationOptions | nul
   return collation;
 }
 
-function parseNumericArg(raw: string | undefined): number | undefined {
-  if (!raw) return undefined;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : undefined;
-}
-
-function parseBooleanArg(raw: string | undefined): boolean | undefined {
-  if (raw === 'true') return true;
-  if (raw === 'false') return false;
-  return undefined;
-}
-
-function parseJsonArg(raw: string | undefined): Record<string, unknown> | undefined {
-  if (!raw) return undefined;
-  const stripped = raw.replace(/^["']/, '').replace(/["']$/, '').replace(/\\"/g, '"');
-  try {
-    const parsed = JSON.parse(stripped);
-    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    // not valid JSON
+// Filter an interpreted `weights` json object down to its numeric entries — the
+// only weight values MongoDB accepts. `Record<string, unknown>` values are
+// narrowed by `typeof`, so no cast is needed. Returns `undefined` only when the
+// arg was absent; a present-but-empty object stays `{}` to match prior behavior.
+function extractWeights(
+  raw: Record<string, unknown> | undefined,
+): Record<string, number> | undefined {
+  if (raw === undefined) return undefined;
+  const weights: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === 'number') weights[key] = value;
   }
-  return undefined;
-}
-
-function parseCollation(attr: ResolvedAttribute): CollationOptions | null | undefined {
-  const locale = stripQuotesHelper(getNamedArgument(attr, 'collationLocale'));
-  if (!locale) {
-    const hasAnyCollationArg =
-      getNamedArgument(attr, 'collationStrength') != null ||
-      getNamedArgument(attr, 'collationCaseLevel') != null ||
-      getNamedArgument(attr, 'collationCaseFirst') != null ||
-      getNamedArgument(attr, 'collationNumericOrdering') != null ||
-      getNamedArgument(attr, 'collationAlternate') != null ||
-      getNamedArgument(attr, 'collationMaxVariable') != null ||
-      getNamedArgument(attr, 'collationBackwards') != null ||
-      getNamedArgument(attr, 'collationNormalization') != null;
-    return hasAnyCollationArg ? null : undefined;
-  }
-
-  const collation: CollationOptions = { locale };
-  const strength = parseNumericArg(getNamedArgument(attr, 'collationStrength'));
-  if (strength != null) collation.strength = strength;
-  const caseLevel = parseBooleanArg(getNamedArgument(attr, 'collationCaseLevel'));
-  if (caseLevel != null) collation.caseLevel = caseLevel;
-  const caseFirst = stripQuotesHelper(getNamedArgument(attr, 'collationCaseFirst'));
-  if (caseFirst != null) collation.caseFirst = caseFirst;
-  const numericOrdering = parseBooleanArg(getNamedArgument(attr, 'collationNumericOrdering'));
-  if (numericOrdering != null) collation.numericOrdering = numericOrdering;
-  const alternate = stripQuotesHelper(getNamedArgument(attr, 'collationAlternate'));
-  if (alternate != null) collation.alternate = alternate;
-  const maxVariable = stripQuotesHelper(getNamedArgument(attr, 'collationMaxVariable'));
-  if (maxVariable != null) collation.maxVariable = maxVariable;
-  const backwards = parseBooleanArg(getNamedArgument(attr, 'collationBackwards'));
-  if (backwards != null) collation.backwards = backwards;
-  const normalization = parseBooleanArg(getNamedArgument(attr, 'collationNormalization'));
-  if (normalization != null) collation.normalization = normalization;
-  return collation;
-}
-
-function stripQuotesHelper(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  return raw.replace(/^["']/, '').replace(/["']$/, '');
+  return weights;
 }
 
 function parseProjectionList(
@@ -747,9 +688,10 @@ function collectIndexes(
     const isTextIndex = attr.name === 'textIndex';
     if (!isIndex && !isUnique && !isTextIndex) continue;
 
-    // @@index/@@unique read arguments through the attribute spec; @@textIndex
-    // stays on the pre-spec parsing path (migrated later). Both produce the same
-    // normalized values the shared index-shape logic below consumes.
+    // @@index/@@unique/@@textIndex all read arguments through their attribute
+    // spec. The two specs infer different named-arg shapes, so each branch
+    // interprets its own spec and fills the shared normalized values the
+    // index-shape logic below consumes.
     let parsedFields: readonly ParsedIndexField[];
     let typeValue: number | string | undefined;
     let sparse: boolean | undefined;
@@ -762,30 +704,32 @@ function collectIndexes(
     let default_language: string | undefined;
     let language_override: string | undefined;
 
+    const node = attributeNodes[attrIndex];
+    if (node === undefined) continue;
+
     if (isTextIndex) {
-      const fieldsArg = getPositionalArgument(attr, 0);
-      if (!fieldsArg) continue;
-      parsedFields = parseIndexFieldList(fieldsArg);
+      const parsed = interpretModelAttribute({
+        node,
+        spec: buildTextIndexModelSpec(specFieldNames),
+        model: pslModel,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed === undefined) continue;
+      parsedFields = parsed.fields.map(normalizeIndexField);
       if (parsedFields.length === 0) continue;
       typeValue = undefined;
       sparse = undefined;
       expireAfterSeconds = undefined;
-      partialFilterExpression = parseJsonArg(getNamedArgument(attr, 'filter'));
-      includeArg = getNamedArgument(attr, 'include');
-      excludeArg = getNamedArgument(attr, 'exclude');
-      collation = parseCollation(attr);
-      const rawWeights = parseJsonArg(getNamedArgument(attr, 'weights'));
-      if (rawWeights) {
-        weights = {};
-        for (const [k, v] of Object.entries(rawWeights)) {
-          if (typeof v === 'number') weights[k] = v;
-        }
-      }
-      default_language = stripQuotesHelper(getNamedArgument(attr, 'language'));
-      language_override = stripQuotesHelper(getNamedArgument(attr, 'languageOverride'));
+      partialFilterExpression = parsed.filter;
+      includeArg = parsed.include;
+      excludeArg = parsed.exclude;
+      collation = buildCollationFromSpec(parsed);
+      weights = extractWeights(parsed.weights);
+      default_language = parsed.language;
+      language_override = parsed.languageOverride;
     } else {
-      const node = attributeNodes[attrIndex];
-      if (node === undefined) continue;
       const parsed = interpretModelAttribute({
         node,
         spec: buildIndexModelSpec(isUnique ? 'unique' : 'index', specFieldNames),

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -55,6 +55,8 @@ import { ifDefined } from '@prisma-next/utils/defined';
 import { notOk, ok, type Result } from '@prisma-next/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
+  baseModelSpec,
+  discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
   interpretFieldAttribute,
@@ -69,7 +71,6 @@ import {
   getPositionalArgument,
   lowerFirst,
   parseIndexFieldList,
-  parseQuotedStringLiteral,
 } from './psl-helpers';
 
 /**
@@ -218,54 +219,53 @@ function collectPolymorphismDeclarations(
   const baseDeclarations = new Map<string, BaseDeclaration>();
 
   for (const model of models) {
-    for (const attr of model.attributes) {
-      if (attr.name === 'discriminator') {
-        const fieldName = getPositionalArgument(attr);
-        if (!fieldName) {
-          diagnostics.push({
-            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
-            message: `Model "${model.name}" @@discriminator requires a field name argument`,
-            sourceId,
-            span: attr.span,
-          });
-          continue;
-        }
+    const discNode = findModelAttributeNode(model, 'discriminator');
+    if (discNode) {
+      const parsed = interpretModelAttribute({
+        node: discNode,
+        spec: discriminatorModelSpec,
+        model,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed) {
+        const fieldName = parsed.field;
         const discField = model.fields[fieldName];
+        // Semantic check — stays: the discriminator field must be a String.
         if (discField && discField.typeName !== 'String') {
           diagnostics.push({
             code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
             message: `Discriminator field "${fieldName}" on model "${model.name}" must be of type String, but is "${discField.typeName}"`,
             sourceId,
-            span: attr.span,
+            span: nodePslSpan(discNode.syntax, sourceFile),
           });
-          continue;
+        } else {
+          discriminatorDeclarations.set(model.name, {
+            fieldName,
+            span: nodePslSpan(discNode.syntax, sourceFile),
+          });
         }
-        discriminatorDeclarations.set(model.name, { fieldName, span: attr.span });
       }
-      if (attr.name === 'base') {
-        const baseName = getPositionalArgument(attr, 0);
-        const rawValue = getPositionalArgument(attr, 1);
-        if (!baseName || !rawValue) {
-          diagnostics.push({
-            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
-            message: `Model "${model.name}" @@base requires two arguments: base model name and discriminator value`,
-            sourceId,
-            span: attr.span,
-          });
-          continue;
-        }
-        const value = parseQuotedStringLiteral(rawValue);
-        if (value === undefined) {
-          diagnostics.push({
-            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
-            message: `Model "${model.name}" @@base discriminator value must be a quoted string literal`,
-            sourceId,
-            span: attr.span,
-          });
-          continue;
-        }
+    }
+    const baseNode = findModelAttributeNode(model, 'base');
+    if (baseNode) {
+      const parsed = interpretModelAttribute({
+        node: baseNode,
+        spec: baseModelSpec,
+        model,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed) {
         const collectionName = resolveCollectionName({ model, sourceFile, sourceId, diagnostics });
-        baseDeclarations.set(model.name, { baseName, value, collectionName, span: attr.span });
+        baseDeclarations.set(model.name, {
+          baseName: parsed.base,
+          value: parsed.value,
+          collectionName,
+          span: nodePslSpan(baseNode.syntax, sourceFile),
+        });
       }
     }
   }

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -61,6 +61,7 @@ import {
   interpretModelAttribute,
   mapFieldSpec,
   mapModelSpec,
+  relationFieldSpec,
 } from './mongo-attribute-specs';
 import {
   getAttribute,
@@ -69,7 +70,6 @@ import {
   lowerFirst,
   parseIndexFieldList,
   parseQuotedStringLiteral,
-  parseRelationAttribute,
 } from './psl-helpers';
 
 /**
@@ -1087,14 +1087,26 @@ export function interpretPslDocumentToMongoContract(
 
     for (const field of Object.values(pslModel.fields)) {
       if (isRelationField(field, modelNames)) {
-        const relation = parseRelationAttribute(field.attributes);
+        const relationNode = findFieldAttributeNode(field, 'relation');
+        const relation = relationNode
+          ? interpretFieldAttribute({
+              node: relationNode,
+              spec: relationFieldSpec,
+              model: pslModel,
+              field,
+              sourceFile,
+              sourceId,
+              diagnostics,
+              resolveReferencedModel: () => allModels.find((m) => m.name === field.typeName),
+            })
+          : undefined;
 
         if (field.list || !(relation?.fields && relation?.references)) {
           backrelationCandidates.push({
             modelName: pslModel.name,
             fieldName: field.name,
             targetModelName: field.typeName,
-            ...ifDefined('relationName', relation?.relationName),
+            ...ifDefined('relationName', relation?.name),
             cardinality: field.list ? '1:N' : '1:1',
             field,
           });
@@ -1125,7 +1137,7 @@ export function interpretPslDocumentToMongoContract(
             declaringModel: pslModel.name,
             fieldName: field.name,
             targetModel: field.typeName,
-            ...ifDefined('relationName', relation.relationName),
+            ...ifDefined('relationName', relation.name),
             localFields: localMapped,
             targetFields: targetMapped,
           });

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -55,8 +55,15 @@ import { ifDefined } from '@prisma-next/utils/defined';
 import { notOk, ok, type Result } from '@prisma-next/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
+  findFieldAttributeNode,
+  findModelAttributeNode,
+  interpretFieldAttribute,
+  interpretModelAttribute,
+  mapFieldSpec,
+  mapModelSpec,
+} from './mongo-attribute-specs';
+import {
   getAttribute,
-  getMapName,
   getNamedArgument,
   getPositionalArgument,
   lowerFirst,
@@ -129,17 +136,52 @@ function fkRelationPairKey(declaringModel: string, targetModel: string): string 
   return `${declaringModel}::${targetModel}`;
 }
 
-function resolveFieldMappings(model: ModelSymbol): FieldMappings {
+function resolveFieldMappings(input: {
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): FieldMappings {
+  const { model, sourceFile, sourceId, diagnostics } = input;
   const pslNameToMapped = new Map<string, string>();
   for (const field of Object.values(model.fields)) {
-    const mapped = getMapName(field.attributes) ?? field.name;
+    const mapNode = findFieldAttributeNode(field, 'map');
+    const mapped =
+      (mapNode
+        ? interpretFieldAttribute({
+            node: mapNode,
+            spec: mapFieldSpec,
+            model,
+            field,
+            sourceFile,
+            sourceId,
+            diagnostics,
+          })?.name
+        : undefined) ?? field.name;
     pslNameToMapped.set(field.name, mapped);
   }
   return { pslNameToMapped };
 }
 
-function resolveCollectionName(model: ModelSymbol): string {
-  return getMapName(model.attributes) ?? lowerFirst(model.name);
+function resolveCollectionName(input: {
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): string {
+  const { model, sourceFile, sourceId, diagnostics } = input;
+  const mapNode = findModelAttributeNode(model, 'map');
+  const name = mapNode
+    ? interpretModelAttribute({
+        node: mapNode,
+        spec: mapModelSpec,
+        model,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      })?.name
+    : undefined;
+  return name ?? lowerFirst(model.name);
 }
 
 interface MongoModelEntry {
@@ -165,6 +207,7 @@ function mongoCrossRef(modelName: string): CrossReference {
 
 function collectPolymorphismDeclarations(
   models: readonly ModelSymbol[],
+  sourceFile: SourceFile,
   sourceId: string,
   diagnostics: ContractSourceDiagnostic[],
 ): {
@@ -221,7 +264,7 @@ function collectPolymorphismDeclarations(
           });
           continue;
         }
-        const collectionName = resolveCollectionName(model);
+        const collectionName = resolveCollectionName({ model, sourceFile, sourceId, diagnostics });
         baseDeclarations.set(model.name, { baseName, value, collectionName, span: attr.span });
       }
     }
@@ -240,6 +283,7 @@ function resolvePolymorphism(input: {
   modelNames: ReadonlySet<string>;
   indexSpans: Map<MongoIndex, PslSpan>;
   modelIndexesByName: Map<string, readonly MongoIndex[]>;
+  sourceFile: SourceFile;
   sourceId: string;
 }): {
   models: Record<string, MongoModelEntry>;
@@ -251,6 +295,7 @@ function resolvePolymorphism(input: {
     discriminatorDeclarations,
     baseDeclarations,
     modelNames,
+    sourceFile,
     sourceId,
     allModels: allModelViews,
     indexSpans,
@@ -277,7 +322,12 @@ function resolvePolymorphism(input: {
 
     const modelView = allModelViews.find((m) => m.name === modelName);
     const mappedDiscriminatorField = modelView
-      ? (resolveFieldMappings(modelView).pslNameToMapped.get(decl.fieldName) ?? decl.fieldName)
+      ? (resolveFieldMappings({
+          model: modelView,
+          sourceFile,
+          sourceId,
+          diagnostics,
+        }).pslNameToMapped.get(decl.fieldName) ?? decl.fieldName)
       : decl.fieldName;
 
     if (!Object.hasOwn(model.fields, mappedDiscriminatorField)) {
@@ -340,7 +390,7 @@ function resolvePolymorphism(input: {
     const baseModel = patched[baseDecl.baseName];
     const variantModelView = allModelViews.find((m) => m.name === variantName);
     if (!variantModelView) continue;
-    const hasExplicitMap = getMapName(variantModelView.attributes) !== undefined;
+    const hasExplicitMap = getAttribute(variantModelView.attributes, 'map') !== undefined;
 
     if (hasExplicitMap && baseModel && baseDecl.collectionName !== baseModel.storage.collection) {
       diagnostics.push({
@@ -365,7 +415,12 @@ function resolvePolymorphism(input: {
       };
     }
 
-    const variantCollectionName = resolveCollectionName(variantModelView);
+    const variantCollectionName = resolveCollectionName({
+      model: variantModelView,
+      sourceFile,
+      sourceId,
+      diagnostics,
+    });
     if (roots[variantCollectionName]?.model === variantName) {
       if (variantCollectionName === baseCollection && baseModel) {
         roots = { ...roots, [variantCollectionName]: mongoCrossRef(baseDecl.baseName) };
@@ -1014,8 +1069,18 @@ export function interpretPslDocumentToMongoContract(
   const backrelationCandidates: BackrelationCandidate[] = [];
 
   for (const pslModel of allModels) {
-    const collectionName = resolveCollectionName(pslModel);
-    const fieldMappings = resolveFieldMappings(pslModel);
+    const collectionName = resolveCollectionName({
+      model: pslModel,
+      sourceFile,
+      sourceId,
+      diagnostics,
+    });
+    const fieldMappings = resolveFieldMappings({
+      model: pslModel,
+      sourceFile,
+      sourceId,
+      diagnostics,
+    });
 
     const fields: Record<string, ContractField> = {};
     const relations: Record<string, ContractReferenceRelation> = {};
@@ -1040,7 +1105,9 @@ export function interpretPslDocumentToMongoContract(
           const localMapped = relation.fields.map((f) => fieldMappings.pslNameToMapped.get(f) ?? f);
 
           const targetModel = allModels.find((m) => m.name === field.typeName);
-          const targetFieldMappings = targetModel ? resolveFieldMappings(targetModel) : undefined;
+          const targetFieldMappings = targetModel
+            ? resolveFieldMappings({ model: targetModel, sourceFile, sourceId, diagnostics })
+            : undefined;
           const targetMapped = relation.references.map(
             (f) => targetFieldMappings?.pslNameToMapped.get(f) ?? f,
           );
@@ -1208,6 +1275,7 @@ export function interpretPslDocumentToMongoContract(
 
   const { discriminatorDeclarations, baseDeclarations } = collectPolymorphismDeclarations(
     allModels,
+    sourceFile,
     sourceId,
     diagnostics,
   );
@@ -1221,6 +1289,7 @@ export function interpretPslDocumentToMongoContract(
     modelNames,
     indexSpans,
     modelIndexesByName,
+    sourceFile,
     sourceId,
   });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -46,6 +46,7 @@ import type {
   PslSpan,
   ResolvedAttribute,
   SymbolTable,
+  TypedFuncCall,
 } from '@prisma-next/psl-parser';
 import { nodePslSpan } from '@prisma-next/psl-parser';
 import type { SourceFile } from '@prisma-next/psl-parser/syntax';
@@ -56,6 +57,7 @@ import { notOk, ok, type Result } from '@prisma-next/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
   baseModelSpec,
+  buildIndexModelSpec,
   discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
@@ -70,6 +72,7 @@ import {
   getNamedArgument,
   getPositionalArgument,
   lowerFirst,
+  type ParsedIndexField,
   parseIndexFieldList,
 } from './psl-helpers';
 
@@ -528,14 +531,90 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function parseIndexDirection(raw: string | undefined): MongoIndexKeyDirection {
-  if (!raw) return 1;
-  const stripped = raw.replace(/^["']/, '').replace(/["']$/, '');
-  const num = Number(stripped);
-  if (num === 1 || num === -1) return num;
-  if (['text', '2dsphere', '2d', 'hashed'].includes(stripped))
-    return stripped as MongoIndexKeyDirection;
-  return 1;
+// The spec's pinned `type` combinators already constrain the value to the exact
+// index-direction alphabet at runtime; map it to the key-direction type,
+// defaulting to ascending (1) when absent. Replaces `parseIndexDirection` for
+// the `@@index`/`@@unique` spec path.
+function normalizeIndexType(value: number | string | undefined): MongoIndexKeyDirection {
+  switch (value) {
+    case -1:
+      return -1;
+    case 'text':
+      return 'text';
+    case '2dsphere':
+      return '2dsphere';
+    case '2d':
+      return '2d';
+    case 'hashed':
+      return 'hashed';
+    default:
+      return 1;
+  }
+}
+
+// Map one interpreted `@@index`/`@@unique` field element to the same
+// `ParsedIndexField` shape the loop consumes. Discriminates the element union
+// structurally (a bare string field, a `wildcard(scope?)` call, or a
+// `field(sort:)` call) so no cast is needed; `args` values are `unknown` and
+// narrowed by comparison.
+function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField {
+  if (typeof element === 'string') {
+    return { name: element, isWildcard: false };
+  }
+  if (element.fn === 'wildcard') {
+    const scope = element.args['scope'];
+    return {
+      name: typeof scope === 'string' ? `${scope}.$**` : '$**',
+      isWildcard: true,
+    };
+  }
+  const sort = element.args['sort'];
+  return { name: element.fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 };
+}
+
+// Interpreted collation named-args of an `@@index`/`@@unique`. Mirrors
+// `parseCollation`'s semantics from spec values: `undefined` when no collation
+// arg is present, `null` when some are present but `collationLocale` is absent
+// (the semantic "collationLocale is required" rule), otherwise the options.
+interface SpecCollationArgs {
+  readonly collationLocale?: string;
+  readonly collationStrength?: number;
+  readonly collationCaseLevel?: boolean;
+  readonly collationCaseFirst?: string;
+  readonly collationNumericOrdering?: boolean;
+  readonly collationAlternate?: string;
+  readonly collationMaxVariable?: string;
+  readonly collationBackwards?: boolean;
+  readonly collationNormalization?: boolean;
+}
+
+function buildCollationFromSpec(args: SpecCollationArgs): CollationOptions | null | undefined {
+  const locale = args.collationLocale;
+  if (locale === undefined) {
+    const hasAnyCollationArg =
+      args.collationStrength !== undefined ||
+      args.collationCaseLevel !== undefined ||
+      args.collationCaseFirst !== undefined ||
+      args.collationNumericOrdering !== undefined ||
+      args.collationAlternate !== undefined ||
+      args.collationMaxVariable !== undefined ||
+      args.collationBackwards !== undefined ||
+      args.collationNormalization !== undefined;
+    return hasAnyCollationArg ? null : undefined;
+  }
+
+  const collation: CollationOptions = { locale };
+  if (args.collationStrength !== undefined) collation.strength = args.collationStrength;
+  if (args.collationCaseLevel !== undefined) collation.caseLevel = args.collationCaseLevel;
+  if (args.collationCaseFirst !== undefined) collation.caseFirst = args.collationCaseFirst;
+  if (args.collationNumericOrdering !== undefined)
+    collation.numericOrdering = args.collationNumericOrdering;
+  if (args.collationAlternate !== undefined) collation.alternate = args.collationAlternate;
+  if (args.collationMaxVariable !== undefined) collation.maxVariable = args.collationMaxVariable;
+  if (args.collationBackwards !== undefined) collation.backwards = args.collationBackwards;
+  if (args.collationNormalization !== undefined)
+    collation.normalization = args.collationNormalization;
+  return collation;
 }
 
 function parseNumericArg(raw: string | undefined): number | undefined {
@@ -628,6 +707,7 @@ function collectIndexes(
   fieldMappings: FieldMappings,
   modelNames: ReadonlySet<string>,
   sourceId: string,
+  sourceFile: SourceFile,
   diagnostics: ContractSourceDiagnostic[],
   indexSpans: Map<MongoIndex, PslSpan>,
 ): MongoIndex[] {
@@ -658,16 +738,76 @@ function collectIndexes(
     indexSpans.set(fieldUniqueIndex, uniqueAttr.span);
   }
 
-  for (const attr of pslModel.attributes) {
+  const specFieldNames = Object.keys(pslModel.fields);
+  const attributeNodes = Array.from(pslModel.node.attributes());
+
+  for (const [attrIndex, attr] of pslModel.attributes.entries()) {
     const isIndex = attr.name === 'index';
     const isUnique = attr.name === 'unique';
     const isTextIndex = attr.name === 'textIndex';
     if (!isIndex && !isUnique && !isTextIndex) continue;
 
-    const fieldsArg = getPositionalArgument(attr, 0);
-    if (!fieldsArg) continue;
-    const parsedFields = parseIndexFieldList(fieldsArg);
-    if (parsedFields.length === 0) continue;
+    // @@index/@@unique read arguments through the attribute spec; @@textIndex
+    // stays on the pre-spec parsing path (migrated later). Both produce the same
+    // normalized values the shared index-shape logic below consumes.
+    let parsedFields: readonly ParsedIndexField[];
+    let typeValue: number | string | undefined;
+    let sparse: boolean | undefined;
+    let expireAfterSeconds: number | undefined;
+    let partialFilterExpression: Record<string, unknown> | undefined;
+    let includeArg: string | undefined;
+    let excludeArg: string | undefined;
+    let collation: CollationOptions | null | undefined;
+    let weights: Record<string, number> | undefined;
+    let default_language: string | undefined;
+    let language_override: string | undefined;
+
+    if (isTextIndex) {
+      const fieldsArg = getPositionalArgument(attr, 0);
+      if (!fieldsArg) continue;
+      parsedFields = parseIndexFieldList(fieldsArg);
+      if (parsedFields.length === 0) continue;
+      typeValue = undefined;
+      sparse = undefined;
+      expireAfterSeconds = undefined;
+      partialFilterExpression = parseJsonArg(getNamedArgument(attr, 'filter'));
+      includeArg = getNamedArgument(attr, 'include');
+      excludeArg = getNamedArgument(attr, 'exclude');
+      collation = parseCollation(attr);
+      const rawWeights = parseJsonArg(getNamedArgument(attr, 'weights'));
+      if (rawWeights) {
+        weights = {};
+        for (const [k, v] of Object.entries(rawWeights)) {
+          if (typeof v === 'number') weights[k] = v;
+        }
+      }
+      default_language = stripQuotesHelper(getNamedArgument(attr, 'language'));
+      language_override = stripQuotesHelper(getNamedArgument(attr, 'languageOverride'));
+    } else {
+      const node = attributeNodes[attrIndex];
+      if (node === undefined) continue;
+      const parsed = interpretModelAttribute({
+        node,
+        spec: buildIndexModelSpec(isUnique ? 'unique' : 'index', specFieldNames),
+        model: pslModel,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed === undefined) continue;
+      parsedFields = parsed.fields.map(normalizeIndexField);
+      if (parsedFields.length === 0) continue;
+      typeValue = parsed.type;
+      sparse = parsed.sparse;
+      expireAfterSeconds = parsed.expireAfterSeconds;
+      partialFilterExpression = parsed.filter;
+      includeArg = parsed.include;
+      excludeArg = parsed.exclude;
+      collation = buildCollationFromSpec(parsed);
+      weights = undefined;
+      default_language = parsed.default_language;
+      language_override = parsed.languageOverride;
+    }
 
     const hasWildcard = parsedFields.some((f) => f.isWildcard);
     const wildcardCount = parsedFields.filter((f) => f.isWildcard).length;
@@ -716,10 +856,9 @@ function collectIndexes(
       }
     }
 
-    const typeArg = getNamedArgument(attr, 'type');
     const defaultDirection: MongoIndexKeyDirection = isTextIndex
       ? 'text'
-      : parseIndexDirection(typeArg);
+      : normalizeIndexType(typeValue);
 
     if (
       hasWildcard &&
@@ -783,10 +922,6 @@ function collectIndexes(
     });
 
     const unique = isUnique ? true : undefined;
-    const sparse = isTextIndex ? undefined : parseBooleanArg(getNamedArgument(attr, 'sparse'));
-    const expireAfterSeconds = isTextIndex
-      ? undefined
-      : parseNumericArg(getNamedArgument(attr, 'expireAfterSeconds'));
 
     if (hasWildcard && expireAfterSeconds != null) {
       diagnostics.push({
@@ -797,11 +932,6 @@ function collectIndexes(
       });
       continue;
     }
-
-    const partialFilterExpression = parseJsonArg(getNamedArgument(attr, 'filter'));
-
-    const includeArg = getNamedArgument(attr, 'include');
-    const excludeArg = getNamedArgument(attr, 'exclude');
 
     if (includeArg != null && excludeArg != null) {
       diagnostics.push({
@@ -831,7 +961,6 @@ function collectIndexes(
           ? parseProjectionList(excludeArg, 0)
           : undefined;
 
-    const collation = parseCollation(attr);
     if (collation === null) {
       diagnostics.push({
         code: 'PSL_INVALID_INDEX',
@@ -841,23 +970,6 @@ function collectIndexes(
       });
       continue;
     }
-
-    const rawWeights = parseJsonArg(getNamedArgument(attr, 'weights'));
-    let weights: Record<string, number> | undefined;
-    if (rawWeights) {
-      weights = {};
-      for (const [k, v] of Object.entries(rawWeights)) {
-        if (typeof v === 'number') weights[k] = v;
-      }
-    }
-
-    const rawDefaultLang = isTextIndex
-      ? getNamedArgument(attr, 'language')
-      : getNamedArgument(attr, 'default_language');
-    const default_language = stripQuotesHelper(rawDefaultLang);
-
-    const rawLangOverride = getNamedArgument(attr, 'languageOverride');
-    const language_override = stripQuotesHelper(rawLangOverride);
 
     const index = new MongoIndex({
       keys,
@@ -1201,6 +1313,7 @@ export function interpretPslDocumentToMongoContract(
       fieldMappings,
       modelNames,
       sourceId,
+      sourceFile,
       diagnostics,
       indexSpans,
     );

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -1469,12 +1469,17 @@ export function interpretPslDocumentToMongoContract(
     storage: storageWithoutHash,
     ...mongoContractCanonicalizationHooks,
   });
-  const storage = new MongoStorage({
-    storageHash,
-    namespaces: {
-      [UNBOUND_NAMESPACE_ID]: unboundNamespace,
-    },
-  }) as Contract['storage'];
+  const storage = blindCast<
+    Contract['storage'],
+    'MongoStorage is the Mongo family concrete storage class constructed here; it structurally satisfies the Contract storage slot.'
+  >(
+    new MongoStorage({
+      storageHash,
+      namespaces: {
+        [UNBOUND_NAMESPACE_ID]: unboundNamespace,
+      },
+    }),
+  );
   const capabilities: Record<string, Record<string, boolean>> = {};
 
   const hasEnums = Object.keys(builtEnums).length > 0;

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -40,6 +40,7 @@ import type { CollationOptions } from '@internal/mongo-value/mongodb-types';
 import type {
   CompositeTypeSymbol,
   FieldSymbol,
+  InferAttr,
   ModelSymbol,
   NamespaceSymbol,
   PslExtensionBlock,
@@ -56,13 +57,13 @@ import { notOk, ok, type Result } from '@internal/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
   baseModelSpec,
-  buildIndexModelSpec,
-  buildTextIndexModelSpec,
+  buildIndexModelSpecs,
   discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
   interpretFieldAttribute,
   interpretModelAttribute,
+  type MongoProjectionList,
   mapFieldSpec,
   mapModelSpec,
   relationFieldSpec,
@@ -118,6 +119,11 @@ function validateNamespaceBlocksForMongoTarget(input: {
 
 interface FieldMappings {
   readonly pslNameToMapped: Map<string, string>;
+}
+
+interface MongoModelMetadata {
+  readonly collectionName: string;
+  readonly fieldMappings: FieldMappings;
 }
 
 interface FkRelation {
@@ -204,6 +210,7 @@ function mongoCrossRef(modelName: string): CrossReference {
 
 function collectPolymorphismDeclarations(
   models: readonly ModelSymbol[],
+  modelMetadataByName: ReadonlyMap<string, MongoModelMetadata>,
   sourceFile: SourceFile,
   sourceId: string,
   diagnostics: ContractSourceDiagnostic[],
@@ -255,7 +262,8 @@ function collectPolymorphismDeclarations(
         diagnostics,
       });
       if (parsed) {
-        const collectionName = resolveCollectionName({ model, sourceFile, sourceId, diagnostics });
+        const collectionName =
+          modelMetadataByName.get(model.name)?.collectionName ?? lowerFirst(model.name);
         baseDeclarations.set(model.name, {
           baseName: parsed.base,
           value: parsed.value,
@@ -279,7 +287,7 @@ function resolvePolymorphism(input: {
   modelNames: ReadonlySet<string>;
   indexSpans: Map<MongoIndex, PslSpan>;
   modelIndexesByName: Map<string, readonly MongoIndex[]>;
-  sourceFile: SourceFile;
+  modelMetadataByName: ReadonlyMap<string, MongoModelMetadata>;
   sourceId: string;
 }): {
   models: Record<string, MongoModelEntry>;
@@ -291,7 +299,7 @@ function resolvePolymorphism(input: {
     discriminatorDeclarations,
     baseDeclarations,
     modelNames,
-    sourceFile,
+    modelMetadataByName,
     sourceId,
     allModels: allModelViews,
     indexSpans,
@@ -316,15 +324,9 @@ function resolvePolymorphism(input: {
     const model = patched[modelName];
     if (!model) continue;
 
-    const modelView = allModelViews.find((m) => m.name === modelName);
-    const mappedDiscriminatorField = modelView
-      ? (resolveFieldMappings({
-          model: modelView,
-          sourceFile,
-          sourceId,
-          diagnostics,
-        }).pslNameToMapped.get(decl.fieldName) ?? decl.fieldName)
-      : decl.fieldName;
+    const mappedDiscriminatorField =
+      modelMetadataByName.get(modelName)?.fieldMappings.pslNameToMapped.get(decl.fieldName) ??
+      decl.fieldName;
 
     if (!Object.hasOwn(model.fields, mappedDiscriminatorField)) {
       diagnostics.push({
@@ -411,12 +413,8 @@ function resolvePolymorphism(input: {
       };
     }
 
-    const variantCollectionName = resolveCollectionName({
-      model: variantModelView,
-      sourceFile,
-      sourceId,
-      diagnostics,
-    });
+    const variantCollectionName =
+      modelMetadataByName.get(variantName)?.collectionName ?? lowerFirst(variantName);
     if (roots[variantCollectionName]?.model === variantName) {
       if (variantCollectionName === baseCollection && baseModel) {
         roots = { ...roots, [variantCollectionName]: mongoCrossRef(baseDecl.baseName) };
@@ -560,7 +558,7 @@ function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField 
   if (typeof element === 'string') {
     return { name: element, isWildcard: false };
   }
-  if (element.fn === 'wildcard') {
+  if (element.fn === 'wildcard' && element.args['sort'] === undefined) {
     const scope = element.args['scope'];
     return {
       name: typeof scope === 'string' ? `${scope}.$**` : '$**',
@@ -631,23 +629,226 @@ function extractWeights(
   return weights;
 }
 
-function parseProjectionList(
-  raw: string | undefined,
-  value: 0 | 1,
-): Record<string, 0 | 1> | undefined {
-  if (!raw) return undefined;
-  const stripped = raw.replace(/^["']/, '').replace(/["']$/, '');
-  const inner = stripped.replace(/^\[/, '').replace(/\]$/, '').trim();
-  if (inner.length === 0) return undefined;
-  const fields = inner
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-  const result: Record<string, 0 | 1> = {};
-  for (const f of fields) {
-    result[f] = value;
+type IndexModelSpecs = ReturnType<typeof buildIndexModelSpecs>;
+type NormalIndexArgs = InferAttr<IndexModelSpecs['index']>;
+type TextIndexArgs = InferAttr<IndexModelSpecs['textIndex']>;
+
+interface IndexBuildContext {
+  readonly pslModel: ModelSymbol;
+  readonly fieldMappings: FieldMappings;
+  readonly indexableFieldNames: ReadonlySet<string>;
+  readonly sourceId: string;
+  readonly span: PslSpan;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}
+
+interface ResolvedIndexKeys {
+  readonly keys: readonly { readonly field: string; readonly direction: MongoIndexKeyDirection }[];
+  readonly hasWildcard: boolean;
+}
+
+function resolveIndexKeys(
+  parsedFields: readonly ParsedIndexField[],
+  defaultDirection: MongoIndexKeyDirection,
+  ctx: IndexBuildContext,
+): ResolvedIndexKeys | undefined {
+  const wildcardCount = parsedFields.filter((field) => field.isWildcard).length;
+  if (wildcardCount > 1) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'An index can contain at most one wildcard() field',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
   }
-  return result;
+
+  for (const field of parsedFields) {
+    const wildcardMatch = field.isWildcard ? field.name.match(/^(.+)\.\$\*\*$/) : undefined;
+    const fieldName = field.isWildcard ? wildcardMatch?.[1] : field.name;
+    if (fieldName !== undefined && !ctx.indexableFieldNames.has(fieldName)) {
+      ctx.diagnostics.push({
+        code: 'PSL_INDEX_FIELD_NOT_FOUND',
+        message: `Index on model "${ctx.pslModel.name}" references unknown field "${fieldName}"`,
+        sourceId: ctx.sourceId,
+        span: ctx.span,
+      });
+      return undefined;
+    }
+  }
+
+  const keys = parsedFields.map((field) => {
+    const mappedName = field.isWildcard
+      ? field.name.replace(/^(.+)\.\$\*\*$/, (_, prefix: string) => {
+          const mapped = ctx.fieldMappings.pslNameToMapped.get(prefix);
+          return mapped ? `${mapped}.$**` : `${prefix}.$**`;
+        })
+      : (ctx.fieldMappings.pslNameToMapped.get(field.name) ?? field.name);
+    return { field: mappedName, direction: field.direction ?? defaultDirection };
+  });
+  return { keys, hasWildcard: wildcardCount === 1 };
+}
+
+function buildProjection(
+  include: MongoProjectionList | undefined,
+  exclude: MongoProjectionList | undefined,
+  hasWildcard: boolean,
+  ctx: IndexBuildContext,
+): Record<string, 0 | 1> | null | undefined {
+  if (include !== undefined && exclude !== undefined) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'Cannot specify both include and exclude on the same index',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return null;
+  }
+  const fields = include ?? exclude;
+  if (fields === undefined) return undefined;
+  if (!hasWildcard) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'include/exclude options are only valid when the index contains a wildcard() field',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return null;
+  }
+  if (fields.length === 0) return undefined;
+  const value = include === undefined ? 0 : 1;
+  const projection: Record<string, 0 | 1> = {};
+  for (const field of fields) projection[field] = value;
+  return projection;
+}
+
+function buildNormalIndex(
+  parsed: NormalIndexArgs,
+  unique: boolean,
+  ctx: IndexBuildContext,
+): MongoIndex | undefined {
+  const parsedFields = parsed.fields.map(normalizeIndexField);
+  if (parsedFields.length === 0) return undefined;
+  const defaultDirection = normalizeIndexType(parsed.type);
+  const resolved = resolveIndexKeys(parsedFields, defaultDirection, ctx);
+  if (!resolved) return undefined;
+
+  if (unique && resolved.hasWildcard) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'Unique indexes cannot use wildcard() fields',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+  if (
+    resolved.hasWildcard &&
+    typeof defaultDirection === 'string' &&
+    ['hashed', '2dsphere', '2d'].includes(defaultDirection)
+  ) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: `wildcard() fields cannot be combined with type: ${defaultDirection}`,
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+  if (defaultDirection === 'hashed' && parsedFields.length > 1) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'Hashed indexes must have exactly one field',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+  if (resolved.hasWildcard && parsed.expireAfterSeconds !== undefined) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'expireAfterSeconds cannot be combined with wildcard() fields',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+
+  const wildcardProjection = buildProjection(
+    parsed.include,
+    parsed.exclude,
+    resolved.hasWildcard,
+    ctx,
+  );
+  if (wildcardProjection === null) return undefined;
+  const collation = buildCollationFromSpec(parsed);
+  if (collation === null) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'collationLocale is required when using collation options',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+
+  return new MongoIndex({
+    keys: resolved.keys,
+    ...(unique && { unique: true }),
+    ...(parsed.sparse !== undefined && { sparse: parsed.sparse }),
+    ...(parsed.expireAfterSeconds !== undefined && {
+      expireAfterSeconds: parsed.expireAfterSeconds,
+    }),
+    ...(parsed.filter !== undefined && { partialFilterExpression: parsed.filter }),
+    ...(wildcardProjection !== undefined && { wildcardProjection }),
+    ...(collation !== undefined && { collation }),
+    ...(parsed.default_language !== undefined && { default_language: parsed.default_language }),
+    ...(parsed.languageOverride !== undefined && { language_override: parsed.languageOverride }),
+  });
+}
+
+function buildTextIndex(parsed: TextIndexArgs, ctx: IndexBuildContext): MongoIndex | undefined {
+  const parsedFields = parsed.fields.map(normalizeIndexField);
+  if (parsedFields.length === 0) return undefined;
+  const resolved = resolveIndexKeys(parsedFields, 'text', ctx);
+  if (!resolved) return undefined;
+  if (resolved.hasWildcard) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'wildcard() fields cannot be combined with type: hashed/2dsphere/2d or @@textIndex',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+
+  const wildcardProjection = buildProjection(
+    parsed.include,
+    parsed.exclude,
+    resolved.hasWildcard,
+    ctx,
+  );
+  if (wildcardProjection === null) return undefined;
+  const collation = buildCollationFromSpec(parsed);
+  if (collation === null) {
+    ctx.diagnostics.push({
+      code: 'PSL_INVALID_INDEX',
+      message: 'collationLocale is required when using collation options',
+      sourceId: ctx.sourceId,
+      span: ctx.span,
+    });
+    return undefined;
+  }
+
+  return new MongoIndex({
+    keys: resolved.keys,
+    ...(parsed.filter !== undefined && { partialFilterExpression: parsed.filter }),
+    ...(wildcardProjection !== undefined && { wildcardProjection }),
+    ...(collation !== undefined && { collation }),
+    ...ifDefined('weights', extractWeights(parsed.weights)),
+    ...(parsed.language !== undefined && { default_language: parsed.language }),
+    ...(parsed.languageOverride !== undefined && { language_override: parsed.languageOverride }),
+  });
 }
 
 function collectIndexes(
@@ -661,16 +862,9 @@ function collectIndexes(
 ): MongoIndex[] {
   const indexes: MongoIndex[] = [];
   let textIndexCount = 0;
-
-  // Storage-indexable PSL field names — i.e. all declared fields except
-  // relation fields (which don't materialize a column on this model). The
-  // index field-existence check (PSL_INDEX_FIELD_NOT_FOUND) consults this
-  // rather than fieldMappings.pslNameToMapped because the latter contains
-  // every PSL field including relation fields.
   const indexableFieldNames = new Set<string>();
-  for (const f of Object.values(pslModel.fields)) {
-    if (modelNames.has(f.typeName)) continue;
-    indexableFieldNames.add(f.name);
+  for (const field of Object.values(pslModel.fields)) {
+    if (!modelNames.has(field.typeName)) indexableFieldNames.add(field.name);
   }
 
   for (const field of Object.values(pslModel.fields)) {
@@ -686,104 +880,32 @@ function collectIndexes(
     indexSpans.set(fieldUniqueIndex, uniqueAttr.span);
   }
 
-  const specFieldNames = Object.keys(pslModel.fields);
+  const specs = buildIndexModelSpecs(Object.keys(pslModel.fields));
   const attributeNodes = Array.from(pslModel.node.attributes());
-
   for (const [attrIndex, attr] of pslModel.attributes.entries()) {
-    const isIndex = attr.name === 'index';
-    const isUnique = attr.name === 'unique';
-    const isTextIndex = attr.name === 'textIndex';
-    if (!isIndex && !isUnique && !isTextIndex) continue;
-
-    // @@index/@@unique/@@textIndex all read arguments through their attribute
-    // spec. The two specs infer different named-arg shapes, so each branch
-    // interprets its own spec and fills the shared normalized values the
-    // index-shape logic below consumes.
-    let parsedFields: readonly ParsedIndexField[];
-    let typeValue: number | string | undefined;
-    let sparse: boolean | undefined;
-    let expireAfterSeconds: number | undefined;
-    let partialFilterExpression: Record<string, unknown> | undefined;
-    let includeArg: string | undefined;
-    let excludeArg: string | undefined;
-    let collation: CollationOptions | null | undefined;
-    let weights: Record<string, number> | undefined;
-    let default_language: string | undefined;
-    let language_override: string | undefined;
-
+    if (attr.name !== 'index' && attr.name !== 'unique' && attr.name !== 'textIndex') continue;
     const node = attributeNodes[attrIndex];
-    if (node === undefined) continue;
+    if (!node) continue;
+    const ctx: IndexBuildContext = {
+      pslModel,
+      fieldMappings,
+      indexableFieldNames,
+      sourceId,
+      span: attr.span,
+      diagnostics,
+    };
 
-    if (isTextIndex) {
+    let index: MongoIndex | undefined;
+    if (attr.name === 'textIndex') {
       const parsed = interpretModelAttribute({
         node,
-        spec: buildTextIndexModelSpec(specFieldNames),
+        spec: specs.textIndex,
         model: pslModel,
         sourceFile,
         sourceId,
         diagnostics,
       });
-      if (parsed === undefined) continue;
-      parsedFields = parsed.fields.map(normalizeIndexField);
-      if (parsedFields.length === 0) continue;
-      typeValue = undefined;
-      sparse = undefined;
-      expireAfterSeconds = undefined;
-      partialFilterExpression = parsed.filter;
-      includeArg = parsed.include;
-      excludeArg = parsed.exclude;
-      collation = buildCollationFromSpec(parsed);
-      weights = extractWeights(parsed.weights);
-      default_language = parsed.language;
-      language_override = parsed.languageOverride;
-    } else {
-      const parsed = interpretModelAttribute({
-        node,
-        spec: buildIndexModelSpec(isUnique ? 'unique' : 'index', specFieldNames),
-        model: pslModel,
-        sourceFile,
-        sourceId,
-        diagnostics,
-      });
-      if (parsed === undefined) continue;
-      parsedFields = parsed.fields.map(normalizeIndexField);
-      if (parsedFields.length === 0) continue;
-      typeValue = parsed.type;
-      sparse = parsed.sparse;
-      expireAfterSeconds = parsed.expireAfterSeconds;
-      partialFilterExpression = parsed.filter;
-      includeArg = parsed.include;
-      excludeArg = parsed.exclude;
-      collation = buildCollationFromSpec(parsed);
-      weights = undefined;
-      default_language = parsed.default_language;
-      language_override = parsed.languageOverride;
-    }
-
-    const hasWildcard = parsedFields.some((f) => f.isWildcard);
-    const wildcardCount = parsedFields.filter((f) => f.isWildcard).length;
-
-    if (wildcardCount > 1) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: 'An index can contain at most one wildcard() field',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    if (isUnique && hasWildcard) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: 'Unique indexes cannot use wildcard() fields',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    if (isTextIndex) {
+      if (!parsed || parsed.fields.length === 0) continue;
       textIndexCount++;
       if (textIndexCount > 1) {
         diagnostics.push({
@@ -794,150 +916,25 @@ function collectIndexes(
         });
         continue;
       }
-
-      if (hasWildcard) {
-        diagnostics.push({
-          code: 'PSL_INVALID_INDEX',
-          message:
-            'wildcard() fields cannot be combined with type: hashed/2dsphere/2d or @@textIndex',
-          sourceId,
-          span: attr.span,
-        });
-        continue;
-      }
-    }
-
-    const defaultDirection: MongoIndexKeyDirection = isTextIndex
-      ? 'text'
-      : normalizeIndexType(typeValue);
-
-    if (
-      hasWildcard &&
-      typeof defaultDirection === 'string' &&
-      ['hashed', '2dsphere', '2d'].includes(defaultDirection)
-    ) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: `wildcard() fields cannot be combined with type: ${defaultDirection}`,
+      index = buildTextIndex(parsed, ctx);
+    } else {
+      const unique = attr.name === 'unique';
+      const parsed = interpretModelAttribute({
+        node,
+        spec: unique ? specs.unique : specs.index,
+        model: pslModel,
+        sourceFile,
         sourceId,
-        span: attr.span,
+        diagnostics,
       });
-      continue;
+      if (!parsed) continue;
+      index = buildNormalIndex(parsed, unique, ctx);
     }
 
-    if (defaultDirection === 'hashed' && parsedFields.length > 1) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: 'Hashed indexes must have exactly one field',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    let missingField: string | undefined;
-    for (const pf of parsedFields) {
-      let fieldNameForLookup: string | undefined;
-      if (pf.isWildcard) {
-        const wildcardMatch = pf.name.match(/^(.+)\.\$\*\*$/);
-        fieldNameForLookup = wildcardMatch ? wildcardMatch[1] : undefined;
-      } else {
-        fieldNameForLookup = pf.name;
-      }
-      if (fieldNameForLookup === undefined || fieldNameForLookup.length === 0) continue;
-      if (!indexableFieldNames.has(fieldNameForLookup)) {
-        missingField = fieldNameForLookup;
-        break;
-      }
-    }
-    if (missingField !== undefined) {
-      diagnostics.push({
-        code: 'PSL_INDEX_FIELD_NOT_FOUND',
-        message: `Index on model "${pslModel.name}" references unknown field "${missingField}"`,
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    const keys = parsedFields.map((pf) => {
-      const mappedName = pf.isWildcard
-        ? pf.name.replace(/^(.+)\.\$\*\*$/, (_, prefix: string) => {
-            const mapped = fieldMappings.pslNameToMapped.get(prefix);
-            return mapped ? `${mapped}.$**` : `${prefix}.$**`;
-          })
-        : (fieldMappings.pslNameToMapped.get(pf.name) ?? pf.name);
-      const direction: MongoIndexKeyDirection = pf.direction ?? defaultDirection;
-      return { field: mappedName, direction };
-    });
-
-    const unique = isUnique ? true : undefined;
-
-    if (hasWildcard && expireAfterSeconds != null) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: 'expireAfterSeconds cannot be combined with wildcard() fields',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    if (includeArg != null && excludeArg != null) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: 'Cannot specify both include and exclude on the same index',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    if ((includeArg != null || excludeArg != null) && !hasWildcard) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message:
-          'include/exclude options are only valid when the index contains a wildcard() field',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    const wildcardProjection =
-      includeArg != null
-        ? parseProjectionList(includeArg, 1)
-        : excludeArg != null
-          ? parseProjectionList(excludeArg, 0)
-          : undefined;
-
-    if (collation === null) {
-      diagnostics.push({
-        code: 'PSL_INVALID_INDEX',
-        message: 'collationLocale is required when using collation options',
-        sourceId,
-        span: attr.span,
-      });
-      continue;
-    }
-
-    const index = new MongoIndex({
-      keys,
-      ...(unique != null && { unique }),
-      ...(sparse != null && { sparse }),
-      ...(expireAfterSeconds != null && { expireAfterSeconds }),
-      ...(partialFilterExpression != null && { partialFilterExpression }),
-      ...(wildcardProjection != null && { wildcardProjection }),
-      ...(collation != null && { collation }),
-      ...(weights != null && { weights }),
-      ...(default_language != null && { default_language }),
-      ...(language_override != null && { language_override }),
-    });
-
+    if (!index) continue;
     indexes.push(index);
     indexSpans.set(index, attr.span);
   }
-
   return indexes;
 }
 
@@ -1083,6 +1080,13 @@ export function interpretPslDocumentToMongoContract(
   const allCompositeTypes: CompositeTypeSymbol[] = Object.values(topLevel.compositeTypes);
   const modelNames = new Set(allModels.map((m) => m.name));
   const compositeTypeNames = new Set(allCompositeTypes.map((ct) => ct.name));
+  const modelMetadataByName = new Map<string, MongoModelMetadata>();
+  for (const model of allModels) {
+    modelMetadataByName.set(model.name, {
+      collectionName: resolveCollectionName({ model, sourceFile, sourceId, diagnostics }),
+      fieldMappings: resolveFieldMappings({ model, sourceFile, sourceId, diagnostics }),
+    });
+  }
 
   const topLevelEnumBlocks = Object.values(topLevel.blocks)
     .filter((b) => b.keyword === 'enum')
@@ -1131,18 +1135,9 @@ export function interpretPslDocumentToMongoContract(
   const backrelationCandidates: BackrelationCandidate[] = [];
 
   for (const pslModel of allModels) {
-    const collectionName = resolveCollectionName({
-      model: pslModel,
-      sourceFile,
-      sourceId,
-      diagnostics,
-    });
-    const fieldMappings = resolveFieldMappings({
-      model: pslModel,
-      sourceFile,
-      sourceId,
-      diagnostics,
-    });
+    const metadata = modelMetadataByName.get(pslModel.name);
+    if (!metadata) continue;
+    const { collectionName, fieldMappings } = metadata;
 
     const fields: Record<string, ContractField> = {};
     const relations: Record<string, ContractReferenceRelation> = {};
@@ -1178,10 +1173,7 @@ export function interpretPslDocumentToMongoContract(
         if (relation?.fields && relation?.references) {
           const localMapped = relation.fields.map((f) => fieldMappings.pslNameToMapped.get(f) ?? f);
 
-          const targetModel = allModels.find((m) => m.name === field.typeName);
-          const targetFieldMappings = targetModel
-            ? resolveFieldMappings({ model: targetModel, sourceFile, sourceId, diagnostics })
-            : undefined;
+          const targetFieldMappings = modelMetadataByName.get(field.typeName)?.fieldMappings;
           const targetMapped = relation.references.map(
             (f) => targetFieldMappings?.pslNameToMapped.get(f) ?? f,
           );
@@ -1350,6 +1342,7 @@ export function interpretPslDocumentToMongoContract(
 
   const { discriminatorDeclarations, baseDeclarations } = collectPolymorphismDeclarations(
     allModels,
+    modelMetadataByName,
     sourceFile,
     sourceId,
     diagnostics,
@@ -1364,7 +1357,7 @@ export function interpretPslDocumentToMongoContract(
     modelNames,
     indexSpans,
     modelIndexesByName,
-    sourceFile,
+    modelMetadataByName,
     sourceId,
   });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -63,12 +63,11 @@ import {
   findModelAttributeNode,
   interpretFieldAttribute,
   interpretModelAttribute,
-  type MongoProjectionList,
   mapFieldSpec,
   mapModelSpec,
   relationFieldSpec,
 } from './mongo-attribute-specs';
-import { getAttribute, lowerFirst, type ParsedIndexField } from './psl-helpers';
+import { getAttribute, lowerFirst } from './psl-helpers';
 
 /**
  * Encode an authored enum value to its codec-encoded JSON form via the codec resolved by id from the
@@ -529,44 +528,27 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
-// The spec's pinned `type` combinators already constrain the value to the exact
-// index-direction alphabet at runtime; normalize it to the Mongo key-direction
-// type, defaulting to ascending (1) when absent.
-function normalizeIndexType(value: number | string | undefined): MongoIndexKeyDirection {
-  switch (value) {
-    case -1:
-      return -1;
-    case 'text':
-      return 'text';
-    case '2dsphere':
-      return '2dsphere';
-    case '2d':
-      return '2d';
-    case 'hashed':
-      return 'hashed';
-    default:
-      return 1;
-  }
-}
+type ParsedIndexField =
+  | {
+      readonly kind: 'field';
+      readonly name: string;
+      readonly direction?: 1 | -1;
+    }
+  | {
+      readonly kind: 'wildcard';
+      readonly scope?: string;
+    };
 
-// Map one interpreted `@@index`/`@@unique` field element to the same
-// `ParsedIndexField` shape the loop consumes. Discriminates the element union
-// structurally (a bare string field, a `wildcard(scope?)` call, or a
-// `field(sort:)` call) so no cast is needed; `args` values are `unknown` and
-// narrowed by comparison.
 function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField {
   if (typeof element === 'string') {
-    return { name: element, isWildcard: false };
+    return { kind: 'field', name: element };
   }
   if (element.fn === 'wildcard' && element.args['sort'] === undefined) {
     const scope = element.args['scope'];
-    return {
-      name: typeof scope === 'string' ? `${scope}.$**` : '$**',
-      isWildcard: true,
-    };
+    return typeof scope === 'string' ? { kind: 'wildcard', scope } : { kind: 'wildcard' };
   }
   const sort = element.args['sort'];
-  return { name: element.fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 };
+  return { kind: 'field', name: element.fn, direction: sort === 'Desc' ? -1 : 1 };
 }
 
 interface SpecCollationArgs {
@@ -633,7 +615,7 @@ function resolveIndexKeys(
   defaultDirection: MongoIndexKeyDirection,
   ctx: IndexBuildContext,
 ): ResolvedIndexKeys | undefined {
-  const wildcardCount = parsedFields.filter((field) => field.isWildcard).length;
+  const wildcardCount = parsedFields.filter((field) => field.kind === 'wildcard').length;
   if (wildcardCount > 1) {
     ctx.diagnostics.push({
       code: 'PSL_INVALID_INDEX',
@@ -645,8 +627,7 @@ function resolveIndexKeys(
   }
 
   for (const field of parsedFields) {
-    const wildcardMatch = field.isWildcard ? field.name.match(/^(.+)\.\$\*\*$/) : undefined;
-    const fieldName = field.isWildcard ? wildcardMatch?.[1] : field.name;
+    const fieldName = field.kind === 'wildcard' ? field.scope : field.name;
     if (fieldName !== undefined && !ctx.indexableFieldNames.has(fieldName)) {
       ctx.diagnostics.push({
         code: 'PSL_INDEX_FIELD_NOT_FOUND',
@@ -659,20 +640,20 @@ function resolveIndexKeys(
   }
 
   const keys = parsedFields.map((field) => {
-    const mappedName = field.isWildcard
-      ? field.name.replace(/^(.+)\.\$\*\*$/, (_, prefix: string) => {
-          const mapped = ctx.fieldMappings.pslNameToMapped.get(prefix);
-          return mapped ? `${mapped}.$**` : `${prefix}.$**`;
-        })
-      : (ctx.fieldMappings.pslNameToMapped.get(field.name) ?? field.name);
+    if (field.kind === 'wildcard') {
+      if (field.scope === undefined) return { field: '$**', direction: defaultDirection };
+      const mappedScope = ctx.fieldMappings.pslNameToMapped.get(field.scope) ?? field.scope;
+      return { field: `${mappedScope}.$**`, direction: defaultDirection };
+    }
+    const mappedName = ctx.fieldMappings.pslNameToMapped.get(field.name) ?? field.name;
     return { field: mappedName, direction: field.direction ?? defaultDirection };
   });
   return { keys, hasWildcard: wildcardCount === 1 };
 }
 
 function buildProjection(
-  include: MongoProjectionList | undefined,
-  exclude: MongoProjectionList | undefined,
+  include: readonly string[] | undefined,
+  exclude: readonly string[] | undefined,
   hasWildcard: boolean,
   ctx: IndexBuildContext,
 ): Record<string, 0 | 1> | null | undefined {
@@ -710,7 +691,7 @@ function buildNormalIndex(
 ): MongoIndex | undefined {
   const parsedFields = parsed.fields.map(normalizeIndexField);
   if (parsedFields.length === 0) return undefined;
-  const defaultDirection = normalizeIndexType(parsed.type);
+  const defaultDirection = parsed.type ?? 1;
   const resolved = resolveIndexKeys(parsedFields, defaultDirection, ctx);
   if (!resolved) return undefined;
 
@@ -803,13 +784,6 @@ function buildTextIndex(parsed: TextIndexArgs, ctx: IndexBuildContext): MongoInd
     return undefined;
   }
 
-  const wildcardProjection = buildProjection(
-    parsed.include,
-    parsed.exclude,
-    resolved.hasWildcard,
-    ctx,
-  );
-  if (wildcardProjection === null) return undefined;
   const collation = buildCollationFromSpec(parsed);
   if (collation === null) {
     ctx.diagnostics.push({
@@ -824,7 +798,6 @@ function buildTextIndex(parsed: TextIndexArgs, ctx: IndexBuildContext): MongoInd
   return new MongoIndex({
     keys: resolved.keys,
     ...(parsed.filter !== undefined && { partialFilterExpression: parsed.filter }),
-    ...(wildcardProjection !== undefined && { wildcardProjection }),
     ...(collation !== undefined && { collation }),
     ...ifDefined('weights', parsed.weights),
     ...(parsed.language !== undefined && { default_language: parsed.language }),

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -569,10 +569,6 @@ function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField 
   return { name: element.fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 };
 }
 
-// Interpreted collation named-args of an `@@index`/`@@unique`/`@@textIndex`.
-// Semantics from spec values: `undefined` when no collation arg is present,
-// `null` when some are present but `collationLocale` is absent (the semantic
-// "collationLocale is required" rule), otherwise the options.
 interface SpecCollationArgs {
   readonly collationLocale?: string;
   readonly collationStrength?: number;
@@ -612,21 +608,6 @@ function buildCollationFromSpec(args: SpecCollationArgs): CollationOptions | nul
   if (args.collationNormalization !== undefined)
     collation.normalization = args.collationNormalization;
   return collation;
-}
-
-// Filter an interpreted `weights` json object down to its numeric entries — the
-// only weight values MongoDB accepts. `Record<string, unknown>` values are
-// narrowed by `typeof`, so no cast is needed. Returns `undefined` only when the
-// arg was absent; a present-but-empty object stays `{}` to match prior behavior.
-function extractWeights(
-  raw: Record<string, unknown> | undefined,
-): Record<string, number> | undefined {
-  if (raw === undefined) return undefined;
-  const weights: Record<string, number> = {};
-  for (const [key, value] of Object.entries(raw)) {
-    if (typeof value === 'number') weights[key] = value;
-  }
-  return weights;
 }
 
 type IndexModelSpecs = ReturnType<typeof buildIndexModelSpecs>;
@@ -845,7 +826,7 @@ function buildTextIndex(parsed: TextIndexArgs, ctx: IndexBuildContext): MongoInd
     ...(parsed.filter !== undefined && { partialFilterExpression: parsed.filter }),
     ...(wildcardProjection !== undefined && { wildcardProjection }),
     ...(collation !== undefined && { collation }),
-    ...ifDefined('weights', extractWeights(parsed.weights)),
+    ...ifDefined('weights', parsed.weights),
     ...(parsed.language !== undefined && { default_language: parsed.language }),
     ...(parsed.languageOverride !== undefined && { language_override: parsed.languageOverride }),
   });

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -46,6 +46,7 @@ import type {
   PslSpan,
   ResolvedAttribute,
   SymbolTable,
+  TypedFuncCall,
 } from '@internal/psl-parser';
 import { nodePslSpan } from '@internal/psl-parser';
 import type { SourceFile } from '@internal/psl-parser/syntax';
@@ -56,6 +57,7 @@ import { notOk, ok, type Result } from '@internal/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
   baseModelSpec,
+  buildIndexModelSpec,
   discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
@@ -70,6 +72,7 @@ import {
   getNamedArgument,
   getPositionalArgument,
   lowerFirst,
+  type ParsedIndexField,
   parseIndexFieldList,
 } from './psl-helpers';
 
@@ -528,14 +531,90 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function parseIndexDirection(raw: string | undefined): MongoIndexKeyDirection {
-  if (!raw) return 1;
-  const stripped = raw.replace(/^["']/, '').replace(/["']$/, '');
-  const num = Number(stripped);
-  if (num === 1 || num === -1) return num;
-  if (['text', '2dsphere', '2d', 'hashed'].includes(stripped))
-    return stripped as MongoIndexKeyDirection;
-  return 1;
+// The spec's pinned `type` combinators already constrain the value to the exact
+// index-direction alphabet at runtime; map it to the key-direction type,
+// defaulting to ascending (1) when absent. Replaces `parseIndexDirection` for
+// the `@@index`/`@@unique` spec path.
+function normalizeIndexType(value: number | string | undefined): MongoIndexKeyDirection {
+  switch (value) {
+    case -1:
+      return -1;
+    case 'text':
+      return 'text';
+    case '2dsphere':
+      return '2dsphere';
+    case '2d':
+      return '2d';
+    case 'hashed':
+      return 'hashed';
+    default:
+      return 1;
+  }
+}
+
+// Map one interpreted `@@index`/`@@unique` field element to the same
+// `ParsedIndexField` shape the loop consumes. Discriminates the element union
+// structurally (a bare string field, a `wildcard(scope?)` call, or a
+// `field(sort:)` call) so no cast is needed; `args` values are `unknown` and
+// narrowed by comparison.
+function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField {
+  if (typeof element === 'string') {
+    return { name: element, isWildcard: false };
+  }
+  if (element.fn === 'wildcard') {
+    const scope = element.args['scope'];
+    return {
+      name: typeof scope === 'string' ? `${scope}.$**` : '$**',
+      isWildcard: true,
+    };
+  }
+  const sort = element.args['sort'];
+  return { name: element.fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 };
+}
+
+// Interpreted collation named-args of an `@@index`/`@@unique`. Mirrors
+// `parseCollation`'s semantics from spec values: `undefined` when no collation
+// arg is present, `null` when some are present but `collationLocale` is absent
+// (the semantic "collationLocale is required" rule), otherwise the options.
+interface SpecCollationArgs {
+  readonly collationLocale?: string;
+  readonly collationStrength?: number;
+  readonly collationCaseLevel?: boolean;
+  readonly collationCaseFirst?: string;
+  readonly collationNumericOrdering?: boolean;
+  readonly collationAlternate?: string;
+  readonly collationMaxVariable?: string;
+  readonly collationBackwards?: boolean;
+  readonly collationNormalization?: boolean;
+}
+
+function buildCollationFromSpec(args: SpecCollationArgs): CollationOptions | null | undefined {
+  const locale = args.collationLocale;
+  if (locale === undefined) {
+    const hasAnyCollationArg =
+      args.collationStrength !== undefined ||
+      args.collationCaseLevel !== undefined ||
+      args.collationCaseFirst !== undefined ||
+      args.collationNumericOrdering !== undefined ||
+      args.collationAlternate !== undefined ||
+      args.collationMaxVariable !== undefined ||
+      args.collationBackwards !== undefined ||
+      args.collationNormalization !== undefined;
+    return hasAnyCollationArg ? null : undefined;
+  }
+
+  const collation: CollationOptions = { locale };
+  if (args.collationStrength !== undefined) collation.strength = args.collationStrength;
+  if (args.collationCaseLevel !== undefined) collation.caseLevel = args.collationCaseLevel;
+  if (args.collationCaseFirst !== undefined) collation.caseFirst = args.collationCaseFirst;
+  if (args.collationNumericOrdering !== undefined)
+    collation.numericOrdering = args.collationNumericOrdering;
+  if (args.collationAlternate !== undefined) collation.alternate = args.collationAlternate;
+  if (args.collationMaxVariable !== undefined) collation.maxVariable = args.collationMaxVariable;
+  if (args.collationBackwards !== undefined) collation.backwards = args.collationBackwards;
+  if (args.collationNormalization !== undefined)
+    collation.normalization = args.collationNormalization;
+  return collation;
 }
 
 function parseNumericArg(raw: string | undefined): number | undefined {
@@ -628,6 +707,7 @@ function collectIndexes(
   fieldMappings: FieldMappings,
   modelNames: ReadonlySet<string>,
   sourceId: string,
+  sourceFile: SourceFile,
   diagnostics: ContractSourceDiagnostic[],
   indexSpans: Map<MongoIndex, PslSpan>,
 ): MongoIndex[] {
@@ -658,16 +738,76 @@ function collectIndexes(
     indexSpans.set(fieldUniqueIndex, uniqueAttr.span);
   }
 
-  for (const attr of pslModel.attributes) {
+  const specFieldNames = Object.keys(pslModel.fields);
+  const attributeNodes = Array.from(pslModel.node.attributes());
+
+  for (const [attrIndex, attr] of pslModel.attributes.entries()) {
     const isIndex = attr.name === 'index';
     const isUnique = attr.name === 'unique';
     const isTextIndex = attr.name === 'textIndex';
     if (!isIndex && !isUnique && !isTextIndex) continue;
 
-    const fieldsArg = getPositionalArgument(attr, 0);
-    if (!fieldsArg) continue;
-    const parsedFields = parseIndexFieldList(fieldsArg);
-    if (parsedFields.length === 0) continue;
+    // @@index/@@unique read arguments through the attribute spec; @@textIndex
+    // stays on the pre-spec parsing path (migrated later). Both produce the same
+    // normalized values the shared index-shape logic below consumes.
+    let parsedFields: readonly ParsedIndexField[];
+    let typeValue: number | string | undefined;
+    let sparse: boolean | undefined;
+    let expireAfterSeconds: number | undefined;
+    let partialFilterExpression: Record<string, unknown> | undefined;
+    let includeArg: string | undefined;
+    let excludeArg: string | undefined;
+    let collation: CollationOptions | null | undefined;
+    let weights: Record<string, number> | undefined;
+    let default_language: string | undefined;
+    let language_override: string | undefined;
+
+    if (isTextIndex) {
+      const fieldsArg = getPositionalArgument(attr, 0);
+      if (!fieldsArg) continue;
+      parsedFields = parseIndexFieldList(fieldsArg);
+      if (parsedFields.length === 0) continue;
+      typeValue = undefined;
+      sparse = undefined;
+      expireAfterSeconds = undefined;
+      partialFilterExpression = parseJsonArg(getNamedArgument(attr, 'filter'));
+      includeArg = getNamedArgument(attr, 'include');
+      excludeArg = getNamedArgument(attr, 'exclude');
+      collation = parseCollation(attr);
+      const rawWeights = parseJsonArg(getNamedArgument(attr, 'weights'));
+      if (rawWeights) {
+        weights = {};
+        for (const [k, v] of Object.entries(rawWeights)) {
+          if (typeof v === 'number') weights[k] = v;
+        }
+      }
+      default_language = stripQuotesHelper(getNamedArgument(attr, 'language'));
+      language_override = stripQuotesHelper(getNamedArgument(attr, 'languageOverride'));
+    } else {
+      const node = attributeNodes[attrIndex];
+      if (node === undefined) continue;
+      const parsed = interpretModelAttribute({
+        node,
+        spec: buildIndexModelSpec(isUnique ? 'unique' : 'index', specFieldNames),
+        model: pslModel,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed === undefined) continue;
+      parsedFields = parsed.fields.map(normalizeIndexField);
+      if (parsedFields.length === 0) continue;
+      typeValue = parsed.type;
+      sparse = parsed.sparse;
+      expireAfterSeconds = parsed.expireAfterSeconds;
+      partialFilterExpression = parsed.filter;
+      includeArg = parsed.include;
+      excludeArg = parsed.exclude;
+      collation = buildCollationFromSpec(parsed);
+      weights = undefined;
+      default_language = parsed.default_language;
+      language_override = parsed.languageOverride;
+    }
 
     const hasWildcard = parsedFields.some((f) => f.isWildcard);
     const wildcardCount = parsedFields.filter((f) => f.isWildcard).length;
@@ -716,10 +856,9 @@ function collectIndexes(
       }
     }
 
-    const typeArg = getNamedArgument(attr, 'type');
     const defaultDirection: MongoIndexKeyDirection = isTextIndex
       ? 'text'
-      : parseIndexDirection(typeArg);
+      : normalizeIndexType(typeValue);
 
     if (
       hasWildcard &&
@@ -783,10 +922,6 @@ function collectIndexes(
     });
 
     const unique = isUnique ? true : undefined;
-    const sparse = isTextIndex ? undefined : parseBooleanArg(getNamedArgument(attr, 'sparse'));
-    const expireAfterSeconds = isTextIndex
-      ? undefined
-      : parseNumericArg(getNamedArgument(attr, 'expireAfterSeconds'));
 
     if (hasWildcard && expireAfterSeconds != null) {
       diagnostics.push({
@@ -797,11 +932,6 @@ function collectIndexes(
       });
       continue;
     }
-
-    const partialFilterExpression = parseJsonArg(getNamedArgument(attr, 'filter'));
-
-    const includeArg = getNamedArgument(attr, 'include');
-    const excludeArg = getNamedArgument(attr, 'exclude');
 
     if (includeArg != null && excludeArg != null) {
       diagnostics.push({
@@ -831,7 +961,6 @@ function collectIndexes(
           ? parseProjectionList(excludeArg, 0)
           : undefined;
 
-    const collation = parseCollation(attr);
     if (collation === null) {
       diagnostics.push({
         code: 'PSL_INVALID_INDEX',
@@ -841,23 +970,6 @@ function collectIndexes(
       });
       continue;
     }
-
-    const rawWeights = parseJsonArg(getNamedArgument(attr, 'weights'));
-    let weights: Record<string, number> | undefined;
-    if (rawWeights) {
-      weights = {};
-      for (const [k, v] of Object.entries(rawWeights)) {
-        if (typeof v === 'number') weights[k] = v;
-      }
-    }
-
-    const rawDefaultLang = isTextIndex
-      ? getNamedArgument(attr, 'language')
-      : getNamedArgument(attr, 'default_language');
-    const default_language = stripQuotesHelper(rawDefaultLang);
-
-    const rawLangOverride = getNamedArgument(attr, 'languageOverride');
-    const language_override = stripQuotesHelper(rawLangOverride);
 
     const index = new MongoIndex({
       keys,
@@ -1201,6 +1313,7 @@ export function interpretPslDocumentToMongoContract(
       fieldMappings,
       modelNames,
       sourceId,
+      sourceFile,
       diagnostics,
       indexSpans,
     );

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -55,8 +55,15 @@ import { ifDefined } from '@internal/utils/defined';
 import { notOk, ok, type Result } from '@internal/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
+  findFieldAttributeNode,
+  findModelAttributeNode,
+  interpretFieldAttribute,
+  interpretModelAttribute,
+  mapFieldSpec,
+  mapModelSpec,
+} from './mongo-attribute-specs';
+import {
   getAttribute,
-  getMapName,
   getNamedArgument,
   getPositionalArgument,
   lowerFirst,
@@ -129,17 +136,52 @@ function fkRelationPairKey(declaringModel: string, targetModel: string): string 
   return `${declaringModel}::${targetModel}`;
 }
 
-function resolveFieldMappings(model: ModelSymbol): FieldMappings {
+function resolveFieldMappings(input: {
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): FieldMappings {
+  const { model, sourceFile, sourceId, diagnostics } = input;
   const pslNameToMapped = new Map<string, string>();
   for (const field of Object.values(model.fields)) {
-    const mapped = getMapName(field.attributes) ?? field.name;
+    const mapNode = findFieldAttributeNode(field, 'map');
+    const mapped =
+      (mapNode
+        ? interpretFieldAttribute({
+            node: mapNode,
+            spec: mapFieldSpec,
+            model,
+            field,
+            sourceFile,
+            sourceId,
+            diagnostics,
+          })?.name
+        : undefined) ?? field.name;
     pslNameToMapped.set(field.name, mapped);
   }
   return { pslNameToMapped };
 }
 
-function resolveCollectionName(model: ModelSymbol): string {
-  return getMapName(model.attributes) ?? lowerFirst(model.name);
+function resolveCollectionName(input: {
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): string {
+  const { model, sourceFile, sourceId, diagnostics } = input;
+  const mapNode = findModelAttributeNode(model, 'map');
+  const name = mapNode
+    ? interpretModelAttribute({
+        node: mapNode,
+        spec: mapModelSpec,
+        model,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      })?.name
+    : undefined;
+  return name ?? lowerFirst(model.name);
 }
 
 interface MongoModelEntry {
@@ -165,6 +207,7 @@ function mongoCrossRef(modelName: string): CrossReference {
 
 function collectPolymorphismDeclarations(
   models: readonly ModelSymbol[],
+  sourceFile: SourceFile,
   sourceId: string,
   diagnostics: ContractSourceDiagnostic[],
 ): {
@@ -221,7 +264,7 @@ function collectPolymorphismDeclarations(
           });
           continue;
         }
-        const collectionName = resolveCollectionName(model);
+        const collectionName = resolveCollectionName({ model, sourceFile, sourceId, diagnostics });
         baseDeclarations.set(model.name, { baseName, value, collectionName, span: attr.span });
       }
     }
@@ -240,6 +283,7 @@ function resolvePolymorphism(input: {
   modelNames: ReadonlySet<string>;
   indexSpans: Map<MongoIndex, PslSpan>;
   modelIndexesByName: Map<string, readonly MongoIndex[]>;
+  sourceFile: SourceFile;
   sourceId: string;
 }): {
   models: Record<string, MongoModelEntry>;
@@ -251,6 +295,7 @@ function resolvePolymorphism(input: {
     discriminatorDeclarations,
     baseDeclarations,
     modelNames,
+    sourceFile,
     sourceId,
     allModels: allModelViews,
     indexSpans,
@@ -277,7 +322,12 @@ function resolvePolymorphism(input: {
 
     const modelView = allModelViews.find((m) => m.name === modelName);
     const mappedDiscriminatorField = modelView
-      ? (resolveFieldMappings(modelView).pslNameToMapped.get(decl.fieldName) ?? decl.fieldName)
+      ? (resolveFieldMappings({
+          model: modelView,
+          sourceFile,
+          sourceId,
+          diagnostics,
+        }).pslNameToMapped.get(decl.fieldName) ?? decl.fieldName)
       : decl.fieldName;
 
     if (!Object.hasOwn(model.fields, mappedDiscriminatorField)) {
@@ -340,7 +390,7 @@ function resolvePolymorphism(input: {
     const baseModel = patched[baseDecl.baseName];
     const variantModelView = allModelViews.find((m) => m.name === variantName);
     if (!variantModelView) continue;
-    const hasExplicitMap = getMapName(variantModelView.attributes) !== undefined;
+    const hasExplicitMap = getAttribute(variantModelView.attributes, 'map') !== undefined;
 
     if (hasExplicitMap && baseModel && baseDecl.collectionName !== baseModel.storage.collection) {
       diagnostics.push({
@@ -365,7 +415,12 @@ function resolvePolymorphism(input: {
       };
     }
 
-    const variantCollectionName = resolveCollectionName(variantModelView);
+    const variantCollectionName = resolveCollectionName({
+      model: variantModelView,
+      sourceFile,
+      sourceId,
+      diagnostics,
+    });
     if (roots[variantCollectionName]?.model === variantName) {
       if (variantCollectionName === baseCollection && baseModel) {
         roots = { ...roots, [variantCollectionName]: mongoCrossRef(baseDecl.baseName) };
@@ -1014,8 +1069,18 @@ export function interpretPslDocumentToMongoContract(
   const backrelationCandidates: BackrelationCandidate[] = [];
 
   for (const pslModel of allModels) {
-    const collectionName = resolveCollectionName(pslModel);
-    const fieldMappings = resolveFieldMappings(pslModel);
+    const collectionName = resolveCollectionName({
+      model: pslModel,
+      sourceFile,
+      sourceId,
+      diagnostics,
+    });
+    const fieldMappings = resolveFieldMappings({
+      model: pslModel,
+      sourceFile,
+      sourceId,
+      diagnostics,
+    });
 
     const fields: Record<string, ContractField> = {};
     const relations: Record<string, ContractReferenceRelation> = {};
@@ -1040,7 +1105,9 @@ export function interpretPslDocumentToMongoContract(
           const localMapped = relation.fields.map((f) => fieldMappings.pslNameToMapped.get(f) ?? f);
 
           const targetModel = allModels.find((m) => m.name === field.typeName);
-          const targetFieldMappings = targetModel ? resolveFieldMappings(targetModel) : undefined;
+          const targetFieldMappings = targetModel
+            ? resolveFieldMappings({ model: targetModel, sourceFile, sourceId, diagnostics })
+            : undefined;
           const targetMapped = relation.references.map(
             (f) => targetFieldMappings?.pslNameToMapped.get(f) ?? f,
           );
@@ -1208,6 +1275,7 @@ export function interpretPslDocumentToMongoContract(
 
   const { discriminatorDeclarations, baseDeclarations } = collectPolymorphismDeclarations(
     allModels,
+    sourceFile,
     sourceId,
     diagnostics,
   );
@@ -1221,6 +1289,7 @@ export function interpretPslDocumentToMongoContract(
     modelNames,
     indexSpans,
     modelIndexesByName,
+    sourceFile,
     sourceId,
   });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -463,7 +463,7 @@ function resolvePolymorphism(input: {
         Object.entries(collections).filter(([key]) => key !== variantCollectionName),
       );
       if (scopedVariantIndexes.length > 0 && baseColl) {
-        const baseIndexes = (baseColl['indexes'] ?? []) as MongoIndex[];
+        const baseIndexes = collectionIndexes(baseColl);
         collections = {
           ...filtered,
           [baseCollection]: {
@@ -475,7 +475,7 @@ function resolvePolymorphism(input: {
         collections = filtered;
       }
     } else if (baseColl) {
-      const existingIndexes = (baseColl['indexes'] ?? []) as MongoIndex[];
+      const existingIndexes = collectionIndexes(baseColl);
       const variantIndexSet = new Set<MongoIndex>(variantOwnIndexes);
       const withoutUnscopedVariants = existingIndexes.filter((idx) => !variantIndexSet.has(idx));
       const mergedIndexes = [...withoutUnscopedVariants];
@@ -506,6 +506,13 @@ function resolvePolymorphism(input: {
   return { models: patched, roots, collections, diagnostics };
 }
 
+function collectionIndexes(collection: Record<string, unknown>): MongoIndex[] {
+  return blindCast<
+    MongoIndex[],
+    'Mongo collection indexes are constructed as MongoIndex arrays by this interpreter'
+  >(collection['indexes'] ?? []);
+}
+
 // Property-order-stable serialization for structural equality of plain
 // JSON-compatible values. Used for comparing MongoIndex shapes in
 // the variant-merge dedup path where a future change to the spread order
@@ -516,7 +523,7 @@ function canonicalJson(value: unknown): string {
     return `[${value.map(canonicalJson).join(',')}]`;
   }
   if (value && typeof value === 'object') {
-    return `{${Object.entries(value as Record<string, unknown>)
+    return `{${Object.entries(value)
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
       .join(',')}}`;
@@ -860,8 +867,7 @@ function collectIndexes(
             return mapped ? `${mapped}.$**` : `${prefix}.$**`;
           })
         : (fieldMappings.pslNameToMapped.get(pf.name) ?? pf.name);
-      const direction: MongoIndexKeyDirection =
-        pf.direction != null ? (pf.direction as MongoIndexKeyDirection) : defaultDirection;
+      const direction: MongoIndexKeyDirection = pf.direction ?? defaultDirection;
       return { field: mappedName, direction };
     });
 
@@ -1264,7 +1270,7 @@ export function interpretPslDocumentToMongoContract(
     modelIndexesByName.set(pslModel.name, modelIndexes);
     const existingColl = collections[collectionName];
     if (existingColl && modelIndexes.length > 0) {
-      const existingIndexes = (existingColl['indexes'] ?? []) as MongoIndex[];
+      const existingIndexes = collectionIndexes(existingColl);
       collections[collectionName] = { indexes: [...existingIndexes, ...modelIndexes] };
     } else if (!existingColl) {
       collections[collectionName] = modelIndexes.length > 0 ? { indexes: modelIndexes } : {};

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -44,7 +44,6 @@ import type {
   NamespaceSymbol,
   PslExtensionBlock,
   PslSpan,
-  ResolvedAttribute,
   SymbolTable,
   TypedFuncCall,
 } from '@internal/psl-parser';
@@ -58,6 +57,7 @@ import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-sch
 import {
   baseModelSpec,
   buildIndexModelSpec,
+  buildTextIndexModelSpec,
   discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
@@ -67,14 +67,7 @@ import {
   mapModelSpec,
   relationFieldSpec,
 } from './mongo-attribute-specs';
-import {
-  getAttribute,
-  getNamedArgument,
-  getPositionalArgument,
-  lowerFirst,
-  type ParsedIndexField,
-  parseIndexFieldList,
-} from './psl-helpers';
+import { getAttribute, lowerFirst, type ParsedIndexField } from './psl-helpers';
 
 /**
  * Encode an authored enum value to its codec-encoded JSON form via the codec resolved by id from the
@@ -532,9 +525,8 @@ function canonicalJson(value: unknown): string {
 }
 
 // The spec's pinned `type` combinators already constrain the value to the exact
-// index-direction alphabet at runtime; map it to the key-direction type,
-// defaulting to ascending (1) when absent. Replaces `parseIndexDirection` for
-// the `@@index`/`@@unique` spec path.
+// index-direction alphabet at runtime; normalize it to the Mongo key-direction
+// type, defaulting to ascending (1) when absent.
 function normalizeIndexType(value: number | string | undefined): MongoIndexKeyDirection {
   switch (value) {
     case -1:
@@ -572,10 +564,10 @@ function normalizeIndexField(element: string | TypedFuncCall): ParsedIndexField 
   return { name: element.fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 };
 }
 
-// Interpreted collation named-args of an `@@index`/`@@unique`. Mirrors
-// `parseCollation`'s semantics from spec values: `undefined` when no collation
-// arg is present, `null` when some are present but `collationLocale` is absent
-// (the semantic "collationLocale is required" rule), otherwise the options.
+// Interpreted collation named-args of an `@@index`/`@@unique`/`@@textIndex`.
+// Semantics from spec values: `undefined` when no collation arg is present,
+// `null` when some are present but `collationLocale` is absent (the semantic
+// "collationLocale is required" rule), otherwise the options.
 interface SpecCollationArgs {
   readonly collationLocale?: string;
   readonly collationStrength?: number;
@@ -617,70 +609,19 @@ function buildCollationFromSpec(args: SpecCollationArgs): CollationOptions | nul
   return collation;
 }
 
-function parseNumericArg(raw: string | undefined): number | undefined {
-  if (!raw) return undefined;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : undefined;
-}
-
-function parseBooleanArg(raw: string | undefined): boolean | undefined {
-  if (raw === 'true') return true;
-  if (raw === 'false') return false;
-  return undefined;
-}
-
-function parseJsonArg(raw: string | undefined): Record<string, unknown> | undefined {
-  if (!raw) return undefined;
-  const stripped = raw.replace(/^["']/, '').replace(/["']$/, '').replace(/\\"/g, '"');
-  try {
-    const parsed = JSON.parse(stripped);
-    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
-    }
-  } catch {
-    // not valid JSON
+// Filter an interpreted `weights` json object down to its numeric entries — the
+// only weight values MongoDB accepts. `Record<string, unknown>` values are
+// narrowed by `typeof`, so no cast is needed. Returns `undefined` only when the
+// arg was absent; a present-but-empty object stays `{}` to match prior behavior.
+function extractWeights(
+  raw: Record<string, unknown> | undefined,
+): Record<string, number> | undefined {
+  if (raw === undefined) return undefined;
+  const weights: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === 'number') weights[key] = value;
   }
-  return undefined;
-}
-
-function parseCollation(attr: ResolvedAttribute): CollationOptions | null | undefined {
-  const locale = stripQuotesHelper(getNamedArgument(attr, 'collationLocale'));
-  if (!locale) {
-    const hasAnyCollationArg =
-      getNamedArgument(attr, 'collationStrength') != null ||
-      getNamedArgument(attr, 'collationCaseLevel') != null ||
-      getNamedArgument(attr, 'collationCaseFirst') != null ||
-      getNamedArgument(attr, 'collationNumericOrdering') != null ||
-      getNamedArgument(attr, 'collationAlternate') != null ||
-      getNamedArgument(attr, 'collationMaxVariable') != null ||
-      getNamedArgument(attr, 'collationBackwards') != null ||
-      getNamedArgument(attr, 'collationNormalization') != null;
-    return hasAnyCollationArg ? null : undefined;
-  }
-
-  const collation: CollationOptions = { locale };
-  const strength = parseNumericArg(getNamedArgument(attr, 'collationStrength'));
-  if (strength != null) collation.strength = strength;
-  const caseLevel = parseBooleanArg(getNamedArgument(attr, 'collationCaseLevel'));
-  if (caseLevel != null) collation.caseLevel = caseLevel;
-  const caseFirst = stripQuotesHelper(getNamedArgument(attr, 'collationCaseFirst'));
-  if (caseFirst != null) collation.caseFirst = caseFirst;
-  const numericOrdering = parseBooleanArg(getNamedArgument(attr, 'collationNumericOrdering'));
-  if (numericOrdering != null) collation.numericOrdering = numericOrdering;
-  const alternate = stripQuotesHelper(getNamedArgument(attr, 'collationAlternate'));
-  if (alternate != null) collation.alternate = alternate;
-  const maxVariable = stripQuotesHelper(getNamedArgument(attr, 'collationMaxVariable'));
-  if (maxVariable != null) collation.maxVariable = maxVariable;
-  const backwards = parseBooleanArg(getNamedArgument(attr, 'collationBackwards'));
-  if (backwards != null) collation.backwards = backwards;
-  const normalization = parseBooleanArg(getNamedArgument(attr, 'collationNormalization'));
-  if (normalization != null) collation.normalization = normalization;
-  return collation;
-}
-
-function stripQuotesHelper(raw: string | undefined): string | undefined {
-  if (!raw) return undefined;
-  return raw.replace(/^["']/, '').replace(/["']$/, '');
+  return weights;
 }
 
 function parseProjectionList(
@@ -747,9 +688,10 @@ function collectIndexes(
     const isTextIndex = attr.name === 'textIndex';
     if (!isIndex && !isUnique && !isTextIndex) continue;
 
-    // @@index/@@unique read arguments through the attribute spec; @@textIndex
-    // stays on the pre-spec parsing path (migrated later). Both produce the same
-    // normalized values the shared index-shape logic below consumes.
+    // @@index/@@unique/@@textIndex all read arguments through their attribute
+    // spec. The two specs infer different named-arg shapes, so each branch
+    // interprets its own spec and fills the shared normalized values the
+    // index-shape logic below consumes.
     let parsedFields: readonly ParsedIndexField[];
     let typeValue: number | string | undefined;
     let sparse: boolean | undefined;
@@ -762,30 +704,32 @@ function collectIndexes(
     let default_language: string | undefined;
     let language_override: string | undefined;
 
+    const node = attributeNodes[attrIndex];
+    if (node === undefined) continue;
+
     if (isTextIndex) {
-      const fieldsArg = getPositionalArgument(attr, 0);
-      if (!fieldsArg) continue;
-      parsedFields = parseIndexFieldList(fieldsArg);
+      const parsed = interpretModelAttribute({
+        node,
+        spec: buildTextIndexModelSpec(specFieldNames),
+        model: pslModel,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed === undefined) continue;
+      parsedFields = parsed.fields.map(normalizeIndexField);
       if (parsedFields.length === 0) continue;
       typeValue = undefined;
       sparse = undefined;
       expireAfterSeconds = undefined;
-      partialFilterExpression = parseJsonArg(getNamedArgument(attr, 'filter'));
-      includeArg = getNamedArgument(attr, 'include');
-      excludeArg = getNamedArgument(attr, 'exclude');
-      collation = parseCollation(attr);
-      const rawWeights = parseJsonArg(getNamedArgument(attr, 'weights'));
-      if (rawWeights) {
-        weights = {};
-        for (const [k, v] of Object.entries(rawWeights)) {
-          if (typeof v === 'number') weights[k] = v;
-        }
-      }
-      default_language = stripQuotesHelper(getNamedArgument(attr, 'language'));
-      language_override = stripQuotesHelper(getNamedArgument(attr, 'languageOverride'));
+      partialFilterExpression = parsed.filter;
+      includeArg = parsed.include;
+      excludeArg = parsed.exclude;
+      collation = buildCollationFromSpec(parsed);
+      weights = extractWeights(parsed.weights);
+      default_language = parsed.language;
+      language_override = parsed.languageOverride;
     } else {
-      const node = attributeNodes[attrIndex];
-      if (node === undefined) continue;
       const parsed = interpretModelAttribute({
         node,
         spec: buildIndexModelSpec(isUnique ? 'unique' : 'index', specFieldNames),

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts
@@ -55,6 +55,8 @@ import { ifDefined } from '@internal/utils/defined';
 import { notOk, ok, type Result } from '@internal/utils/result';
 import { deriveJsonSchema, derivePolymorphicJsonSchema } from './derive-json-schema';
 import {
+  baseModelSpec,
+  discriminatorModelSpec,
   findFieldAttributeNode,
   findModelAttributeNode,
   interpretFieldAttribute,
@@ -69,7 +71,6 @@ import {
   getPositionalArgument,
   lowerFirst,
   parseIndexFieldList,
-  parseQuotedStringLiteral,
 } from './psl-helpers';
 
 /**
@@ -218,54 +219,53 @@ function collectPolymorphismDeclarations(
   const baseDeclarations = new Map<string, BaseDeclaration>();
 
   for (const model of models) {
-    for (const attr of model.attributes) {
-      if (attr.name === 'discriminator') {
-        const fieldName = getPositionalArgument(attr);
-        if (!fieldName) {
-          diagnostics.push({
-            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
-            message: `Model "${model.name}" @@discriminator requires a field name argument`,
-            sourceId,
-            span: attr.span,
-          });
-          continue;
-        }
+    const discNode = findModelAttributeNode(model, 'discriminator');
+    if (discNode) {
+      const parsed = interpretModelAttribute({
+        node: discNode,
+        spec: discriminatorModelSpec,
+        model,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed) {
+        const fieldName = parsed.field;
         const discField = model.fields[fieldName];
+        // Semantic check — stays: the discriminator field must be a String.
         if (discField && discField.typeName !== 'String') {
           diagnostics.push({
             code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
             message: `Discriminator field "${fieldName}" on model "${model.name}" must be of type String, but is "${discField.typeName}"`,
             sourceId,
-            span: attr.span,
+            span: nodePslSpan(discNode.syntax, sourceFile),
           });
-          continue;
+        } else {
+          discriminatorDeclarations.set(model.name, {
+            fieldName,
+            span: nodePslSpan(discNode.syntax, sourceFile),
+          });
         }
-        discriminatorDeclarations.set(model.name, { fieldName, span: attr.span });
       }
-      if (attr.name === 'base') {
-        const baseName = getPositionalArgument(attr, 0);
-        const rawValue = getPositionalArgument(attr, 1);
-        if (!baseName || !rawValue) {
-          diagnostics.push({
-            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
-            message: `Model "${model.name}" @@base requires two arguments: base model name and discriminator value`,
-            sourceId,
-            span: attr.span,
-          });
-          continue;
-        }
-        const value = parseQuotedStringLiteral(rawValue);
-        if (value === undefined) {
-          diagnostics.push({
-            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
-            message: `Model "${model.name}" @@base discriminator value must be a quoted string literal`,
-            sourceId,
-            span: attr.span,
-          });
-          continue;
-        }
+    }
+    const baseNode = findModelAttributeNode(model, 'base');
+    if (baseNode) {
+      const parsed = interpretModelAttribute({
+        node: baseNode,
+        spec: baseModelSpec,
+        model,
+        sourceFile,
+        sourceId,
+        diagnostics,
+      });
+      if (parsed) {
         const collectionName = resolveCollectionName({ model, sourceFile, sourceId, diagnostics });
-        baseDeclarations.set(model.name, { baseName, value, collectionName, span: attr.span });
+        baseDeclarations.set(model.name, {
+          baseName: parsed.base,
+          value: parsed.value,
+          collectionName,
+          span: nodePslSpan(baseNode.syntax, sourceFile),
+        });
       }
     }
   }

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -1,0 +1,125 @@
+import type { ContractSourceDiagnostic } from '@prisma-next/config/config-types';
+import type {
+  AttributeSpec,
+  FieldSymbol,
+  InterpretCtx,
+  ModelSymbol,
+} from '@prisma-next/psl-parser';
+import { fieldAttribute, interpretAttribute, modelAttribute, str } from '@prisma-next/psl-parser';
+import type {
+  FieldAttributeAst,
+  ModelAttributeAst,
+  SourceFile,
+} from '@prisma-next/psl-parser/syntax';
+
+export function findModelAttributeNode(
+  model: ModelSymbol,
+  name: string,
+): ModelAttributeAst | undefined {
+  for (const attribute of model.node.attributes()) {
+    if (attribute.name()?.isSimpleName(name) === true) return attribute;
+  }
+  return undefined;
+}
+
+export function findFieldAttributeNode(
+  field: FieldSymbol,
+  name: string,
+): FieldAttributeAst | undefined {
+  for (const attribute of field.node.attributes()) {
+    if (attribute.name()?.isSimpleName(name) === true) return attribute;
+  }
+  return undefined;
+}
+
+function buildModelInterpretCtx(input: {
+  readonly selfModel: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+}): InterpretCtx {
+  return {
+    level: 'model',
+    sourceId: input.sourceId,
+    sourceFile: input.sourceFile,
+    selfModel: input.selfModel,
+    resolveReferencedModel: () => undefined,
+  };
+}
+
+function buildFieldInterpretCtx(input: {
+  readonly selfModel: ModelSymbol;
+  readonly field: FieldSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly resolveReferencedModel?: (() => ModelSymbol | undefined) | undefined;
+}): InterpretCtx {
+  return {
+    level: 'field',
+    sourceId: input.sourceId,
+    sourceFile: input.sourceFile,
+    selfModel: input.selfModel,
+    resolveReferencedModel: input.resolveReferencedModel ?? (() => undefined),
+    field: input.field,
+  };
+}
+
+// Interpret a model-level attribute node against its spec, draining any parse
+// failures into `diagnostics`. Returns the typed value, or `undefined` on
+// failure so the caller can apply its own default/absence handling.
+export function interpretModelAttribute<Out>(input: {
+  readonly node: ModelAttributeAst;
+  readonly spec: AttributeSpec<Out>;
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): Out | undefined {
+  const result = interpretAttribute(
+    input.node,
+    input.spec,
+    buildModelInterpretCtx({
+      selfModel: input.model,
+      sourceFile: input.sourceFile,
+      sourceId: input.sourceId,
+    }),
+  );
+  if (!result.ok) {
+    for (const failure of result.failure) input.diagnostics.push(failure);
+    return undefined;
+  }
+  return result.value;
+}
+
+// Interpret a field-level attribute node against its spec, draining any parse
+// failures into `diagnostics`. Returns the typed value, or `undefined` on
+// failure so the caller can apply its own default/absence handling.
+export function interpretFieldAttribute<Out>(input: {
+  readonly node: FieldAttributeAst;
+  readonly spec: AttributeSpec<Out>;
+  readonly model: ModelSymbol;
+  readonly field: FieldSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+  readonly resolveReferencedModel?: () => ModelSymbol | undefined;
+}): Out | undefined {
+  const result = interpretAttribute(
+    input.node,
+    input.spec,
+    buildFieldInterpretCtx({
+      selfModel: input.model,
+      field: input.field,
+      sourceFile: input.sourceFile,
+      sourceId: input.sourceId,
+      resolveReferencedModel: input.resolveReferencedModel,
+    }),
+  );
+  if (!result.ok) {
+    for (const failure of result.failure) input.diagnostics.push(failure);
+    return undefined;
+  }
+  return result.value;
+}
+
+export const mapModelSpec = modelAttribute('map', { positional: [{ key: 'name', type: str() }] });
+export const mapFieldSpec = fieldAttribute('map', { positional: [{ key: 'name', type: str() }] });

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -215,3 +215,22 @@ export function buildIndexModelSpec(name: 'index' | 'unique', fieldNames: readon
     },
   });
 }
+
+// Argument spec for model-level `@@textIndex`. Shares the field-list element and
+// collation args with `@@index`/`@@unique`, but its text-search options differ:
+// `weights` (json), `language` (note: `language`, not `default_language`), and
+// `languageOverride`. It does not accept `type`/`sparse`/`expireAfterSeconds`.
+export function buildTextIndexModelSpec(fieldNames: readonly string[]) {
+  return modelAttribute('textIndex', {
+    positional: [{ key: 'fields', type: list(indexFieldElement(fieldNames), { nonEmpty: true }) }],
+    named: {
+      filter: optional(json()),
+      include: optional(str()),
+      exclude: optional(str()),
+      weights: optional(json()),
+      language: optional(str()),
+      languageOverride: optional(str()),
+      ...collationNamedArgs,
+    },
+  });
+}

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -7,6 +7,7 @@ import type {
   ModelSymbol,
 } from '@prisma-next/psl-parser';
 import {
+  entityRef,
   fieldAttribute,
   fieldRef,
   interpretAttribute,
@@ -142,3 +143,13 @@ export const relationFieldSpec = fieldAttribute('relation', {
   },
 });
 export type RelationFieldOutput = InferAttr<typeof relationFieldSpec>;
+
+export const discriminatorModelSpec = modelAttribute('discriminator', {
+  positional: [{ key: 'field', type: fieldRef('self') }],
+});
+export const baseModelSpec = modelAttribute('base', {
+  positional: [
+    { key: 'base', type: entityRef() },
+    { key: 'value', type: str() },
+  ],
+});

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -1,18 +1,28 @@
 import type { ContractSourceDiagnostic } from '@prisma-next/config/config-types';
 import type {
+  ArgType,
   AttributeSpec,
   FieldSymbol,
+  FuncCallSig,
   InferAttr,
   InterpretCtx,
   ModelSymbol,
+  TypedFuncCall,
 } from '@prisma-next/psl-parser';
 import {
+  bool,
   entityRef,
   fieldAttribute,
   fieldRef,
+  funcCall,
+  identifier,
+  int,
   interpretAttribute,
+  json,
   list,
   modelAttribute,
+  num,
+  oneOf,
   optional,
   str,
 } from '@prisma-next/psl-parser';
@@ -153,3 +163,55 @@ export const baseModelSpec = modelAttribute('base', {
     { key: 'value', type: str() },
   ],
 });
+
+const sortSig = {
+  named: { sort: oneOf(identifier('Asc'), identifier('Desc')) },
+} satisfies FuncCallSig;
+
+// One element of an `@@index`/`@@unique` field list, composed per model from its
+// field names (like `buildDefaultSpec`): a bare field reference (`name`), a
+// `wildcard(scope?)` call, or a `field(sort: Asc|Desc)` call. Output is a field
+// name string or a `TypedFuncCall`; the wildcard and bare-field arms are fixed,
+// the sorted arms are one `funcCall(name, sortSig)` per field.
+function indexFieldElement(fieldNames: readonly string[]): ArgType<string | TypedFuncCall> {
+  const arms: readonly [ArgType<string | TypedFuncCall>, ...ArgType<string | TypedFuncCall>[]] = [
+    fieldRef('self'),
+    funcCall('wildcard', { positional: [{ key: 'scope', type: optional(fieldRef('self')) }] }),
+    ...fieldNames.map((name) => funcCall(name, sortSig)),
+  ];
+  return oneOf(...arms);
+}
+
+const collationNamedArgs = {
+  collationLocale: optional(str()),
+  collationStrength: optional(int()),
+  collationCaseLevel: optional(bool()),
+  collationCaseFirst: optional(str()),
+  collationNumericOrdering: optional(bool()),
+  collationAlternate: optional(str()),
+  collationMaxVariable: optional(str()),
+  collationBackwards: optional(bool()),
+  collationNormalization: optional(bool()),
+};
+
+// Argument spec shared by model-level `@@index` and `@@unique` — same argument
+// surface, only the attribute name differs. `fieldNames` seeds the per-field
+// sorted arms of each element.
+export function buildIndexModelSpec(name: 'index' | 'unique', fieldNames: readonly string[]) {
+  return modelAttribute(name, {
+    positional: [{ key: 'fields', type: list(indexFieldElement(fieldNames), { nonEmpty: true }) }],
+    named: {
+      type: optional(
+        oneOf(num(1), num(-1), str('text'), str('2dsphere'), str('2d'), str('hashed')),
+      ),
+      sparse: optional(bool()),
+      expireAfterSeconds: optional(int()),
+      filter: optional(json()),
+      include: optional(str()),
+      exclude: optional(str()),
+      default_language: optional(str()),
+      languageOverride: optional(str()),
+      ...collationNamedArgs,
+    },
+  });
+}

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -2,10 +2,19 @@ import type { ContractSourceDiagnostic } from '@prisma-next/config/config-types'
 import type {
   AttributeSpec,
   FieldSymbol,
+  InferAttr,
   InterpretCtx,
   ModelSymbol,
 } from '@prisma-next/psl-parser';
-import { fieldAttribute, interpretAttribute, modelAttribute, str } from '@prisma-next/psl-parser';
+import {
+  fieldAttribute,
+  fieldRef,
+  interpretAttribute,
+  list,
+  modelAttribute,
+  optional,
+  str,
+} from '@prisma-next/psl-parser';
 import type {
   FieldAttributeAst,
   ModelAttributeAst,
@@ -123,3 +132,13 @@ export function interpretFieldAttribute<Out>(input: {
 
 export const mapModelSpec = modelAttribute('map', { positional: [{ key: 'name', type: str() }] });
 export const mapFieldSpec = fieldAttribute('map', { positional: [{ key: 'name', type: str() }] });
+
+export const relationFieldSpec = fieldAttribute('relation', {
+  positional: [{ key: 'name', type: optional(str()) }],
+  named: {
+    name: optional(str()),
+    fields: optional(list(fieldRef('self'), { nonEmpty: true, unique: true })),
+    references: optional(list(fieldRef('referenced'), { nonEmpty: true, unique: true })),
+  },
+});
+export type RelationFieldOutput = InferAttr<typeof relationFieldSpec>;

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -21,14 +21,13 @@ import {
   json,
   list,
   modelAttribute,
-  nodePslSpan,
   num,
   oneOf,
   optional,
+  record,
   str,
 } from '@internal/psl-parser';
 import type { FieldAttributeAst, ModelAttributeAst, SourceFile } from '@internal/psl-parser/syntax';
-import { notOk, ok } from '@internal/utils/result';
 
 export function findModelAttributeNode(
   model: ModelSymbol,
@@ -166,87 +165,13 @@ const sortSig = {
   named: { sort: oneOf(identifier('Asc'), identifier('Desc')) },
 } satisfies FuncCallSig;
 
-// One element of an `@@index`/`@@unique` field list, composed per model from its
-// field names (like `buildDefaultSpec`): a bare field reference (`name`), a
-// `wildcard(scope?)` call, or a `field(sort: Asc|Desc)` call. Output is a field
-// name string or a `TypedFuncCall`; the wildcard and bare-field arms are fixed,
-// the sorted arms are one `funcCall(name, sortSig)` per field.
 function indexFieldElement(fieldNames: readonly string[]): ArgType<string | TypedFuncCall> {
   const arms: readonly [ArgType<string | TypedFuncCall>, ...ArgType<string | TypedFuncCall>[]] = [
     fieldRef('self'),
-    funcCall('wildcard', { positional: [{ key: 'scope', type: optional(fieldRef('self')) }] }),
+    funcCall('wildcard', { positional: [{ key: 'scope', type: optional(entityRef()) }] }),
     ...fieldNames.map((name) => funcCall(name, sortSig)),
   ];
   return oneOf(...arms);
-}
-
-export type MongoProjectionList = readonly string[];
-
-function projectionList(): ArgType<MongoProjectionList> {
-  const stringLiteral = str();
-  return {
-    kind: 'mongoProjectionList',
-    label: 'Mongo projection list',
-    parse: (arg, ctx) => {
-      const parsed = stringLiteral.parse(arg, ctx);
-      if (!parsed.ok) return parsed;
-
-      const raw = parsed.value.trim();
-      if (!raw.startsWith('[') || !raw.endsWith(']')) {
-        return notOk([
-          {
-            code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-            message: 'Expected a projection list string such as "[field, nested.path]"',
-            sourceId: ctx.sourceId,
-            span: nodePslSpan(arg.syntax, ctx.sourceFile),
-          },
-        ]);
-      }
-
-      const inner = raw.slice(1, -1).trim();
-      if (inner.length === 0) return ok([]);
-      const fields = inner.split(',').map((field) => field.trim());
-      if (fields.some((field) => field.length === 0)) {
-        return notOk([
-          {
-            code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-            message: 'Expected a projection list string without empty fields',
-            sourceId: ctx.sourceId,
-            span: nodePslSpan(arg.syntax, ctx.sourceFile),
-          },
-        ]);
-      }
-      return ok(fields);
-    },
-  };
-}
-
-function textIndexWeights(): ArgType<Record<string, number>> {
-  const jsonObject = json();
-  return {
-    kind: 'mongoTextIndexWeights',
-    label: 'Mongo text index weights',
-    parse: (arg, ctx) => {
-      const parsed = jsonObject.parse(arg, ctx);
-      if (!parsed.ok) return parsed;
-
-      const entries: [string, number][] = [];
-      for (const [field, value] of Object.entries(parsed.value)) {
-        if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 99_999) {
-          return notOk([
-            {
-              code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-              message: `Expected text index weight "${field}" to be an integer from 1 to 99,999`,
-              sourceId: ctx.sourceId,
-              span: nodePslSpan(arg.syntax, ctx.sourceFile),
-            },
-          ]);
-        }
-        entries.push([field, value]);
-      }
-      return ok(Object.fromEntries(entries));
-    },
-  };
 }
 
 const collationNamedArgs = {
@@ -274,8 +199,8 @@ function buildIndexModelSpec(
       sparse: optional(bool()),
       expireAfterSeconds: optional(int()),
       filter: optional(json()),
-      include: optional(projectionList()),
-      exclude: optional(projectionList()),
+      include: optional(list(str())),
+      exclude: optional(list(str())),
       default_language: optional(str()),
       languageOverride: optional(str()),
       ...collationNamedArgs,
@@ -288,9 +213,7 @@ function buildTextIndexModelSpec(fieldElement: ArgType<string | TypedFuncCall>) 
     positional: [{ key: 'fields', type: list(fieldElement, { nonEmpty: true }) }],
     named: {
       filter: optional(json()),
-      include: optional(projectionList()),
-      exclude: optional(projectionList()),
-      weights: optional(textIndexWeights()),
+      weights: optional(record(int({ min: 1, max: 99_999 }))),
       language: optional(str()),
       languageOverride: optional(str()),
       ...collationNamedArgs,

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -1,4 +1,4 @@
-import type { ContractSourceDiagnostic } from '@prisma-next/config/config-types';
+import type { ContractSourceDiagnostic } from '@internal/config/config-types';
 import type {
   ArgType,
   AttributeSpec,
@@ -8,7 +8,7 @@ import type {
   InterpretCtx,
   ModelSymbol,
   TypedFuncCall,
-} from '@prisma-next/psl-parser';
+} from '@internal/psl-parser';
 import {
   bool,
   entityRef,
@@ -25,12 +25,8 @@ import {
   oneOf,
   optional,
   str,
-} from '@prisma-next/psl-parser';
-import type {
-  FieldAttributeAst,
-  ModelAttributeAst,
-  SourceFile,
-} from '@prisma-next/psl-parser/syntax';
+} from '@internal/psl-parser';
+import type { FieldAttributeAst, ModelAttributeAst, SourceFile } from '@internal/psl-parser/syntax';
 
 export function findModelAttributeNode(
   model: ModelSymbol,

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -221,14 +221,42 @@ function projectionList(): ArgType<MongoProjectionList> {
   };
 }
 
+function textIndexWeights(): ArgType<Record<string, number>> {
+  const jsonObject = json();
+  return {
+    kind: 'mongoTextIndexWeights',
+    label: 'Mongo text index weights',
+    parse: (arg, ctx) => {
+      const parsed = jsonObject.parse(arg, ctx);
+      if (!parsed.ok) return parsed;
+
+      const weights: Record<string, number> = {};
+      for (const [field, value] of Object.entries(parsed.value)) {
+        if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 99_999) {
+          return notOk([
+            {
+              code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+              message: `Expected text index weight "${field}" to be an integer from 1 to 99,999`,
+              sourceId: ctx.sourceId,
+              span: nodePslSpan(arg.syntax, ctx.sourceFile),
+            },
+          ]);
+        }
+        weights[field] = value;
+      }
+      return ok(weights);
+    },
+  };
+}
+
 const collationNamedArgs = {
   collationLocale: optional(str()),
-  collationStrength: optional(int()),
+  collationStrength: optional(oneOf(num(1), num(2), num(3), num(4), num(5))),
   collationCaseLevel: optional(bool()),
-  collationCaseFirst: optional(str()),
+  collationCaseFirst: optional(oneOf(str('upper'), str('lower'), str('off'))),
   collationNumericOrdering: optional(bool()),
-  collationAlternate: optional(str()),
-  collationMaxVariable: optional(str()),
+  collationAlternate: optional(oneOf(str('non-ignorable'), str('shifted'))),
+  collationMaxVariable: optional(oneOf(str('punct'), str('space'))),
   collationBackwards: optional(bool()),
   collationNormalization: optional(bool()),
 };
@@ -262,7 +290,7 @@ function buildTextIndexModelSpec(fieldElement: ArgType<string | TypedFuncCall>) 
       filter: optional(json()),
       include: optional(projectionList()),
       exclude: optional(projectionList()),
-      weights: optional(json()),
+      weights: optional(textIndexWeights()),
       language: optional(str()),
       languageOverride: optional(str()),
       ...collationNamedArgs,

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -21,12 +21,14 @@ import {
   json,
   list,
   modelAttribute,
+  nodePslSpan,
   num,
   oneOf,
   optional,
   str,
 } from '@internal/psl-parser';
 import type { FieldAttributeAst, ModelAttributeAst, SourceFile } from '@internal/psl-parser/syntax';
+import { notOk, ok } from '@internal/utils/result';
 
 export function findModelAttributeNode(
   model: ModelSymbol,
@@ -178,6 +180,47 @@ function indexFieldElement(fieldNames: readonly string[]): ArgType<string | Type
   return oneOf(...arms);
 }
 
+export type MongoProjectionList = readonly string[];
+
+function projectionList(): ArgType<MongoProjectionList> {
+  const stringLiteral = str();
+  return {
+    kind: 'mongoProjectionList',
+    label: 'Mongo projection list',
+    parse: (arg, ctx) => {
+      const parsed = stringLiteral.parse(arg, ctx);
+      if (!parsed.ok) return parsed;
+
+      const raw = parsed.value.trim();
+      if (!raw.startsWith('[') || !raw.endsWith(']')) {
+        return notOk([
+          {
+            code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+            message: 'Expected a projection list string such as "[field, nested.path]"',
+            sourceId: ctx.sourceId,
+            span: nodePslSpan(arg.syntax, ctx.sourceFile),
+          },
+        ]);
+      }
+
+      const inner = raw.slice(1, -1).trim();
+      if (inner.length === 0) return ok([]);
+      const fields = inner.split(',').map((field) => field.trim());
+      if (fields.some((field) => field.length === 0)) {
+        return notOk([
+          {
+            code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+            message: 'Expected a projection list string without empty fields',
+            sourceId: ctx.sourceId,
+            span: nodePslSpan(arg.syntax, ctx.sourceFile),
+          },
+        ]);
+      }
+      return ok(fields);
+    },
+  };
+}
+
 const collationNamedArgs = {
   collationLocale: optional(str()),
   collationStrength: optional(int()),
@@ -190,12 +233,12 @@ const collationNamedArgs = {
   collationNormalization: optional(bool()),
 };
 
-// Argument spec shared by model-level `@@index` and `@@unique` — same argument
-// surface, only the attribute name differs. `fieldNames` seeds the per-field
-// sorted arms of each element.
-export function buildIndexModelSpec(name: 'index' | 'unique', fieldNames: readonly string[]) {
+function buildIndexModelSpec(
+  name: 'index' | 'unique',
+  fieldElement: ArgType<string | TypedFuncCall>,
+) {
   return modelAttribute(name, {
-    positional: [{ key: 'fields', type: list(indexFieldElement(fieldNames), { nonEmpty: true }) }],
+    positional: [{ key: 'fields', type: list(fieldElement, { nonEmpty: true }) }],
     named: {
       type: optional(
         oneOf(num(1), num(-1), str('text'), str('2dsphere'), str('2d'), str('hashed')),
@@ -203,8 +246,8 @@ export function buildIndexModelSpec(name: 'index' | 'unique', fieldNames: readon
       sparse: optional(bool()),
       expireAfterSeconds: optional(int()),
       filter: optional(json()),
-      include: optional(str()),
-      exclude: optional(str()),
+      include: optional(projectionList()),
+      exclude: optional(projectionList()),
       default_language: optional(str()),
       languageOverride: optional(str()),
       ...collationNamedArgs,
@@ -212,21 +255,26 @@ export function buildIndexModelSpec(name: 'index' | 'unique', fieldNames: readon
   });
 }
 
-// Argument spec for model-level `@@textIndex`. Shares the field-list element and
-// collation args with `@@index`/`@@unique`, but its text-search options differ:
-// `weights` (json), `language` (note: `language`, not `default_language`), and
-// `languageOverride`. It does not accept `type`/`sparse`/`expireAfterSeconds`.
-export function buildTextIndexModelSpec(fieldNames: readonly string[]) {
+function buildTextIndexModelSpec(fieldElement: ArgType<string | TypedFuncCall>) {
   return modelAttribute('textIndex', {
-    positional: [{ key: 'fields', type: list(indexFieldElement(fieldNames), { nonEmpty: true }) }],
+    positional: [{ key: 'fields', type: list(fieldElement, { nonEmpty: true }) }],
     named: {
       filter: optional(json()),
-      include: optional(str()),
-      exclude: optional(str()),
+      include: optional(projectionList()),
+      exclude: optional(projectionList()),
       weights: optional(json()),
       language: optional(str()),
       languageOverride: optional(str()),
       ...collationNamedArgs,
     },
   });
+}
+
+export function buildIndexModelSpecs(fieldNames: readonly string[]) {
+  const fieldElement = indexFieldElement(fieldNames);
+  return {
+    index: buildIndexModelSpec('index', fieldElement),
+    unique: buildIndexModelSpec('unique', fieldElement),
+    textIndex: buildTextIndexModelSpec(fieldElement),
+  };
 }

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts
@@ -230,7 +230,7 @@ function textIndexWeights(): ArgType<Record<string, number>> {
       const parsed = jsonObject.parse(arg, ctx);
       if (!parsed.ok) return parsed;
 
-      const weights: Record<string, number> = {};
+      const entries: [string, number][] = [];
       for (const [field, value] of Object.entries(parsed.value)) {
         if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 99_999) {
           return notOk([
@@ -242,9 +242,9 @@ function textIndexWeights(): ArgType<Record<string, number>> {
             },
           ]);
         }
-        weights[field] = value;
+        entries.push([field, value]);
       }
-      return ok(weights);
+      return ok(Object.fromEntries(entries));
     },
   };
 }

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -1,6 +1,5 @@
-import type { ResolvedAttribute, ResolvedAttributeArg } from '@prisma-next/psl-parser';
+import type { ResolvedAttribute } from '@prisma-next/psl-parser';
 import { parseQuotedStringLiteral } from '@prisma-next/psl-parser';
-import { ifDefined } from '@prisma-next/utils/defined';
 
 export { parseQuotedStringLiteral };
 
@@ -81,49 +80,4 @@ export function getAttribute(
   name: string,
 ): ResolvedAttribute | undefined {
   return attributes.find((attr) => attr.name === name);
-}
-
-export interface ParsedRelationAttribute {
-  readonly relationName?: string;
-  readonly fields?: readonly string[];
-  readonly references?: readonly string[];
-}
-
-export function parseRelationAttribute(
-  attributes: readonly ResolvedAttribute[],
-): ParsedRelationAttribute | undefined {
-  const relationAttr = getAttribute(attributes, 'relation');
-  if (!relationAttr) return undefined;
-
-  let relationName: string | undefined;
-  let fieldsArg: ResolvedAttributeArg | undefined;
-  let referencesArg: ResolvedAttributeArg | undefined;
-
-  for (const arg of relationAttr.args) {
-    if (arg.kind === 'positional') {
-      relationName = stripQuotes(arg.value);
-    } else if (arg.name === 'name') {
-      relationName = stripQuotes(arg.value);
-    } else if (arg.name === 'fields') {
-      fieldsArg = arg;
-    } else if (arg.name === 'references') {
-      referencesArg = arg;
-    }
-  }
-
-  const fields = fieldsArg ? parseFieldList(fieldsArg.value) : undefined;
-  const references = referencesArg ? parseFieldList(referencesArg.value) : undefined;
-
-  return {
-    ...ifDefined('relationName', relationName),
-    ...ifDefined('fields', fields),
-    ...ifDefined('references', references),
-  };
-}
-
-function stripQuotes(value: string): string {
-  if (value.startsWith('"') && value.endsWith('"')) {
-    return value.slice(1, -1);
-  }
-  return value;
 }

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -83,14 +83,6 @@ export function getAttribute(
   return attributes.find((attr) => attr.name === name);
 }
 
-export function getMapName(attributes: readonly ResolvedAttribute[]): string | undefined {
-  const mapAttr = getAttribute(attributes, 'map');
-  if (!mapAttr) return undefined;
-  const arg = mapAttr.args[0];
-  if (!arg) return undefined;
-  return stripQuotes(arg.value);
-}
-
 export interface ParsedRelationAttribute {
   readonly relationName?: string;
   readonly fields?: readonly string[];

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -3,71 +3,10 @@ import { parseQuotedStringLiteral } from '@prisma-next/psl-parser';
 
 export { parseQuotedStringLiteral };
 
-export function getPositionalArgument(attr: ResolvedAttribute, index = 0): string | undefined {
-  return attr.args.filter((arg) => arg.kind === 'positional')[index]?.value;
-}
-
-export function getNamedArgument(attr: ResolvedAttribute, name: string): string | undefined {
-  const arg = attr.args.find((a) => a.kind === 'named' && a.name === name);
-  return arg?.value;
-}
-
-export function parseFieldList(value: string): readonly string[] {
-  const inner = value.replace(/^\[/, '').replace(/\]$/, '').trim();
-  if (inner.length === 0) return [];
-  return splitTopLevel(inner).map((s) => s.trim());
-}
-
 export interface ParsedIndexField {
   readonly name: string;
   readonly isWildcard: boolean;
   readonly direction?: number;
-}
-
-export function parseIndexFieldList(value: string): readonly ParsedIndexField[] {
-  const segments = parseFieldList(value);
-  return segments.map(parseIndexFieldSegment);
-}
-
-function parseIndexFieldSegment(segment: string): ParsedIndexField {
-  const wildcardMatch = segment.match(/^wildcard\(\s*(.*?)\s*\)$/);
-  if (wildcardMatch) {
-    const scope = wildcardMatch[1] ?? '';
-    return {
-      name: scope.length > 0 ? `${scope}.$**` : '$**',
-      isWildcard: true,
-    };
-  }
-
-  const modifierMatch = segment.match(/^(\w+)\(\s*sort:\s*(\w+)\s*\)$/);
-  if (modifierMatch) {
-    const fieldName = modifierMatch[1] ?? segment;
-    const sortValue = modifierMatch[2];
-    return {
-      name: fieldName,
-      isWildcard: false,
-      direction: sortValue === 'Desc' ? -1 : 1,
-    };
-  }
-
-  return { name: segment, isWildcard: false };
-}
-
-function splitTopLevel(input: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let start = 0;
-  for (let i = 0; i < input.length; i++) {
-    const ch = input[i];
-    if (ch === '(' || ch === '[' || ch === '{') depth++;
-    else if (ch === ')' || ch === ']' || ch === '}') depth = Math.max(0, depth - 1);
-    else if (ch === ',' && depth === 0) {
-      parts.push(input.slice(start, i));
-      start = i + 1;
-    }
-  }
-  parts.push(input.slice(start));
-  return parts;
 }
 
 export function lowerFirst(value: string): string {

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -3,71 +3,10 @@ import { parseQuotedStringLiteral } from '@internal/psl-parser';
 
 export { parseQuotedStringLiteral };
 
-export function getPositionalArgument(attr: ResolvedAttribute, index = 0): string | undefined {
-  return attr.args.filter((arg) => arg.kind === 'positional')[index]?.value;
-}
-
-export function getNamedArgument(attr: ResolvedAttribute, name: string): string | undefined {
-  const arg = attr.args.find((a) => a.kind === 'named' && a.name === name);
-  return arg?.value;
-}
-
-export function parseFieldList(value: string): readonly string[] {
-  const inner = value.replace(/^\[/, '').replace(/\]$/, '').trim();
-  if (inner.length === 0) return [];
-  return splitTopLevel(inner).map((s) => s.trim());
-}
-
 export interface ParsedIndexField {
   readonly name: string;
   readonly isWildcard: boolean;
   readonly direction?: number;
-}
-
-export function parseIndexFieldList(value: string): readonly ParsedIndexField[] {
-  const segments = parseFieldList(value);
-  return segments.map(parseIndexFieldSegment);
-}
-
-function parseIndexFieldSegment(segment: string): ParsedIndexField {
-  const wildcardMatch = segment.match(/^wildcard\(\s*(.*?)\s*\)$/);
-  if (wildcardMatch) {
-    const scope = wildcardMatch[1] ?? '';
-    return {
-      name: scope.length > 0 ? `${scope}.$**` : '$**',
-      isWildcard: true,
-    };
-  }
-
-  const modifierMatch = segment.match(/^(\w+)\(\s*sort:\s*(\w+)\s*\)$/);
-  if (modifierMatch) {
-    const fieldName = modifierMatch[1] ?? segment;
-    const sortValue = modifierMatch[2];
-    return {
-      name: fieldName,
-      isWildcard: false,
-      direction: sortValue === 'Desc' ? -1 : 1,
-    };
-  }
-
-  return { name: segment, isWildcard: false };
-}
-
-function splitTopLevel(input: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let start = 0;
-  for (let i = 0; i < input.length; i++) {
-    const ch = input[i];
-    if (ch === '(' || ch === '[' || ch === '{') depth++;
-    else if (ch === ')' || ch === ']' || ch === '}') depth = Math.max(0, depth - 1);
-    else if (ch === ',' && depth === 0) {
-      parts.push(input.slice(start, i));
-      start = i + 1;
-    }
-  }
-  parts.push(input.slice(start));
-  return parts;
 }
 
 export function lowerFirst(value: string): string {

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -1,6 +1,5 @@
-import type { ResolvedAttribute, ResolvedAttributeArg } from '@internal/psl-parser';
+import type { ResolvedAttribute } from '@internal/psl-parser';
 import { parseQuotedStringLiteral } from '@internal/psl-parser';
-import { ifDefined } from '@internal/utils/defined';
 
 export { parseQuotedStringLiteral };
 
@@ -81,49 +80,4 @@ export function getAttribute(
   name: string,
 ): ResolvedAttribute | undefined {
   return attributes.find((attr) => attr.name === name);
-}
-
-export interface ParsedRelationAttribute {
-  readonly relationName?: string;
-  readonly fields?: readonly string[];
-  readonly references?: readonly string[];
-}
-
-export function parseRelationAttribute(
-  attributes: readonly ResolvedAttribute[],
-): ParsedRelationAttribute | undefined {
-  const relationAttr = getAttribute(attributes, 'relation');
-  if (!relationAttr) return undefined;
-
-  let relationName: string | undefined;
-  let fieldsArg: ResolvedAttributeArg | undefined;
-  let referencesArg: ResolvedAttributeArg | undefined;
-
-  for (const arg of relationAttr.args) {
-    if (arg.kind === 'positional') {
-      relationName = stripQuotes(arg.value);
-    } else if (arg.name === 'name') {
-      relationName = stripQuotes(arg.value);
-    } else if (arg.name === 'fields') {
-      fieldsArg = arg;
-    } else if (arg.name === 'references') {
-      referencesArg = arg;
-    }
-  }
-
-  const fields = fieldsArg ? parseFieldList(fieldsArg.value) : undefined;
-  const references = referencesArg ? parseFieldList(referencesArg.value) : undefined;
-
-  return {
-    ...ifDefined('relationName', relationName),
-    ...ifDefined('fields', fields),
-    ...ifDefined('references', references),
-  };
-}
-
-function stripQuotes(value: string): string {
-  if (value.startsWith('"') && value.endsWith('"')) {
-    return value.slice(1, -1);
-  }
-  return value;
 }

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -6,7 +6,7 @@ export { parseQuotedStringLiteral };
 export interface ParsedIndexField {
   readonly name: string;
   readonly isWildcard: boolean;
-  readonly direction?: number;
+  readonly direction?: 1 | -1;
 }
 
 export function lowerFirst(value: string): string {

--- a/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts
@@ -3,12 +3,6 @@ import { parseQuotedStringLiteral } from '@internal/psl-parser';
 
 export { parseQuotedStringLiteral };
 
-export interface ParsedIndexField {
-  readonly name: string;
-  readonly isWildcard: boolean;
-  readonly direction?: 1 | -1;
-}
-
 export function lowerFirst(value: string): string {
   if (value.length === 0) return value;
   return value[0]?.toLowerCase() + value.slice(1);

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter-test-helpers.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter-test-helpers.ts
@@ -1,0 +1,22 @@
+import type {
+  ContractSourceDiagnostic,
+  ContractSourceDiagnostics,
+} from '@internal/config/config-types';
+import type { Result } from '@internal/utils/result';
+import { expect } from 'vitest';
+
+export function expectInvalidAttributeSyntax<Success>(
+  result: Result<Success, ContractSourceDiagnostics>,
+  message: RegExp,
+): ContractSourceDiagnostic {
+  expect(result.ok).toBe(false);
+  if (result.ok) throw new Error('Expected interpretation to fail');
+  const diagnostics = result.failure.diagnostics.filter(
+    (diagnostic) => diagnostic.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+  );
+  expect(diagnostics).toHaveLength(1);
+  const diagnostic = diagnostics[0];
+  if (!diagnostic) throw new Error('Expected PSL_INVALID_ATTRIBUTE_SYNTAX diagnostic');
+  expect(diagnostic.message).toMatch(message);
+  return diagnostic;
+}

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -301,7 +301,40 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
       if (result.ok) return;
       expect(result.failure.diagnostics).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ code: 'PSL_DISCRIMINATOR_FIELD_NOT_FOUND' }),
+          expect.objectContaining({
+            code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+            message: expect.stringContaining('does not exist'),
+          }),
+        ]),
+      );
+    });
+
+    it('diagnoses non-String discriminator field', () => {
+      const result = interpret(`
+        model Task {
+          id    ObjectId @id @map("_id")
+          title String
+          type  Int
+
+          @@discriminator(type)
+        }
+
+        model Bug {
+          id       ObjectId @id @map("_id")
+          severity String
+
+          @@base(Task, "bug")
+        }
+      `);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
+            message: expect.stringContaining('must be of type String'),
+          }),
         ]),
       );
     });

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -633,7 +633,7 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
       expect(conflict?.span?.end.offset).toBeGreaterThan(conflict?.span?.start.offset ?? 0);
     });
 
-    it('emits PSL_INDEX_FIELD_NOT_FOUND when a variant indexes a base-inherited field', () => {
+    it('rejects a variant indexing a base-inherited field', () => {
       const result = interpret(`
         model Task {
           id    ObjectId @id @map("_id")
@@ -655,10 +655,15 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      // `title` is inherited from the base, not declared on Bug, so it is absent
+      // from Bug's own field set; `fieldRef('self')` rejects it at the grammar
+      // layer (Option A) as PSL_INVALID_ATTRIBUTE_SYNTAX rather than the
+      // downstream PSL_INDEX_FIELD_NOT_FOUND.
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/title/);
-      expect(diag?.message).toMatch(/Bug/);
+      expect(diag?.message).toMatch(/Expected one of/);
       expect(diag?.span?.start.offset).toBeGreaterThan(0);
     });
   });

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -299,7 +299,40 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
       if (result.ok) return;
       expect(result.failure.diagnostics).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ code: 'PSL_DISCRIMINATOR_FIELD_NOT_FOUND' }),
+          expect.objectContaining({
+            code: 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+            message: expect.stringContaining('does not exist'),
+          }),
+        ]),
+      );
+    });
+
+    it('diagnoses non-String discriminator field', () => {
+      const result = interpret(`
+        model Task {
+          id    ObjectId @id @map("_id")
+          title String
+          type  Int
+
+          @@discriminator(type)
+        }
+
+        model Bug {
+          id       ObjectId @id @map("_id")
+          severity String
+
+          @@base(Task, "bug")
+        }
+      `);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
+            message: expect.stringContaining('must be of type String'),
+          }),
         ]),
       );
     });

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -1,3 +1,4 @@
+import type { ContractSourceDiagnostic } from '@internal/config/config-types';
 import type { Contract } from '@internal/contract/types';
 import { crossRef } from '@internal/contract/types';
 import type { CodecLookup } from '@internal/framework-components/codec';
@@ -81,6 +82,22 @@ function interpretOk(schema: string) {
   expect(result.ok).toBe(true);
   if (!result.ok) throw new Error('Expected ok result');
   return result.value;
+}
+
+function expectInvalidAttributeSyntax(
+  result: ReturnType<typeof interpret>,
+  message: RegExp,
+): ContractSourceDiagnostic {
+  expect(result.ok).toBe(false);
+  if (result.ok) throw new Error('Expected interpretation to fail');
+  const diagnostics = result.failure.diagnostics.filter(
+    (diagnostic) => diagnostic.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+  );
+  expect(diagnostics).toHaveLength(1);
+  const diagnostic = diagnostics[0];
+  if (!diagnostic) throw new Error('Expected PSL_INVALID_ATTRIBUTE_SYNTAX diagnostic');
+  expect(diagnostic.message).toMatch(message);
+  return diagnostic;
 }
 
 describe('interpretPslDocumentToMongoContract — polymorphism', () => {
@@ -381,6 +398,27 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
       );
     });
 
+    it('emits one syntax diagnostic for a malformed variant @@map', () => {
+      const result = interpret(`
+        model Task {
+          id   ObjectId @id @map("_id")
+          type String
+
+          @@discriminator(type)
+          @@map("tasks")
+        }
+
+        model Bug {
+          severity String
+
+          @@base(Task, "bug")
+          @@map(42)
+        }
+      `);
+
+      expectInvalidAttributeSyntax(result, /Expected a string literal/);
+    });
+
     it('diagnoses variant with @@map to different collection', () => {
       const result = interpret(`
         model Task {
@@ -651,18 +689,12 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
         }
       `);
 
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
       // `title` is inherited from the base, not declared on Bug, so it is absent
       // from Bug's own field set; `fieldRef('self')` rejects it at the grammar
       // layer (Option A) as PSL_INVALID_ATTRIBUTE_SYNTAX rather than the
       // downstream PSL_INDEX_FIELD_NOT_FOUND.
-      const diag = result.failure.diagnostics.find(
-        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-      );
-      expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/Expected one of/);
-      expect(diag?.span?.start.offset).toBeGreaterThan(0);
+      const diag = expectInvalidAttributeSyntax(result, /Expected one of/);
+      expect(diag.span?.start.offset).toBeGreaterThan(0);
     });
   });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -1,4 +1,3 @@
-import type { ContractSourceDiagnostic } from '@internal/config/config-types';
 import type { Contract } from '@internal/contract/types';
 import { crossRef } from '@internal/contract/types';
 import type { CodecLookup } from '@internal/framework-components/codec';
@@ -13,6 +12,7 @@ import type { SourceFile } from '@internal/psl-parser/syntax';
 import { parse } from '@internal/psl-parser/syntax';
 import { describe, expect, it } from 'vitest';
 import { interpretPslDocumentToMongoContract } from '../src/interpreter';
+import { expectInvalidAttributeSyntax } from './interpreter-test-helpers';
 
 const mongoScalarTypeDescriptors: ReadonlyMap<string, string> = new Map([
   ['String', 'mongo/string@1'],
@@ -82,22 +82,6 @@ function interpretOk(schema: string) {
   expect(result.ok).toBe(true);
   if (!result.ok) throw new Error('Expected ok result');
   return result.value;
-}
-
-function expectInvalidAttributeSyntax(
-  result: ReturnType<typeof interpret>,
-  message: RegExp,
-): ContractSourceDiagnostic {
-  expect(result.ok).toBe(false);
-  if (result.ok) throw new Error('Expected interpretation to fail');
-  const diagnostics = result.failure.diagnostics.filter(
-    (diagnostic) => diagnostic.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-  );
-  expect(diagnostics).toHaveLength(1);
-  const diagnostic = diagnostics[0];
-  if (!diagnostic) throw new Error('Expected PSL_INVALID_ATTRIBUTE_SYNTAX diagnostic');
-  expect(diagnostic.message).toMatch(message);
-  return diagnostic;
 }
 
 describe('interpretPslDocumentToMongoContract — polymorphism', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -689,10 +689,6 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
         }
       `);
 
-      // `title` is inherited from the base, not declared on Bug, so it is absent
-      // from Bug's own field set; `fieldRef('self')` rejects it at the grammar
-      // layer (Option A) as PSL_INVALID_ATTRIBUTE_SYNTAX rather than the
-      // downstream PSL_INDEX_FIELD_NOT_FOUND.
       const diag = expectInvalidAttributeSyntax(result, /Expected one of/);
       expect(diag.span?.start.offset).toBeGreaterThan(0);
     });

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -631,7 +631,7 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
       expect(conflict?.span?.end.offset).toBeGreaterThan(conflict?.span?.start.offset ?? 0);
     });
 
-    it('emits PSL_INDEX_FIELD_NOT_FOUND when a variant indexes a base-inherited field', () => {
+    it('rejects a variant indexing a base-inherited field', () => {
       const result = interpret(`
         model Task {
           id    ObjectId @id @map("_id")
@@ -653,10 +653,15 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      // `title` is inherited from the base, not declared on Bug, so it is absent
+      // from Bug's own field set; `fieldRef('self')` rejects it at the grammar
+      // layer (Option A) as PSL_INVALID_ATTRIBUTE_SYNTAX rather than the
+      // downstream PSL_INDEX_FIELD_NOT_FOUND.
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/title/);
-      expect(diag?.message).toMatch(/Bug/);
+      expect(diag?.message).toMatch(/Expected one of/);
       expect(diag?.span?.start.offset).toBeGreaterThan(0);
     });
   });

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -552,6 +552,27 @@ describe('interpretPslDocumentToMongoContract', () => {
         ]),
       );
     });
+
+    it('rejects @relation naming a field that does not exist on the model', () => {
+      const result = interpret(`
+        model User {
+          id ObjectId @id @map("_id")
+        }
+
+        model Post {
+          id       ObjectId @id @map("_id")
+          authorId ObjectId
+          author   User @relation(fields: [missing], references: [id])
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
+      expect(diag).toBeDefined();
+      expect(diag?.message).toMatch(/missing/);
+    });
   });
 
   describe('@id validation', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1382,6 +1382,22 @@ describe('interpretPslDocumentToMongoContract', () => {
       expect(indexes![0]!['unique']).toBe(true);
       expect(indexes![0]!['partialFilterExpression']).toEqual({ active: true });
     });
+
+    it('creates a distinct index per @@index on the same model', () => {
+      const ir = interpretOk(`
+        model User {
+          id    ObjectId @id @map("_id")
+          email String
+          name  String
+          @@index([email])
+          @@index([name])
+        }
+      `);
+      const indexes = getIndexes(ir, 'user');
+      expect(indexes).toHaveLength(2);
+      expect(indexes![0]!['keys']).toEqual([{ field: 'email', direction: 1 }]);
+      expect(indexes![1]!['keys']).toEqual([{ field: 'name', direction: 1 }]);
+    });
   });
 
   describe('index validation', () => {
@@ -1547,6 +1563,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       }
     });
 
+    // With the spec migration, a field absent from the model is rejected at the
+    // grammar layer by `fieldRef('self')` (operator Option A): no field-element
+    // arm matches, so the element surfaces PSL_INVALID_ATTRIBUTE_SYNTAX with the
+    // `oneOf` "Expected one of" message. The downstream PSL_INDEX_FIELD_NOT_FOUND
+    // now guards only present-but-not-indexable fields (e.g. relation fields).
     it('rejects @@index that references an undeclared field', () => {
       const result = interpret(`
         model User {
@@ -1557,10 +1578,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
-      expect(diag?.message).toMatch(/User/);
+      expect(diag?.message).toMatch(/Expected one of/);
       expect(diag?.span?.start.offset).toBeGreaterThan(0);
       expect(diag?.span?.end.offset).toBeGreaterThan(diag?.span?.start.offset ?? 0);
     });
@@ -1575,9 +1597,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
+      expect(diag?.message).toMatch(/Expected one of/);
     });
 
     it('rejects @@textIndex that references an undeclared field', () => {
@@ -1605,12 +1629,14 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
+      expect(diag?.message).toMatch(/Expected one of/);
     });
 
-    it('emits one diagnostic naming the missing field when one of multiple keys is undeclared', () => {
+    it('emits one diagnostic when one of multiple keys is undeclared', () => {
       const result = interpret(`
         model User {
           id    ObjectId @id @map("_id")
@@ -1621,10 +1647,9 @@ describe('interpretPslDocumentToMongoContract', () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       const diags = result.failure.diagnostics.filter(
-        (d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND',
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
       );
       expect(diags).toHaveLength(1);
-      expect(diags[0]?.message).toMatch(/nonexistent/);
       expect(diags[0]?.message).not.toMatch(/email/);
     });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1614,9 +1614,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
+      expect(diag?.message).toMatch(/Expected one of/);
     });
 
     it('rejects @@index wildcard scope referencing an undeclared field', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1631,11 +1631,6 @@ describe('interpretPslDocumentToMongoContract', () => {
       }
     });
 
-    // With the spec migration, a field absent from the model is rejected at the
-    // grammar layer by `fieldRef('self')` (operator Option A): no field-element
-    // arm matches, so the element surfaces PSL_INVALID_ATTRIBUTE_SYNTAX with the
-    // `oneOf` "Expected one of" message. The downstream PSL_INDEX_FIELD_NOT_FOUND
-    // now guards only present-but-not-indexable fields (e.g. relation fields).
     it('rejects @@index that references an undeclared field', () => {
       const result = interpret(`
         model User {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1,4 +1,3 @@
-import type { ContractSourceDiagnostic } from '@internal/config/config-types';
 import { canonicalizeContractToObject } from '@internal/contract/hashing';
 import {
   type Contract,
@@ -24,6 +23,7 @@ import {
   type InterpretPslDocumentToMongoContractInput,
   interpretPslDocumentToMongoContract,
 } from '../src/interpreter';
+import { expectInvalidAttributeSyntax } from './interpreter-test-helpers';
 
 function buildSymbolTableInput(
   schema: string,
@@ -126,22 +126,6 @@ function interpretOk(
   expect(result.ok).toBe(true);
   if (!result.ok) throw new Error('Expected ok result');
   return result.value;
-}
-
-function expectInvalidAttributeSyntax(
-  result: ReturnType<typeof interpret>,
-  message: RegExp,
-): ContractSourceDiagnostic {
-  expect(result.ok).toBe(false);
-  if (result.ok) throw new Error('Expected interpretation to fail');
-  const diagnostics = result.failure.diagnostics.filter(
-    (diagnostic) => diagnostic.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-  );
-  expect(diagnostics).toHaveLength(1);
-  const diagnostic = diagnostics[0];
-  if (!diagnostic) throw new Error('Expected PSL_INVALID_ATTRIBUTE_SYNTAX diagnostic');
-  expect(diagnostic.message).toMatch(message);
-  return diagnostic;
 }
 
 function getIndexes(
@@ -597,13 +581,7 @@ describe('interpretPslDocumentToMongoContract', () => {
           author   User @relation(fields: [missing], references: [id])
         }
       `);
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      const diag = result.failure.diagnostics.find(
-        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-      );
-      expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/missing/);
+      expectInvalidAttributeSyntax(result, /missing.*does not exist/i);
     });
   });
 
@@ -1075,7 +1053,7 @@ describe('interpretPslDocumentToMongoContract', () => {
   });
 
   describe('index authoring', () => {
-    it('creates ascending index from @@index', () => {
+    it('defaults index direction to the ascending literal', () => {
       const ir = interpretOk(`
         model User {
           id    ObjectId @id @map("_id")
@@ -1088,6 +1066,17 @@ describe('interpretPslDocumentToMongoContract', () => {
         | undefined;
       expect(indexes).toHaveLength(1);
       expect(indexes![0]!['keys']).toEqual([{ field: 'email', direction: 1 }]);
+    });
+
+    it('uses the exact descending index type literal', () => {
+      const ir = interpretOk(`
+        model User {
+          id    ObjectId @id @map("_id")
+          email String
+          @@index([email], type: -1)
+        }
+      `);
+      expect(getIndexes(ir, 'user')?.[0]?.['keys']).toEqual([{ field: 'email', direction: -1 }]);
     });
 
     it('creates unique index from @@unique', () => {
@@ -1393,20 +1382,19 @@ describe('interpretPslDocumentToMongoContract', () => {
       }
     });
 
-    it('parses include as wildcardProjection with 1 values', () => {
+    it('parses native include paths as wildcardProjection with 1 values', () => {
       const ir = interpretOk(`
         model Events {
           id       ObjectId @id @map("_id")
           metadata String
-          tags     String
-          @@index([wildcard()], include: "[metadata, tags]")
+          @@index([wildcard()], include: ["metadata", "nested.path"])
         }
       `);
       const indexes = getIndexes(ir, 'events');
-      expect(indexes![0]!['wildcardProjection']).toEqual({ metadata: 1, tags: 1 });
+      expect(indexes![0]!['wildcardProjection']).toEqual({ metadata: 1, 'nested.path': 1 });
     });
 
-    it('rejects a malformed projection list at the attribute boundary', () => {
+    it('rejects a non-list projection at the attribute boundary', () => {
       const result = interpret(`
         model Events {
           id       ObjectId @id @map("_id")
@@ -1415,27 +1403,30 @@ describe('interpretPslDocumentToMongoContract', () => {
         }
       `);
 
-      expectInvalidAttributeSyntax(result, /projection list/);
+      expectInvalidAttributeSyntax(result, /Expected a list/);
     });
 
-    it('rejects a malformed text-index projection list at the attribute boundary', () => {
-      const result = interpret(`
-        model Article {
-          id    ObjectId @id @map("_id")
-          title String
-          @@textIndex([title], exclude: "title")
-        }
-      `);
+    it.each(['include', 'exclude'])(
+      'rejects @@textIndex %s at the attribute boundary',
+      (option) => {
+        const result = interpret(`
+          model Article {
+            id    ObjectId @id @map("_id")
+            title String
+            @@textIndex([title], ${option}: ["title"])
+          }
+        `);
 
-      expectInvalidAttributeSyntax(result, /projection list/);
-    });
+        expectInvalidAttributeSyntax(result, /received unknown argument/i);
+      },
+    );
 
-    it('parses exclude as wildcardProjection with 0 values', () => {
+    it('parses native exclude paths as wildcardProjection with 0 values', () => {
       const ir = interpretOk(`
         model Events {
           id       ObjectId @id @map("_id")
           internal String
-          @@index([wildcard()], exclude: "[internal, _class]")
+          @@index([wildcard()], exclude: ["internal", "_class"])
         }
       `);
       const indexes = getIndexes(ir, 'events');
@@ -1465,7 +1456,7 @@ describe('interpretPslDocumentToMongoContract', () => {
           id    ObjectId @id @map("_id")
           title String
           body  String
-          @@textIndex([title, body], weights: "{\\"title\\": 1, \\"body\\": 99999}", language: "english", languageOverride: "idioma")
+          @@textIndex([title, body], weights: { title: 1, body: 99999 }, language: "english", languageOverride: "idioma")
         }
       `);
       const indexes = getIndexes(ir, 'article');
@@ -1479,7 +1470,7 @@ describe('interpretPslDocumentToMongoContract', () => {
         model Article {
           id    ObjectId @id @map("_id")
           title String
-          @@textIndex([title], weights: "{\\"__proto__\\": 10}")
+          @@textIndex([title], weights: { "__proto__": 10 })
         }
       `);
       const weights = getIndexes(ir, 'article')?.[0]?.['weights'];
@@ -1493,20 +1484,20 @@ describe('interpretPslDocumentToMongoContract', () => {
     });
 
     it.each([
-      ['nonnumeric', '{"title": "high"}'],
-      ['below range', '{"title": 0}'],
-      ['above range', '{"title": 100000}'],
-      ['non-integer', '{"title": 1.5}'],
-    ])('rejects %s text-index weights at the attribute boundary', (_label, weights) => {
+      ['nonnumeric', '{ title: "high" }'],
+      ['below range', '{ title: 0 }'],
+      ['above range', '{ title: 100000 }'],
+      ['non-integer', '{ title: 1.5 }'],
+    ])('rejects %s native text-index weights at the attribute boundary', (_label, weights) => {
       const result = interpret(`
         model Article {
           id    ObjectId @id @map("_id")
           title String
-          @@textIndex([title], weights: ${JSON.stringify(weights)})
+          @@textIndex([title], weights: ${weights})
         }
       `);
 
-      expectInvalidAttributeSyntax(result, /weight.*integer.*1.*99,999/i);
+      expectInvalidAttributeSyntax(result, /integer|between|99,?999/i);
     });
 
     it('creates @@unique with collation', () => {
@@ -1593,7 +1584,7 @@ describe('interpretPslDocumentToMongoContract', () => {
         model Events {
           id       ObjectId @id @map("_id")
           metadata String
-          @@index([wildcard()], include: "[metadata]", exclude: "[_class]")
+          @@index([wildcard()], include: ["metadata"], exclude: ["_class"])
         }
       `);
       expect(result.ok).toBe(false);
@@ -1611,7 +1602,7 @@ describe('interpretPslDocumentToMongoContract', () => {
         model Events {
           id     ObjectId @id @map("_id")
           status String
-          @@index([status], include: "[status]")
+          @@index([status], include: ["status"])
         }
       `);
       expect(result.ok).toBe(false);
@@ -1758,7 +1749,14 @@ describe('interpretPslDocumentToMongoContract', () => {
           @@index([wildcard(nonexistent)])
         }
       `);
-      expectInvalidAttributeSyntax(result, /Expected one of/);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics).toEqual([
+        expect.objectContaining({
+          code: 'PSL_INDEX_FIELD_NOT_FOUND',
+          message: expect.stringMatching(/nonexistent/),
+        }),
+      ]);
     });
 
     it('emits one diagnostic when one of multiple keys is undeclared', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1,3 +1,4 @@
+import type { ContractSourceDiagnostic } from '@internal/config/config-types';
 import { canonicalizeContractToObject } from '@internal/contract/hashing';
 import {
   type Contract,
@@ -125,6 +126,22 @@ function interpretOk(
   expect(result.ok).toBe(true);
   if (!result.ok) throw new Error('Expected ok result');
   return result.value;
+}
+
+function expectInvalidAttributeSyntax(
+  result: ReturnType<typeof interpret>,
+  message: RegExp,
+): ContractSourceDiagnostic {
+  expect(result.ok).toBe(false);
+  if (result.ok) throw new Error('Expected interpretation to fail');
+  const diagnostics = result.failure.diagnostics.filter(
+    (diagnostic) => diagnostic.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+  );
+  expect(diagnostics).toHaveLength(1);
+  const diagnostic = diagnostics[0];
+  if (!diagnostic) throw new Error('Expected PSL_INVALID_ATTRIBUTE_SYNTAX diagnostic');
+  expect(diagnostic.message).toMatch(message);
+  return diagnostic;
 }
 
 function getIndexes(
@@ -394,6 +411,23 @@ describe('interpretPslDocumentToMongoContract', () => {
           },
         },
       });
+    });
+
+    it('emits one syntax diagnostic for a malformed target field @map', () => {
+      const result = interpret(`
+        model Parent {
+          id       ObjectId @id @map(42)
+          children Child[]
+        }
+
+        model Child {
+          id       ObjectId @id @map("_id")
+          parentId ObjectId
+          parent   Parent @relation(fields: [parentId], references: [id])
+        }
+      `);
+
+      expectInvalidAttributeSyntax(result, /Expected a string literal/);
     });
 
     it('uses mapped field names in relation on-clauses', () => {
@@ -1200,6 +1234,18 @@ describe('interpretPslDocumentToMongoContract', () => {
       expect(indexes![0]!['keys']).toEqual([{ field: 'metadata.$**', direction: 1 }]);
     });
 
+    it('treats a declared wildcard field with sort as a normal field', () => {
+      const ir = interpretOk(`
+        model Events {
+          id       ObjectId @id @map("_id")
+          wildcard String
+          @@index([wildcard(sort: Desc)])
+        }
+      `);
+      const indexes = getIndexes(ir, 'events');
+      expect(indexes![0]!['keys']).toEqual([{ field: 'wildcard', direction: -1 }]);
+    });
+
     it('creates descending index from sort: Desc', () => {
       const ir = interpretOk(`
         model Events {
@@ -1309,6 +1355,30 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       const indexes = getIndexes(ir, 'events');
       expect(indexes![0]!['wildcardProjection']).toEqual({ metadata: 1, tags: 1 });
+    });
+
+    it('rejects a malformed projection list at the attribute boundary', () => {
+      const result = interpret(`
+        model Events {
+          id       ObjectId @id @map("_id")
+          metadata String
+          @@index([wildcard()], include: "metadata")
+        }
+      `);
+
+      expectInvalidAttributeSyntax(result, /projection list/);
+    });
+
+    it('rejects a malformed text-index projection list at the attribute boundary', () => {
+      const result = interpret(`
+        model Article {
+          id    ObjectId @id @map("_id")
+          title String
+          @@textIndex([title], exclude: "title")
+        }
+      `);
+
+      expectInvalidAttributeSyntax(result, /projection list/);
     });
 
     it('parses exclude as wildcardProjection with 0 values', () => {
@@ -1574,15 +1644,9 @@ describe('interpretPslDocumentToMongoContract', () => {
           @@index([nonexistent])
         }
       `);
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      const diag = result.failure.diagnostics.find(
-        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-      );
-      expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/Expected one of/);
-      expect(diag?.span?.start.offset).toBeGreaterThan(0);
-      expect(diag?.span?.end.offset).toBeGreaterThan(diag?.span?.start.offset ?? 0);
+      const diag = expectInvalidAttributeSyntax(result, /Expected one of/);
+      expect(diag.span?.start.offset).toBeGreaterThan(0);
+      expect(diag.span?.end.offset).toBeGreaterThan(diag.span?.start.offset ?? 0);
     });
 
     it('rejects @@unique that references an undeclared field', () => {
@@ -1593,13 +1657,7 @@ describe('interpretPslDocumentToMongoContract', () => {
           @@unique([nonexistent])
         }
       `);
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      const diag = result.failure.diagnostics.find(
-        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-      );
-      expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/Expected one of/);
+      expectInvalidAttributeSyntax(result, /Expected one of/);
     });
 
     it('rejects @@textIndex that references an undeclared field', () => {
@@ -1610,13 +1668,7 @@ describe('interpretPslDocumentToMongoContract', () => {
           @@textIndex([nonexistent])
         }
       `);
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      const diag = result.failure.diagnostics.find(
-        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-      );
-      expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/Expected one of/);
+      expectInvalidAttributeSyntax(result, /Expected one of/);
     });
 
     it('rejects @@index wildcard scope referencing an undeclared field', () => {
@@ -1627,13 +1679,7 @@ describe('interpretPslDocumentToMongoContract', () => {
           @@index([wildcard(nonexistent)])
         }
       `);
-      expect(result.ok).toBe(false);
-      if (result.ok) return;
-      const diag = result.failure.diagnostics.find(
-        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
-      );
-      expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/Expected one of/);
+      expectInvalidAttributeSyntax(result, /Expected one of/);
     });
 
     it('emits one diagnostic when one of multiple keys is undeclared', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1344,6 +1344,55 @@ describe('interpretPslDocumentToMongoContract', () => {
       });
     });
 
+    it.each(['index', 'textIndex'])('accepts every finite collation value for @@%s', (kind) => {
+      const options = [
+        'collationStrength: 1',
+        'collationStrength: 5',
+        'collationCaseFirst: "upper"',
+        'collationCaseFirst: "lower"',
+        'collationCaseFirst: "off"',
+        'collationAlternate: "non-ignorable"',
+        'collationAlternate: "shifted"',
+        'collationMaxVariable: "punct"',
+        'collationMaxVariable: "space"',
+      ];
+      const models = options
+        .map(
+          (option, index) => `
+            model Item${index} {
+              id    ObjectId @id @map("_id")
+              value String
+              @@${kind}([value], collationLocale: "en", ${option})
+            }
+          `,
+        )
+        .join('\n');
+
+      expect(interpret(models).ok).toBe(true);
+    });
+
+    it.each(['index', 'textIndex'])('rejects invalid finite collation values for @@%s', (kind) => {
+      const invalidOptions = [
+        'collationStrength: 0',
+        'collationStrength: 6',
+        'collationCaseFirst: "invalid"',
+        'collationAlternate: "invalid"',
+        'collationMaxVariable: "invalid"',
+      ];
+
+      for (const option of invalidOptions) {
+        const result = interpret(`
+          model Item {
+            id    ObjectId @id @map("_id")
+            value String
+            @@${kind}([value], collationLocale: "en", ${option})
+          }
+        `);
+
+        expectInvalidAttributeSyntax(result, /Expected one of/);
+      }
+    });
+
     it('parses include as wildcardProjection with 1 values', () => {
       const ir = interpretOk(`
         model Events {
@@ -1416,13 +1465,30 @@ describe('interpretPslDocumentToMongoContract', () => {
           id    ObjectId @id @map("_id")
           title String
           body  String
-          @@textIndex([title, body], weights: "{\\"title\\": 10, \\"body\\": 5}", language: "english", languageOverride: "idioma")
+          @@textIndex([title, body], weights: "{\\"title\\": 1, \\"body\\": 99999}", language: "english", languageOverride: "idioma")
         }
       `);
       const indexes = getIndexes(ir, 'article');
-      expect(indexes![0]!['weights']).toEqual({ title: 10, body: 5 });
+      expect(indexes![0]!['weights']).toEqual({ title: 1, body: 99999 });
       expect(indexes![0]!['default_language']).toBe('english');
       expect(indexes![0]!['language_override']).toBe('idioma');
+    });
+
+    it.each([
+      ['nonnumeric', '{"title": "high"}'],
+      ['below range', '{"title": 0}'],
+      ['above range', '{"title": 100000}'],
+      ['non-integer', '{"title": 1.5}'],
+    ])('rejects %s text-index weights at the attribute boundary', (_label, weights) => {
+      const result = interpret(`
+        model Article {
+          id    ObjectId @id @map("_id")
+          title String
+          @@textIndex([title], weights: ${JSON.stringify(weights)})
+        }
+      `);
+
+      expectInvalidAttributeSyntax(result, /weight.*integer.*1.*99,999/i);
     });
 
     it('creates @@unique with collation', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -550,6 +550,27 @@ describe('interpretPslDocumentToMongoContract', () => {
         ]),
       );
     });
+
+    it('rejects @relation naming a field that does not exist on the model', () => {
+      const result = interpret(`
+        model User {
+          id ObjectId @id @map("_id")
+        }
+
+        model Post {
+          id       ObjectId @id @map("_id")
+          authorId ObjectId
+          author   User @relation(fields: [missing], references: [id])
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
+      expect(diag).toBeDefined();
+      expect(diag?.message).toMatch(/missing/);
+    });
   });
 
   describe('@id validation', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1474,6 +1474,24 @@ describe('interpretPslDocumentToMongoContract', () => {
       expect(indexes![0]!['language_override']).toBe('idioma');
     });
 
+    it('preserves an own __proto__ text-index weight', () => {
+      const ir = interpretOk(`
+        model Article {
+          id    ObjectId @id @map("_id")
+          title String
+          @@textIndex([title], weights: "{\\"__proto__\\": 10}")
+        }
+      `);
+      const weights = getIndexes(ir, 'article')?.[0]?.['weights'];
+
+      expect(weights).not.toBeNull();
+      expect(typeof weights).toBe('object');
+      if (typeof weights !== 'object' || weights === null)
+        throw new Error('Expected weights object');
+      expect(Object.hasOwn(weights, '__proto__')).toBe(true);
+      expect(Object.getOwnPropertyDescriptor(weights, '__proto__')?.value).toBe(10);
+    });
+
     it.each([
       ['nonnumeric', '{"title": "high"}'],
       ['below range', '{"title": 0}'],

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1380,6 +1380,22 @@ describe('interpretPslDocumentToMongoContract', () => {
       expect(indexes![0]!['unique']).toBe(true);
       expect(indexes![0]!['partialFilterExpression']).toEqual({ active: true });
     });
+
+    it('creates a distinct index per @@index on the same model', () => {
+      const ir = interpretOk(`
+        model User {
+          id    ObjectId @id @map("_id")
+          email String
+          name  String
+          @@index([email])
+          @@index([name])
+        }
+      `);
+      const indexes = getIndexes(ir, 'user');
+      expect(indexes).toHaveLength(2);
+      expect(indexes![0]!['keys']).toEqual([{ field: 'email', direction: 1 }]);
+      expect(indexes![1]!['keys']).toEqual([{ field: 'name', direction: 1 }]);
+    });
   });
 
   describe('index validation', () => {
@@ -1545,6 +1561,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       }
     });
 
+    // With the spec migration, a field absent from the model is rejected at the
+    // grammar layer by `fieldRef('self')` (operator Option A): no field-element
+    // arm matches, so the element surfaces PSL_INVALID_ATTRIBUTE_SYNTAX with the
+    // `oneOf` "Expected one of" message. The downstream PSL_INDEX_FIELD_NOT_FOUND
+    // now guards only present-but-not-indexable fields (e.g. relation fields).
     it('rejects @@index that references an undeclared field', () => {
       const result = interpret(`
         model User {
@@ -1555,10 +1576,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
-      expect(diag?.message).toMatch(/User/);
+      expect(diag?.message).toMatch(/Expected one of/);
       expect(diag?.span?.start.offset).toBeGreaterThan(0);
       expect(diag?.span?.end.offset).toBeGreaterThan(diag?.span?.start.offset ?? 0);
     });
@@ -1573,9 +1595,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
+      expect(diag?.message).toMatch(/Expected one of/);
     });
 
     it('rejects @@textIndex that references an undeclared field', () => {
@@ -1603,12 +1627,14 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
+      expect(diag?.message).toMatch(/Expected one of/);
     });
 
-    it('emits one diagnostic naming the missing field when one of multiple keys is undeclared', () => {
+    it('emits one diagnostic when one of multiple keys is undeclared', () => {
       const result = interpret(`
         model User {
           id    ObjectId @id @map("_id")
@@ -1619,10 +1645,9 @@ describe('interpretPslDocumentToMongoContract', () => {
       expect(result.ok).toBe(false);
       if (result.ok) return;
       const diags = result.failure.diagnostics.filter(
-        (d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND',
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
       );
       expect(diags).toHaveLength(1);
-      expect(diags[0]?.message).toMatch(/nonexistent/);
       expect(diags[0]?.message).not.toMatch(/email/);
     });
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts
@@ -1612,9 +1612,11 @@ describe('interpretPslDocumentToMongoContract', () => {
       `);
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      const diag = result.failure.diagnostics.find((d) => d.code === 'PSL_INDEX_FIELD_NOT_FOUND');
+      const diag = result.failure.diagnostics.find(
+        (d) => d.code === 'PSL_INVALID_ATTRIBUTE_SYNTAX',
+      );
       expect(diag).toBeDefined();
-      expect(diag?.message).toMatch(/nonexistent/);
+      expect(diag?.message).toMatch(/Expected one of/);
     });
 
     it('rejects @@index wildcard scope referencing an undeclared field', () => {

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/01-mongo-wiring-map.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/01-mongo-wiring-map.md
@@ -1,0 +1,102 @@
+# Brief: D1 — Mongo `InterpretCtx` wiring + `@map`/`@@map` migration
+
+> Fresh implementer. Slice `mongo-attributes`, branch `tml-2956-mongo-attributes` (off `origin/main`). Do NOT push or touch GitHub. ONE signed commit. Tests-first.
+
+## ⛔ TOOLING RULE (operator standing order — non-negotiable)
+**NEVER call the regex / codebase-search MCP tool — it HANGS and deadlocks the run.** SEARCH-FREE brief. Use `rg`/`grep` in the **terminal** only; reading named files/line-ranges with the file reader is fine. If genuinely under-specified, STOP and report "brief under-specified: <what>".
+
+## Why
+The Mongo family still parses every attribute imperatively off `ResolvedAttribute` + string helpers; it does not use the declarative kit at all. This dispatch lands the Mongo-side kit wiring (a `mongo-attribute-specs.ts` mirroring the SQL family's) and migrates the simplest attribute — `@map`/`@@map` — end-to-end through `interpretAttribute`, proving the seam. No new kit combinators are needed (`str`, `fieldAttribute`, `modelAttribute`, `interpretAttribute` already exist). No `packages/1-framework` or `packages/2-sql` changes.
+
+## The pattern to mirror
+The SQL family's wiring lives in `packages/2-sql/2-authoring/contract-psl/src/sql-attribute-specs.ts` (lines ~36-146): `findModelAttributeNode`, `findFieldAttributeNode`, `buildModelInterpretCtx`, `buildFieldInterpretCtx`, `interpretModelAttribute`, `interpretFieldAttribute`, and the `mapModelSpec`/`mapFieldSpec` constants. **Read that file first** — you will reproduce those functions in the Mongo package (they are family-agnostic: they take `ModelSymbol`/`FieldSymbol`/`SourceFile`/`sourceId`/`diagnostics`). Do NOT import them from `@prisma-next/sql-contract-psl` — that is a forbidden cross-family dependency; copy the wiring into the Mongo package.
+
+## Step 1 — new file `packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts`
+Reproduce, adapted to this package, from the SQL template:
+- `findModelAttributeNode(model, name)` and `findFieldAttributeNode(field, name)` (iterate `model.node.attributes()` / `field.node.attributes()`, return the AST node whose `.name()?.isSimpleName(name) === true`).
+- `buildModelInterpretCtx({ selfModel, sourceFile, sourceId })` → `InterpretCtx` (level `'model'`, `resolveReferencedModel: () => undefined`).
+- `buildFieldInterpretCtx({ selfModel, field, sourceFile, sourceId, resolveReferencedModel? })` → `InterpretCtx` (level `'field'`).
+- `interpretModelAttribute<Out>({ node, spec, model, sourceFile, sourceId, diagnostics })` and `interpretFieldAttribute<Out>({ node, spec, model, field, sourceFile, sourceId, diagnostics, resolveReferencedModel? })` — call `interpretAttribute(node, spec, ctx)`, drain `result.failure` into `diagnostics` and return `undefined` on failure, else `result.value`.
+- The two map specs:
+```ts
+export const mapModelSpec = modelAttribute('map', { positional: [{ key: 'name', type: str() }] });
+export const mapFieldSpec = fieldAttribute('map', { positional: [{ key: 'name', type: str() }] });
+```
+Imports: from `@prisma-next/psl-parser` — `fieldAttribute, modelAttribute, str, interpretAttribute` (values) and `type { AttributeSpec, FieldSymbol, InterpretCtx, ModelSymbol }`; from `@prisma-next/psl-parser/syntax` — `type { FieldAttributeAst, ModelAttributeAst, SourceFile }`; from `@prisma-next/config/config-types` — `type { ContractSourceDiagnostic }`. (Match the exact import specifiers the SQL file uses.)
+
+## Step 2 — migrate the three `getMapName` sites in `interpreter.ts`
+(a) **Field `@map`** — `resolveFieldMappings` (currently ~L132-139). Change its signature to take the interpret context and use the spec:
+```ts
+function resolveFieldMappings(input: {
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): FieldMappings {
+  const { model, sourceFile, sourceId, diagnostics } = input;
+  const pslNameToMapped = new Map<string, string>();
+  for (const field of Object.values(model.fields)) {
+    const mapNode = findFieldAttributeNode(field, 'map');
+    const mapped =
+      (mapNode
+        ? interpretFieldAttribute({ node: mapNode, spec: mapFieldSpec, model, field, sourceFile, sourceId, diagnostics })?.name
+        : undefined) ?? field.name;
+    pslNameToMapped.set(field.name, mapped);
+  }
+  return { pslNameToMapped };
+}
+```
+(b) **Collection `@@map`** — `resolveCollectionName` (currently ~L141-143):
+```ts
+function resolveCollectionName(input: {
+  readonly model: ModelSymbol;
+  readonly sourceFile: SourceFile;
+  readonly sourceId: string;
+  readonly diagnostics: ContractSourceDiagnostic[];
+}): string {
+  const { model, sourceFile, sourceId, diagnostics } = input;
+  const mapNode = findModelAttributeNode(model, 'map');
+  const name = mapNode
+    ? interpretModelAttribute({ node: mapNode, spec: mapModelSpec, model, sourceFile, sourceId, diagnostics })?.name
+    : undefined;
+  return name ?? lowerFirst(model.name);
+}
+```
+(c) **Variant presence check** — currently `interpreter.ts` ~L343: `const hasExplicitMap = getMapName(variantModelView.attributes) !== undefined;`. `variantModelView` is a resolved model view (not a `ModelSymbol` with `.node`), so keep this a presence check via the surviving `getAttribute` helper:
+```ts
+const hasExplicitMap = getAttribute(variantModelView.attributes, 'map') !== undefined;
+```
+(For a well-formed `@@map("x")` both forms are equivalent; a valueless `@@map()` is invalid PSL upstream.)
+
+## Step 3 — thread context into the callers
+The two call sites are `interpreter.ts` ~L1017-1018:
+```ts
+const collectionName = resolveCollectionName(pslModel);
+const fieldMappings = resolveFieldMappings(pslModel);
+```
+Read the enclosing function (`interpretPslDocumentToMongoContract`, ~L952 onward) to find the in-scope `sourceFile`, `sourceId`, and the `diagnostics` accumulator (they exist — the entry emits diagnostics with `sourceId`/`sourceFile` already). Pass them:
+```ts
+const collectionName = resolveCollectionName({ model: pslModel, sourceFile, sourceId, diagnostics });
+const fieldMappings = resolveFieldMappings({ model: pslModel, sourceFile, sourceId, diagnostics });
+```
+If `resolveFieldMappings`/`resolveCollectionName` are called from any other site, thread context there too (grep in the terminal to confirm the call sites).
+
+## Step 4 — retire `getMapName`
+Delete `getMapName` from `packages/2-mongo-family/2-authoring/contract-psl/src/psl-helpers.ts` and remove it from the `interpreter.ts` import list. **Keep** `getAttribute`, `stripQuotes`, `lowerFirst`, and the other helpers (still used by not-yet-migrated attributes). Confirm with `rg -n "getMapName" packages/2-mongo-family` → zero after the edit.
+
+## Tests
+`@map`/`@@map` behaviour must be **byte-identical** — the existing Mongo contract-psl suite + `fixtures:check` are the primary signal (a real `str()`-decoded map name equals the old `stripQuotes` value). Run them. If the suite has no direct coverage of a mapped field/collection name, add one concise case (a model with `@@map("things")` and a field with `@map("_id")`) asserting the emitted `storage.collection` and the mapped field name. Tests-first for any added case.
+
+## Scope
+**In:** the new `mongo-attribute-specs.ts` wiring + map specs; the three `interpreter.ts` migration sites + caller threading; deleting `getMapName`. **Out:** every other Mongo attribute (later dispatches); any `packages/1-framework` or `packages/2-sql` change; the interpreter's semantic checks.
+
+## Constraints
+No `any`; no bare `as` (a narrow justified `blindCast` is acceptable only if the SQL template itself uses one at the same spot — mirror it exactly, no wider); no file-ext imports; never suppress biome; `pnpm` not `npm`. Commit once: `git commit -s` (DCO), explicit staging, no `--amend`, NO push, no GitHub. Read-only on `projects/**`, `.agents/**`.
+
+## Gates (all green, in order)
+1. `pnpm --filter @prisma-next/mongo-contract-psl build && typecheck && test` (confirm the exact package name from `packages/2-mongo-family/2-authoring/contract-psl/package.json`; use that in the filter)
+2. `pnpm fixtures:check` — clean, no Mongo contract drift
+3. `pnpm lint:deps` (0 — catches any forbidden cross-family import) and `pnpm lint:framework-vocabulary` (threshold unchanged; the edits are in `packages/2-mongo-family`, not `1-framework`, so it should not move)
+
+## Report back
+The `mongo-attribute-specs.ts` exports; the three migration sites + how you threaded `sourceFile`/`sourceId`/`diagnostics` (and the exact local names you found in the entry); confirmation `getMapName` is gone (`rg` → zero) and `getAttribute`/`stripQuotes` retained; whether you added a map test or relied on existing coverage; all gate results; the commit SHA. If the SQL template uses an import specifier or a `blindCast` you can't cleanly mirror, or a caller can't reach `diagnostics`, STOP and report rather than guessing.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/02-mongo-relation.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/02-mongo-relation.md
@@ -1,0 +1,76 @@
+# Brief: D2 — migrate Mongo `@relation` to a spec
+
+> Fresh implementer. Slice `mongo-attributes`, branch `tml-2956-mongo-attributes`. Do NOT push or touch GitHub. ONE signed commit. Tests-first. Builds on D1 (the Mongo `mongo-attribute-specs.ts` wiring already exists).
+
+## ⛔ TOOLING RULE (operator standing order — non-negotiable)
+**NEVER call the regex / codebase-search MCP tool — it HANGS and deadlocks the run.** SEARCH-FREE brief. Use `rg`/`grep` in the **terminal** only; reading named files/line-ranges is fine. If under-specified, STOP and report.
+
+## Why
+Mongo `@relation` is parsed by the hand-written `parseRelationAttribute` (string extraction of `name`/`fields`/`references`). Replace it with a declarative spec through `interpretAttribute`, reusing D1's `mongo-attribute-specs.ts` wiring. The SQL family already did this — its spec is the template.
+
+## The template
+`packages/2-sql/2-authoring/contract-psl/src/psl-relation-resolution.ts` (lines ~99-126) defines `sqlRelation`. Read it. The Mongo spec is a **subset**: Mongo `@relation` carries only `name` (alias) + `fields` + `references` — **no `map`, no `onDelete`/`onUpdate`, and no `refine`** (see the behaviour note below). Also note (from `combinators/field-ref.ts`): `fieldRef(scope)` returns `ArgType<string>` — it yields the field-name string (with an existence check against the scoped model), so `list(fieldRef('self'))` produces `string[]`, matching the old parser's output.
+
+## Step 1 — add the Mongo relation spec to `mongo-attribute-specs.ts`
+```ts
+export const relationFieldSpec = fieldAttribute('relation', {
+  positional: [{ key: 'name', type: optional(str()) }],
+  named: {
+    name: optional(str()),
+    fields: optional(list(fieldRef('self'), { nonEmpty: true, unique: true })),
+    references: optional(list(fieldRef('referenced'), { nonEmpty: true, unique: true })),
+  },
+});
+export type RelationFieldOutput = InferAttr<typeof relationFieldSpec>;
+```
+Add the needed imports to `mongo-attribute-specs.ts`: `fieldRef, list, optional` (values) and `type { InferAttr }` from `@prisma-next/psl-parser` (mirror the SQL file's specifiers). Output shape: `{ name?: string; fields?: string[]; references?: string[] }`.
+
+**No `refine`.** SQL's `relationInvariants` errors when `fields` XOR `references` is present; Mongo must NOT adopt that — the Mongo interpreter (below) treats "not both `fields` and `references`" as a **backrelation candidate**, not an error. Adding the refine would change Mongo behaviour. Omit it.
+
+## Step 2 — migrate the consumption in `interpreter.ts` (~L1088-1133)
+The single call site is `const relation = parseRelationAttribute(field.attributes);` (~L1090), inside `for (const field of Object.values(pslModel.fields))` guarded by `isRelationField(field, modelNames)`. Replace with:
+```ts
+const relationNode = findFieldAttributeNode(field, 'relation');
+const relation = relationNode
+  ? interpretFieldAttribute({
+      node: relationNode,
+      spec: relationFieldSpec,
+      model: pslModel,
+      field,
+      sourceFile,
+      sourceId,
+      diagnostics,
+      resolveReferencedModel: () => allModels.find((m) => m.name === field.typeName),
+    })
+  : undefined;
+```
+Add `relationFieldSpec` (and `findFieldAttributeNode`, `interpretFieldAttribute` if not already imported) to the `import { … } from './mongo-attribute-specs'` line. `allModels`, `sourceFile`, `sourceId`, `diagnostics` are all in scope here (confirm by reading ~L1016-1090).
+
+Then update the two reads of the old `relationName` key — the spec output uses `name`, not `relationName`. The **output** key stays `relationName`:
+- `...ifDefined('relationName', relation?.relationName)` → `...ifDefined('relationName', relation?.name)` (the backrelation-candidate push, ~L1097)
+- `...ifDefined('relationName', relation.relationName)` → `...ifDefined('relationName', relation.name)` (the FK-relation push, ~L1128)
+
+`relation?.fields` and `relation?.references` are `string[]` exactly as before — the `.map((f) => fieldMappings.pslNameToMapped.get(f) ?? f)` lines are unchanged, as is the `if (field.list || !(relation?.fields && relation?.references))` backrelation branch.
+
+## Behaviour note — new field-existence validation
+The old `parseRelationAttribute` did no validation; `fieldRef('self')`/`fieldRef('referenced')` now check that each named field exists on the self / referenced model (the referenced check is skipped when `resolveReferencedModel()` returns `undefined`, e.g. a cross-space target). For **valid** schemas this is byte-identical (the names resolve and the same `string[]` comes out). For a schema naming a non-existent relation field, a `PSL_INVALID_ATTRIBUTE_SYNTAX` now fires at parse time. Run the suite: if an existing test asserted a different code/behaviour for a bad relation field ref, update it per operator "Option A" (shape/existence → `PSL_INVALID_ATTRIBUTE_SYNTAX`) and note it; if no such test exists, rely on the green suite + `fixtures:check`.
+
+## Step 3 — retire the dead parser
+Delete `parseRelationAttribute` and the `ParsedRelationAttribute` interface from `psl-helpers.ts`, and remove `parseRelationAttribute` from the `interpreter.ts` import list. Then `rg` in the terminal for the now-possibly-unused helpers: **`parseRelationAttribute`** must be zero. `stripQuotes` was used only by the (already-deleted) `getMapName` and by `parseRelationAttribute` — if `rg -n "stripQuotes" packages/2-mongo-family` is now zero outside its own definition, delete `stripQuotes` too. **Keep `parseFieldList`** (still used by `parseIndexFieldList`, migrated in a later dispatch) and `getAttribute`/`lowerFirst`/`getPositionalArgument`/`getNamedArgument`.
+
+## Tests
+`@relation` lowering must stay byte-identical for valid schemas — the Mongo contract-psl suite + `fixtures:check` are the primary signal. If the suite lacks a direct FK-relation case (a model with `@relation(fields: [x], references: [y])` producing `relations[...]` with `on.localFields`/`on.targetFields`) or a named-relation/backrelation case, add one concise case. Tests-first for anything added.
+
+## Scope
+**In:** the Mongo `relationFieldSpec`; the `interpreter.ts` relation call-site migration + the `relationName`→`name` read changes; deleting `parseRelationAttribute`/`ParsedRelationAttribute` (+ `stripQuotes` if now dead). **Out:** every other Mongo attribute; `packages/1-framework` / `packages/2-sql` changes; the interpreter's relation semantics (backrelation matching, FK indexing) — only the argument parse changes.
+
+## Constraints
+No `any`; no bare `as` (a narrow justified `blindCast` only if the SQL template uses one at the same spot); no file-ext imports; never suppress biome; `pnpm` not `npm`. Commit once: `git commit -s` (DCO), explicit staging, no `--amend`, NO push, no GitHub. Read-only on `projects/**`, `.agents/**`.
+
+## Gates (all green, in order)
+1. `pnpm --filter @prisma-next/mongo-contract-psl build && typecheck && test` (use the exact package name from its package.json)
+2. `pnpm fixtures:check` — clean, no Mongo contract drift
+3. `pnpm lint:deps` (0) and `pnpm lint:framework-vocabulary` (threshold unchanged)
+
+## Report back
+The `relationFieldSpec` shape + confirmation no `refine` was added; the migration site + `relationName`→`name` read changes; whether any field-existence-validation test shifted (and how); `parseRelationAttribute` gone (`rg` → zero) and whether `stripQuotes` was also removed; the test path (added vs relied-on); all gate results; the commit SHA. If the SQL template diverges from this brief, or `stripQuotes` turns out still-used, or a gate goes red you can't resolve from the brief, STOP and report.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/03-mongo-polymorphism.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/03-mongo-polymorphism.md
@@ -1,0 +1,93 @@
+# Brief: D3 — migrate Mongo `@@discriminator` / `@@base` to specs
+
+> Fresh implementer. Slice `mongo-attributes`, branch `tml-2956-mongo-attributes`. Do NOT push or touch GitHub. ONE signed commit. Tests-first. Builds on D1 (the `mongo-attribute-specs.ts` wiring exists) and D2 (already merged into the branch).
+
+## ⛔ TOOLING RULE (operator standing order — non-negotiable)
+**NEVER call the regex / codebase-search MCP tool — it HANGS and deadlocks.** SEARCH-FREE brief. Use `rg`/`grep` in the **terminal** only; reading named files/line-ranges is fine. If under-specified, STOP and report.
+
+## Why
+Mongo `@@discriminator` / `@@base` argument shapes are parsed imperatively in `collectPolymorphismDeclarations` (`interpreter.ts`) via `getPositionalArgument` + `parseQuotedStringLiteral`. Migrate the **argument parsing** to specs through `interpretAttribute`. The polymorphism cross-model semantics (`resolvePolymorphism`) are untouched — only the per-attribute argument parse changes.
+
+## The templates
+SQL's `sql-attribute-specs.ts` already defines `discriminatorModelSpec` and `baseModelSpec` (near the bottom of the file). Read them. They are exactly what Mongo needs:
+```ts
+export const discriminatorModelSpec = modelAttribute('discriminator', {
+  positional: [{ key: 'field', type: fieldRef('self') }],
+});
+export const baseModelSpec = modelAttribute('base', {
+  positional: [
+    { key: 'base', type: entityRef() },
+    { key: 'value', type: str() },
+  ],
+});
+```
+`fieldRef('self')` → the field-name string (validates it exists on the model); `entityRef()` → the model-name string (existence deferred downstream, exactly as today); `str()` → the decoded quoted-string value.
+
+## Step 1 — add the two specs to `mongo-attribute-specs.ts`
+Copy the two spec constants above into `mongo-attribute-specs.ts` (do NOT import from the SQL package). Add imports `entityRef, fieldRef` to the `@prisma-next/psl-parser` value import (it already imports `modelAttribute`, `str`). Export both.
+
+## Step 2 — migrate `collectPolymorphismDeclarations` (`interpreter.ts` ~L208-274)
+The function loops `for (const model of models) { for (const attr of model.attributes) { if (attr.name === 'discriminator') {…} if (attr.name === 'base') {…} } }`. Replace the inner `attr`-loop with two `findModelAttributeNode` lookups per model (there is at most one of each):
+
+```ts
+for (const model of models) {
+  const discNode = findModelAttributeNode(model, 'discriminator');
+  if (discNode) {
+    const parsed = interpretModelAttribute({ node: discNode, spec: discriminatorModelSpec, model, sourceFile, sourceId, diagnostics });
+    if (parsed) {
+      const fieldName = parsed.field;
+      const discField = model.fields[fieldName];
+      // Semantic check — stays: the discriminator field must be a String.
+      if (discField && discField.typeName !== 'String') {
+        diagnostics.push({
+          code: 'PSL_INVALID_ATTRIBUTE_ARGUMENT',
+          message: `Discriminator field "${fieldName}" on model "${model.name}" must be of type String, but is "${discField.typeName}"`,
+          sourceId,
+          span: nodePslSpan(discNode.syntax, sourceFile),
+        });
+      } else {
+        discriminatorDeclarations.set(model.name, { fieldName, span: nodePslSpan(discNode.syntax, sourceFile) });
+      }
+    }
+  }
+  const baseNode = findModelAttributeNode(model, 'base');
+  if (baseNode) {
+    const parsed = interpretModelAttribute({ node: baseNode, spec: baseModelSpec, model, sourceFile, sourceId, diagnostics });
+    if (parsed) {
+      const collectionName = resolveCollectionName({ model, sourceFile, sourceId, diagnostics });
+      baseDeclarations.set(model.name, { baseName: parsed.base, value: parsed.value, collectionName, span: nodePslSpan(baseNode.syntax, sourceFile) });
+    }
+  }
+}
+```
+- Add `discriminatorModelSpec`, `baseModelSpec` (and `interpretModelAttribute`, `findModelAttributeNode` if not already) to the `import { … } from './mongo-attribute-specs'` line. `nodePslSpan` is already imported from `@prisma-next/psl-parser`.
+- The `discField.typeName !== 'String'` check keeps its `PSL_INVALID_ATTRIBUTE_ARGUMENT` code (it is genuinely semantic, not arg-shape).
+- Delete the now-dead imperative bodies (the `getPositionalArgument(attr)` / `getPositionalArgument(attr, 0|1)` / `parseQuotedStringLiteral(rawValue)` blocks and their `PSL_INVALID_ATTRIBUTE_ARGUMENT` "requires …" / "must be a quoted string literal" diagnostics).
+
+## Diagnostic-code shifts (operator "Option A")
+These arg-shape errors move from `PSL_INVALID_ATTRIBUTE_ARGUMENT` to the grammar's `PSL_INVALID_ATTRIBUTE_SYNTAX`:
+- `@@discriminator` with no field arg → missing-required-arg (was "requires a field name argument").
+- `@@discriminator` naming a non-existent field → `fieldRef` existence failure (previously silently recorded).
+- `@@base` with fewer than two args → missing-required-arg (was "requires two arguments").
+- `@@base` whose value isn't a quoted string → `str()` rejection (was "must be a quoted string literal").
+The base-model-existence check and the discriminator⇄base consistency checks in `resolvePolymorphism` are unchanged. **Grep the Mongo test suite for these cases and update the asserted codes/messages per Option A** (search for `discriminator`/`@@base`/`PSL_INVALID_ATTRIBUTE_ARGUMENT` in `packages/2-mongo-family/2-authoring/contract-psl/test`), keeping the String-type-check test (`PSL_INVALID_ATTRIBUTE_ARGUMENT`) as-is. Tests-first for any new case.
+
+## Step 3 — no parser deletions yet
+`getPositionalArgument` and `parseQuotedStringLiteral` are still used by the index attributes (migrated in D4). Do NOT delete them here — only their `@@discriminator`/`@@base` call sites go away. Confirm they are still imported/used after your edit.
+
+## Tests
+Polymorphism lowering must be byte-identical for valid schemas — the Mongo contract-psl suite + `fixtures:check` are the primary signal. Update any bad-arg diagnostic-code assertions per the shifts above. If a valid `@@base`/`@@discriminator` round-trip case is missing, add one.
+
+## Scope
+**In:** the two Mongo polymorphism specs; the `collectPolymorphismDeclarations` argument-parse migration; the diagnostic-code-shift test updates. **Out:** `resolvePolymorphism` semantics; every other attribute; `packages/1-framework` / `packages/2-sql`; helper deletions (D6).
+
+## Constraints
+No `any`; no bare `as` (mirror the SQL template's justified `blindCast` only if it uses one at the same spot); no file-ext imports; never suppress biome; `pnpm` not `npm`. Commit once: `git commit -s` (DCO), explicit staging, no `--amend`, NO push, no GitHub. Read-only on `projects/**`, `.agents/**`.
+
+## Gates (all green, in order)
+1. `pnpm --filter @prisma-next/mongo-contract-psl build && typecheck && test`
+2. `pnpm fixtures:check` — clean, no Mongo contract drift
+3. `pnpm lint:deps` (0) and `pnpm lint:framework-vocabulary` (threshold unchanged)
+
+## Report back
+The two specs added; the `collectPolymorphismDeclarations` migration + confirmation the String-type check kept `PSL_INVALID_ATTRIBUTE_ARGUMENT`; which bad-arg tests shifted to `PSL_INVALID_ATTRIBUTE_SYNTAX`; confirmation `getPositionalArgument`/`parseQuotedStringLiteral` are still used (not deleted); the test path; all gate results; the commit SHA. If a span change breaks a diagnostic-span assertion, or the SQL template diverges, STOP and report.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/04-kit-str-value-json.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/04-kit-str-value-json.md
@@ -1,0 +1,96 @@
+# Brief: D4 — kit combinators `str(value)` + `json()` for the Mongo index surface
+
+> Fresh implementer. Slice `mongo-attributes`, branch `tml-2956-mongo-attributes`. Do NOT push or touch GitHub. ONE signed commit. Tests-first. **psl-parser (kit) only — no Mongo/SQL package changes.**
+
+## ⛔ TOOLING RULE (operator standing order — non-negotiable)
+**NEVER call the regex / codebase-search MCP tool — it HANGS and deadlocks.** SEARCH-FREE brief. Use `rg`/`grep` in the **terminal** only; reading named files is fine. If under-specified, STOP and report.
+
+## Why
+The Mongo `@@index`/`@@unique`/`@@textIndex` argument surface (migrated in later dispatches) needs two leaf combinators the kit lacks:
+- **`str(value)`** — a pinned string literal, for the index `type` set (`type: "hashed"`, `"2dsphere"`, `"2d"`, `"text"` — digit-leading, so they can't be bare identifiers). The ADR calls for this alongside `num(value)`/`identifier(name)`.
+- **`json()`** — reads an opaque JSON **object** from a quoted JSON string (`filter: "{\"status\": \"active\"}"`, `weights: "{\"title\": 10}"`). ADR § "Surface policy" names this the one text-encoded exception. It replaces the interpreter's `parseJsonArg`.
+
+The field-element grammar (`name(sort: Desc)`, `wildcard(scope)`) needs **no** new combinator — it composes from the existing `funcCall(name, sig)` dynamically over the model's fields (done in D5). This dispatch is just the two leaves.
+
+## Part A — `str(value)` overload (`combinators/str.ts`)
+Today `str()` returns `ArgType<string>` (any string literal). Add a pinned overload, mirroring `combinators/num.ts` (`num()` / `num(value)`) exactly:
+```ts
+export function str(): ArgType<string>;
+export function str(value: string): ArgType<string>;
+export function str(value?: string): ArgType<string> {
+  return {
+    kind: 'str',
+    label: value === undefined ? 'string' : JSON.stringify(value),
+    parse: (arg, ctx): Result<string, readonly PslDiagnostic[]> => {
+      if (arg instanceof StringLiteralExprAst) {
+        const parsed = arg.value();
+        if (parsed !== undefined && (value === undefined || parsed === value)) return ok(parsed);
+      }
+      const message = value === undefined ? 'Expected a string literal' : `Expected ${JSON.stringify(value)}`;
+      return notOk([leafDiagnostic(ctx, arg, message)]);
+    },
+  };
+}
+```
+(The unpinned `str()` behaviour is unchanged — all existing callers keep working. Use `JSON.stringify(value)` for the label/message so the quotes show, e.g. `Expected "hashed"`.)
+
+## Part B — `json()` combinator (new file `combinators/json.ts`)
+Reads a quoted JSON string literal and parses it to a JSON **object**. Behaviour matches the interpreter's current `parseJsonArg` (decoded string → `JSON.parse` → must be a non-array object):
+```ts
+import type { PslDiagnostic } from '@prisma-next/framework-components/psl-ast';
+import { notOk, ok, type Result } from '@prisma-next/utils/result';
+import { StringLiteralExprAst } from '../../syntax/ast/expressions';
+import type { ArgType } from '../types';
+import { leafDiagnostic } from './diagnostic';
+
+// Reads an opaque JSON object from a quoted JSON string — the ADR's one text-encoded surface
+// exception (e.g. a Mongo index `filter` / `weights`). The string is decoded by the parser, then
+// JSON-parsed; a non-object (array/scalar) or invalid JSON is a diagnostic.
+export function json(): ArgType<Record<string, unknown>> {
+  return {
+    kind: 'json',
+    label: 'JSON object',
+    parse: (arg, ctx): Result<Record<string, unknown>, readonly PslDiagnostic[]> => {
+      if (!(arg instanceof StringLiteralExprAst)) {
+        return notOk([leafDiagnostic(ctx, arg, 'Expected a JSON object string')]);
+      }
+      const raw = arg.value();
+      if (raw !== undefined) {
+        try {
+          const parsed: unknown = JSON.parse(raw);
+          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            return ok(blindCast<Record<string, unknown>, 'JSON.parse of a validated non-array object literal is a string-keyed record'>(parsed));
+          }
+        } catch {
+          // fall through to the diagnostic
+        }
+      }
+      return notOk([leafDiagnostic(ctx, arg, 'Expected a valid JSON object')]);
+    },
+  };
+}
+```
+Import `blindCast` from `@prisma-next/utils/casts` (the one justified narrow cast — `JSON.parse` returns `any`/`unknown`; narrowing a validated object to `Record<string, unknown>` needs it). No bare `as`.
+
+## Part C — export `json`
+Add `export { json } from '../attribute-spec/combinators/json';` to `packages/1-framework/2-authoring/psl-parser/src/exports/index.ts` (alphabetical, near `int`/`identifier`). `str` is already exported (the overload needs no export change).
+
+## Tests — `test/attribute-spec-combinators.test.ts`
+Add focused unit tests (tests-first):
+- **`str(value)`**: `str('hashed')` accepts `"hashed"` → `'hashed'`; rejects `"2dsphere"` and a bare identifier and a number; the unpinned `str()` still accepts any string. (Mirror the existing `num(value)` test block's structure.)
+- **`json()`**: accepts `"{\"a\": 1}"` → `{ a: 1 }`; rejects a non-object JSON string (`"[1,2]"`, `"5"`), an invalid-JSON string, and a bare identifier / number literal.
+Use the existing `argOf(...)` helper in that test file to build the expression + ctx.
+
+## Scope
+**In:** `str(value)` overload; the `json()` combinator + its export; their unit tests. **Out:** any Mongo/SQL package change; the index migration (D5); wiring `json()` into any spec.
+
+## Constraints
+No `any` (use `unknown` + the single justified `blindCast` in `json`); no other bare `as`; no file-ext imports; never suppress biome; `pnpm` not `npm`. Commit once: `git commit -s` (DCO), explicit staging, no `--amend`, NO push, no GitHub. Read-only on `projects/**`, `.agents/**`.
+
+## Gates (all green, in order)
+1. `pnpm --filter @prisma-next/psl-parser build && typecheck && test`
+2. `pnpm --filter @prisma-next/sql-contract-psl typecheck && test` and `pnpm --filter @prisma-next/mongo-contract-psl typecheck && test` (must stay green with NO edits — the `str()` overload + new `json` export are additive)
+3. `pnpm lint:deps` (0) and `pnpm lint:framework-vocabulary` (bump threshold to the exact new count ONLY if the two combinators' comments move it; prefer rewording)
+
+## Report back
+The `str(value)` overload + `json()` shape; confirmation the unpinned `str()` and all existing psl-parser/sql/mongo tests stay green with no edits; how you handled the `json` cast (the single `blindCast`); the new unit tests; all gate results; the commit SHA. If `arg.value()` on a `StringLiteralExprAst` does NOT return the JSON-decoded (unescaped) content — so `JSON.parse` would need different pre-processing — STOP and report what it returns.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/05-mongo-index.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/05-mongo-index.md
@@ -1,0 +1,112 @@
+# Brief: D5 — migrate Mongo `@@index` / `@@unique` (model) to specs
+
+> Fresh implementer. Slice `mongo-attributes`, branch `tml-2956-mongo-attributes`. Do NOT push or touch GitHub. ONE signed commit. Tests-first. Builds on D1–D4 (the `mongo-attribute-specs.ts` wiring + `str(value)`/`json()` combinators are on the branch).
+
+## ⛔ TOOLING RULE (operator standing order — non-negotiable)
+**NEVER call the regex / codebase-search MCP tool — it HANGS and deadlocks.** SEARCH-FREE brief. Use `rg`/`grep` in the **terminal** only; reading named files/line-ranges is fine. If under-specified, STOP and report.
+
+## Why
+Migrate the **argument parsing** of the model-level `@@index` and `@@unique` attributes off the imperative string helpers onto specs through `interpretAttribute`. The dense index-shape **validation stays** in the interpreter — only the arg *source* changes. `@@textIndex` stays on its current path in this dispatch (migrated in D6); the loop branches to keep textIndex working.
+
+All the code lives in `collectIndexes` (`packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts`, ~L626-880). Read that whole function first — you will preserve all of its validation, key-building, and `MongoIndex` construction; you only replace where the argument *values* come from.
+
+## The argument surface (grounded)
+Positional `fields` = an array of index elements, each one of:
+- a bare field → `fieldRef('self')` → the field-name string;
+- `field(sort: Asc|Desc)` → a per-field sorted ref;
+- `wildcard()` / `wildcard(scope)` → a wildcard path.
+
+Named args (`@@index`/`@@unique`): `type` (`1`/`-1`/`"text"`/`"2dsphere"`/`"2d"`/`"hashed"`), `sparse` (bool), `expireAfterSeconds` (number), `filter` (quoted JSON → object), `include` / `exclude` (quoted bracket-string, e.g. `"[a, b]"`), `default_language` (quoted string), `languageOverride` (quoted string), and the 9 collation args: `collationLocale`/`collationCaseFirst`/`collationAlternate`/`collationMaxVariable` (quoted strings), `collationStrength` (number), `collationCaseLevel`/`collationNumericOrdering`/`collationBackwards`/`collationNormalization` (bools).
+
+## Step 1 — spec infrastructure in `mongo-attribute-specs.ts`
+Add, composed dynamically per model from its field names (exactly like `buildDefaultSpec` composes from the registry):
+
+**(a) The field element** (the plan's `sortedFieldRef`/`wildcardPath` dissolve into `funcCall` composition — no new combinators):
+```ts
+const sortSig = { named: { sort: oneOf(identifier('Asc'), identifier('Desc')) } } satisfies FuncCallSig;
+function indexFieldElement(fieldNames: readonly string[]) {
+  const fieldArms = fieldNames.map((name) => funcCall(name, sortSig)); // `field(sort: X)` → { fn: name, args: { sort } }
+  return oneOf(
+    fieldRef('self'),                                                                 // bare field → "name"
+    funcCall('wildcard', { positional: [{ key: 'scope', type: optional(fieldRef('self')) }] }), // wildcard(scope) → { fn: 'wildcard', args: { scope? } }
+    ...fieldArms,
+  );
+}
+```
+Element output is `string | { fn: string; span; args: { sort?: 'Asc'|'Desc'; scope?: string } }`. (If `fieldNames` is empty the model has no fields — guard so the `oneOf` tuple stays non-empty, e.g. skip the field arms; a bare `oneOf(fieldRef('self'), funcCall('wildcard', …))` is still valid.)
+
+**(b) A shared collation named-args object:**
+```ts
+const collationNamedArgs = {
+  collationLocale: optional(str()),
+  collationStrength: optional(int()),
+  collationCaseLevel: optional(bool()),
+  collationCaseFirst: optional(str()),
+  collationNumericOrdering: optional(bool()),
+  collationAlternate: optional(str()),
+  collationMaxVariable: optional(str()),
+  collationBackwards: optional(bool()),
+  collationNormalization: optional(bool()),
+};
+```
+
+**(c) An index-spec factory** (one shape for both `@@index` and `@@unique`; the attribute name differs, args are the same):
+```ts
+export function buildIndexModelSpec(name: 'index' | 'unique', fieldNames: readonly string[]) {
+  return modelAttribute(name, {
+    positional: [{ key: 'fields', type: list(indexFieldElement(fieldNames), { nonEmpty: true }) }],
+    named: {
+      type: optional(oneOf(num(1), num(-1), str('text'), str('2dsphere'), str('2d'), str('hashed'))),
+      sparse: optional(bool()),
+      expireAfterSeconds: optional(int()),
+      filter: optional(json()),
+      include: optional(str()),
+      exclude: optional(str()),
+      default_language: optional(str()),
+      languageOverride: optional(str()),
+      ...collationNamedArgs,
+    },
+  });
+}
+```
+Add the needed imports (`bool, fieldRef, funcCall, identifier, int, json, list, num, oneOf, optional, str`, and `type FuncCallSig`).
+
+## Step 2 — normalize + migrate `collectIndexes`
+Introduce a helper that turns a spec-interpreted `@@index`/`@@unique` into the same normalized values the loop already uses, so the **rest of the loop is unchanged**. The loop today derives, per attribute: `parsedFields: ParsedIndexField[]` (`{ name, isWildcard, direction? }`), then `typeArg`, `sparse`, `expireAfterSeconds`, `partialFilterExpression` (filter), `include`/`exclude` → `wildcardProjection`, `collation`, `default_language`, `language_override`. Produce those from the spec output instead of the `getNamedArgument`/`parse*` calls:
+
+- **Field elements → `ParsedIndexField[]`:** map each interpreted element:
+  - `string` → `{ name, isWildcard: false }`
+  - `{ fn: 'wildcard', args: { scope? } }` → `{ name: scope ? \`${scope}.$**\` : '$**', isWildcard: true }`
+  - `{ fn, args: { sort } }` (fn is the field name) → `{ name: fn, isWildcard: false, direction: sort === 'Desc' ? -1 : 1 }`
+- **`type`:** the interpreted value is already `1 | -1 | 'text' | '2dsphere' | '2d' | 'hashed' | undefined`; feed it where `parseIndexDirection(typeArg)` was used (default `1` when absent). This replaces `parseIndexDirection` for the index/unique path.
+- **`filter`** → the `json()` object (was `parseJsonArg`).
+- **`include`/`exclude`** → the raw `str()` value; feed to the existing `parseProjectionList(value, 1|0)` (parseProjectionList stays — it splits the bracket-string; the spec only supplies the decoded string).
+- **collation** → build the `CollationOptions` from the interpreted collation args (locale/strength/etc.), replacing `parseCollation`. **Preserve the semantic rule:** if any collation arg is present but `collationLocale` is absent → the existing `PSL_INVALID_INDEX` "collationLocale is required" diagnostic. Keep that check (it is genuinely semantic, not arg-shape).
+- **`default_language`/`languageOverride`** → the `str()` values (was `stripQuotesHelper`).
+
+Structure it cleanly: for `@@textIndex` keep the **existing** old-path parsing (branch `if (isTextIndex) { …old parseIndexFieldList/getNamedArgument path… } else { …spec path… }`); for `@@index`/`@@unique` use `interpretModelAttribute({ node: findModelAttributeNode(model, name), spec: buildIndexModelSpec(name, fieldNames), model, sourceFile, sourceId, diagnostics })`. Everything after normalization — the wildcard-count / unique+wildcard / hashed-single-field / wildcard+type / wildcard+expireAfterSeconds / include-xor-exclude / include-requires-wildcard checks, the `PSL_INDEX_FIELD_NOT_FOUND` existence check, the key mapping, and the `new MongoIndex({...})` construction — stays **exactly as is**, reading the normalized values.
+
+Note: `collectIndexes(pslModel, …)` currently takes `(pslModel, fieldMappings, modelNames, sourceId, diagnostics, indexSpans)` — it will also need `sourceFile` (thread it from the caller; the entry has it in scope). `fieldNames` for the spec = the model's field names (`Object.keys(pslModel.fields)`), the same set the existence check uses.
+
+## Diagnostic-code shifts (operator "Option A")
+Arg-shape errors that were silent or bespoke become grammar `PSL_INVALID_ATTRIBUTE_SYNTAX`: an unknown `type` value (was silently defaulted to `1` by `parseIndexDirection`), a non-bool `sparse`, a non-numeric `expireAfterSeconds`, a malformed field element, a bad `sort` direction, invalid `filter`/`weights` JSON. The genuinely-semantic index-shape codes (`PSL_INVALID_INDEX` in all its forms, `PSL_INDEX_FIELD_NOT_FOUND`, the collation-locale-required rule) are **preserved**. Grep the Mongo index tests and update any shifted assertions per Option A; keep the `PSL_INVALID_INDEX`/`PSL_INDEX_FIELD_NOT_FOUND` cases as-is.
+
+## Step 3 — no parser deletions yet
+`parseIndexDirection`, `parseCollation`, `parseNumericArg`, `parseBooleanArg`, `stripQuotesHelper`, `parseIndexFieldList`, `getNamedArgument`, `getPositionalArgument` are **still used by the `@@textIndex` old-path branch** — do NOT delete them here (D6 migrates textIndex, D7 deletes them). `parseProjectionList` and `parseJsonArg`-for-weights stay for now too. Confirm they're all still used after your edit.
+
+## Tests
+`@@index`/`@@unique` lowering must be byte-identical for valid schemas — the Mongo contract-psl suite (`test/interpreter.test.ts` has extensive index coverage: ascending/descending/compound, `type`, `sparse`/`expireAfterSeconds`, `filter`, `include`/`exclude`, wildcard, collation, `@@unique` variants) + `fixtures:check` are the primary signal. Run them; update only the code-shifted bad-arg assertions. Tests-first for any added case.
+
+## Scope
+**In:** the field-element helper + collation args + `buildIndexModelSpec`; the `@@index`/`@@unique` normalization + migration in `collectIndexes` (textIndex kept on the old branch); the `sourceFile` threading; code-shift test updates. **Out:** `@@textIndex` migration (D6); parser deletions (D7); `packages/1-framework` / `packages/2-sql`; all the index-shape semantics (unchanged).
+
+## Constraints
+No `any`; no bare `as` (a narrow justified `blindCast` is acceptable only where mapping the heterogeneous element union forces it — narrow it as far as possible, prefer discriminating on `typeof x === 'string'` / `x.fn === 'wildcard'`); no file-ext imports; never suppress biome; `pnpm` not `npm`. Commit once: `git commit -s` (DCO), explicit staging, no `--amend`, NO push, no GitHub. Read-only on `projects/**`, `.agents/**`.
+
+## Gates (all green, in order)
+1. `pnpm --filter @prisma-next/mongo-contract-psl build && typecheck && test`
+2. `pnpm fixtures:check` — clean, no Mongo contract drift
+3. `pnpm lint:deps` (0) and `pnpm lint:framework-vocabulary` (threshold unchanged; reword rather than bump)
+
+## Report back
+The field-element helper + `buildIndexModelSpec` shape; how you normalized the element union to `ParsedIndexField` (and any `blindCast` used); confirmation the index-shape validation + `MongoIndex` construction are unchanged and `@@textIndex` still works via the old branch; which bad-arg tests shifted to `PSL_INVALID_ATTRIBUTE_SYNTAX`; confirmation the legacy parsers are still used (not deleted); all gate results; the commit SHA. If the element-union normalization forces a wide cast, if a `PSL_INVALID_INDEX` span/message assertion breaks, or a gate goes red you can't resolve from the brief, STOP and report the exact blocker.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/06-mongo-textindex-cleanup.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/dispatches/06-mongo-textindex-cleanup.md
@@ -1,0 +1,88 @@
+# Brief: D6 — migrate Mongo `@@textIndex` + delete the legacy parsers (slice finish)
+
+> Fresh implementer. Slice `mongo-attributes`, branch `tml-2956-mongo-attributes`. Do NOT push or touch GitHub. ONE signed commit. Tests-first. Builds on D1–D5 (all on the branch). **This is the last implementation dispatch — after it the Mongo family is fully spec-driven.**
+
+## ⛔ TOOLING RULE (operator standing order — non-negotiable)
+**NEVER call the regex / codebase-search MCP tool — it HANGS and deadlocks.** SEARCH-FREE brief. Use `rg`/`grep` in the **terminal** only; reading named files/line-ranges is fine. If under-specified, STOP and report.
+
+## Why
+D5 migrated `@@index`/`@@unique` to specs but left `@@textIndex` on the old parsing branch inside `collectIndexes` (`interpreter.ts`). Migrate that branch to a spec too — which orphans the remaining legacy parsers, so they must be deleted in this same commit (biome `noUnusedVariables: error` forbids leaving dead code). Read `collectIndexes` in full first; the D5 structure (a `if (isTextIndex) {…} else {…}` block feeding shared normalized locals, then unchanged validation/key-building/`MongoIndex`) is what you extend.
+
+## Step 1 — add `buildTextIndexModelSpec` to `mongo-attribute-specs.ts`
+Reuse the D5 helpers (`indexFieldElement`, `collationNamedArgs`) already in that file. `@@textIndex` accepts: the field list + `filter` (json), `include`/`exclude` (str), `weights` (json), `language` (str — note: `language`, NOT `default_language`), `languageOverride` (str), and the collation args. It does **not** take `type`/`sparse`/`expireAfterSeconds`/`default_language`.
+```ts
+export function buildTextIndexModelSpec(fieldNames: readonly string[]) {
+  return modelAttribute('textIndex', {
+    positional: [{ key: 'fields', type: list(indexFieldElement(fieldNames), { nonEmpty: true }) }],
+    named: {
+      filter: optional(json()),
+      include: optional(str()),
+      exclude: optional(str()),
+      weights: optional(json()),
+      language: optional(str()),
+      languageOverride: optional(str()),
+      ...collationNamedArgs,
+    },
+  });
+}
+```
+
+## Step 2 — migrate the `isTextIndex` branch in `collectIndexes`
+Replace the old-path body of the `if (isTextIndex) {…}` block (the `getPositionalArgument`/`parseIndexFieldList`/`parseJsonArg`/`parseCollation`/`stripQuotesHelper`/`getNamedArgument` reads) with a spec interpretation that fills the same normalized locals. Prefer unifying both branches — since both now interpret a spec, select the spec by kind and normalize with `isTextIndex` conditionals:
+```ts
+const node = attributeNodes[attrIndex];
+if (node === undefined) continue;
+const spec = isTextIndex
+  ? buildTextIndexModelSpec(specFieldNames)
+  : buildIndexModelSpec(isUnique ? 'unique' : 'index', specFieldNames);
+const parsed = interpretModelAttribute({ node, spec, model: pslModel, sourceFile, sourceId, diagnostics });
+if (parsed === undefined) continue;
+parsedFields = parsed.fields.map(normalizeIndexField);
+if (parsedFields.length === 0) continue;
+typeValue = isTextIndex ? undefined : parsed.type;
+sparse = isTextIndex ? undefined : parsed.sparse;
+expireAfterSeconds = isTextIndex ? undefined : parsed.expireAfterSeconds;
+partialFilterExpression = parsed.filter;
+includeArg = parsed.include;
+excludeArg = parsed.exclude;
+collation = buildCollationFromSpec(parsed);
+default_language = isTextIndex ? parsed.language : parsed.default_language;
+language_override = parsed.languageOverride;
+weights = isTextIndex ? extractWeights(parsed.weights) : undefined;
+```
+- `parsed.weights` from `json()` is `Record<string, unknown> | undefined`; keep the existing number-filter (`extractWeights` = for each entry, keep only `typeof v === 'number'`) — extract it to a small local helper or inline it, cast-free (`unknown` narrowed by `typeof`).
+- `buildCollationFromSpec(parsed)` (the D5 helper) already reads the collation args + preserves the `collationLocale`-required `PSL_INVALID_INDEX` rule — it works for the textIndex spec too since it carries `collationNamedArgs`.
+- **Union the `parsed` types cleanly**: `buildTextIndexModelSpec` and `buildIndexModelSpec` infer different named-arg shapes. Read each field off `parsed` only in the branch where its spec declares it (guard the index-only reads with `isTextIndex ? undefined : parsed.<x>` and the textIndex-only `parsed.language`/`parsed.weights` with `isTextIndex ? … : undefined`). If TypeScript can't reconcile the two `parsed` shapes in one binding, keep the two-branch `if (isTextIndex) {…} else {…}` structure (each branch interprets its own spec and fills the locals) rather than forcing a cast — no bare `as`.
+
+Everything after the normalized locals — the `textIndexCount`/one-per-collection guard, the wildcard/hashed/type/expireAfterSeconds/include-exclude `PSL_INVALID_INDEX` checks, `PSL_INDEX_FIELD_NOT_FOUND`, key-building, `parseProjectionList`-based `wildcardProjection`, and `new MongoIndex({...})` — stays **exactly as is**.
+
+## Step 3 — delete the now-dead legacy parsers
+After Step 2, migrate-then-`rg` to confirm zero remaining uses, then delete (biome will fail otherwise):
+- In `interpreter.ts`: `parseCollation`, `parseNumericArg`, `parseBooleanArg`, `parseJsonArg`, `stripQuotesHelper`, and the `parseIndexFieldList`/`getNamedArgument`/`getPositionalArgument` imports (drop from the `./psl-helpers` import).
+- In `psl-helpers.ts`: `parseIndexFieldList`, `parseIndexFieldSegment`, `parseFieldList`, `splitTopLevel`, `getNamedArgument`, `getPositionalArgument`.
+- **Keep** (still used): `parseProjectionList` (splits the spec's `include`/`exclude` bracket-string → `wildcardProjection`), `getAttribute` (field `@id`/`@unique` presence checks), `lowerFirst` (collection naming), `parseQuotedStringLiteral` if still referenced, and anything else `rg` shows still-used.
+- **Verify each deletion with `rg` first** — if any candidate still has a use outside the index loop, keep it and report.
+
+## Step 4 — reword the stale comment
+`interpreter.ts` ~L536 has a comment naming the removed `parseIndexDirection` ("Replaces `parseIndexDirection` for…"). Reword it to describe the function's purpose without naming removed code (e.g. "Normalizes the index `type` value to a Mongo key direction, defaulting to ascending (1) when absent.").
+
+## Diagnostic-code shifts (operator "Option A")
+`@@textIndex` now rejects args it doesn't declare (`type`/`sparse`/`expireAfterSeconds`/`default_language`) as `PSL_INVALID_ATTRIBUTE_SYNTAX` (the old path silently ignored them). And bad-shape textIndex args (non-JSON `weights`/`filter`, malformed field element) become grammar errors. Non-existent-field references shift to `PSL_INVALID_ATTRIBUTE_SYNTAX` (via `fieldRef`), same as D5's split; relation-field-not-indexable stays `PSL_INDEX_FIELD_NOT_FOUND`. Grep the `@@textIndex` tests and update shifted assertions; keep the `PSL_INVALID_INDEX` (one-per-collection, textIndex+wildcard) cases.
+
+## Tests
+`@@textIndex` lowering must be byte-identical for valid schemas — the Mongo contract-psl suite (`interpreter.test.ts` has textIndex coverage: basic, weights, language/languageOverride, one-per-collection, textIndex+wildcard) + `fixtures:check` are the primary signal. Update only shifted bad-arg assertions. Tests-first for anything added.
+
+## Scope
+**In:** `buildTextIndexModelSpec`; the textIndex branch migration; deleting the orphaned parsers; the stale-comment reword; code-shift test updates. **Out:** `packages/1-framework` / `packages/2-sql`; the index-shape semantics (unchanged); `parseProjectionList`/`getAttribute`/`lowerFirst` (kept).
+
+## Constraints
+No `any`; no bare `as` (narrow the `weights`/element unions with `typeof`; keep the two-branch structure if a union forces a cast); no file-ext imports; never suppress biome; `pnpm` not `npm`. Commit once: `git commit -s` (DCO), explicit staging, no `--amend`, NO push, no GitHub. Read-only on `projects/**`, `.agents/**`.
+
+## Gates (all green, in order)
+1. `pnpm --filter @prisma-next/mongo-contract-psl build && typecheck && test`
+2. `pnpm fixtures:check` — clean, no Mongo contract drift
+3. `pnpm lint:deps` (0) and `pnpm lint:framework-vocabulary` (threshold unchanged; reword rather than bump)
+4. **Grep gate:** `rg -n "parseCollation|parseIndexFieldList|parseFieldList|splitTopLevel|parseNumericArg|parseBooleanArg|parseJsonArg|stripQuotesHelper|getNamedArgument|getPositionalArgument|parseIndexDirection" packages/2-mongo-family/2-authoring/contract-psl/src` → **zero** (all Mongo attribute-argument parsing is now spec-driven).
+
+## Report back
+`buildTextIndexModelSpec` shape; how you migrated the textIndex branch (unified vs two-branch) + how you handled the `parsed`-type union cast-free; the weights number-filter; which parsers you deleted (with the `rg`-confirmed zero) and which you kept + why; the stale-comment reword; which textIndex bad-arg tests shifted; the grep-gate result; all gate results; the commit SHA. If a `parsed`-type union forces a bare `as`, a deletion candidate is still used unexpectedly, or a `PSL_INVALID_INDEX`/textIndex assertion breaks in a way the brief doesn't cover, STOP and report.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/plan.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/plan.md
@@ -6,17 +6,18 @@ Substrate-then-consumers within the slice: D1 lands the Mongo-side wiring and pr
 
 | # | Dispatch | Outcome | Builds on | New kit |
 | - | -------- | ------- | --------- | ------- |
-| D1 | Mongo `InterpretCtx` wiring + `@map`/`@@map` | `mongo-attribute-specs.ts` exists (`buildFieldInterpretCtx`/`buildModelInterpretCtx`, `interpretFieldAttribute`/`interpretModelAttribute`, `findFieldAttributeNode`/`findModelAttributeNode`); `@map`/`@@map` lowered via a spec. Proves the seam end-to-end. | slice 1 kit | — |
-| D2 | `@id`, `@unique`/`@@unique` | Field `@id`/`@unique` + model `@@unique` spec-driven. | D1 wiring | — |
-| D3 | `@relation` (Mongo) | Mongo `@relation` (name positional/named alias, `fields`, `references`) spec-driven; `parseRelationAttribute` retired. | D1 wiring | — |
-| D4 | `@@discriminator`, `@@base` | Polymorphism attribute **argument shapes** spec-driven; cross-model consistency (`resolvePolymorphism`) untouched. | D1 wiring | — |
-| D5 | `@@index` / model `@@unique` core | Index field-element `oneOf(fieldRef, sortedFieldRef, wildcardPath)` + `type` `oneOf(num/str …)` spec-driven; `parseIndexFieldList`/`parseIndexDirection` retired; `PSL_INVALID_INDEX` + field-existence stay. | D2 (model wiring) | `str(value)`, `sortedFieldRef`, `wildcardPath` |
-| D6 | `@@textIndex` | Collation named args + `weights` (`map(fieldRef,int())`) + wildcardProjection spec-driven; `parseCollation`/`parseJsonArg`/`parseNumericArg`/`parseBooleanArg` retired; one-per-collection guard stays. | D5 | `map(key, value)` |
-| D7 | Delete legacy Mongo parsers | Remove the now-dead `psl-helpers.ts` arg parsers + interpreter-local parsers; grep gate → zero; final `fixtures:check`. | D1–D6 | — |
+| D1 ✅ | Mongo `InterpretCtx` wiring + `@map`/`@@map` | `mongo-attribute-specs.ts` exists (`buildFieldInterpretCtx`/`buildModelInterpretCtx`, `interpretFieldAttribute`/`interpretModelAttribute`, `findFieldAttributeNode`/`findModelAttributeNode`); `@map`/`@@map` lowered via a spec. Proves the seam end-to-end. **Done — commit `b6835dc09`.** | slice 1 kit | — |
+| D2 | `@relation` (Mongo) | Mongo `@relation` (name positional/named alias, `fields`, `references`) spec-driven; `parseRelationAttribute` retired. | D1 wiring | — |
+| D3 | `@@discriminator`, `@@base` | Polymorphism attribute **argument shapes** (field name; base/value) spec-driven; cross-model consistency (`resolvePolymorphism`) untouched. | D1 wiring | — |
+| D4 | `@@index` / model `@@unique` core | Index field-element `oneOf(fieldRef, sortedFieldRef, wildcardPath)` + `type` `oneOf(num/str …)` spec-driven; `parseIndexFieldList`/`parseIndexDirection` retired; `PSL_INVALID_INDEX` + field-existence stay. | D1 wiring | `str(value)`, `sortedFieldRef`, `wildcardPath` |
+| D5 | `@@textIndex` | Collation named args + `weights` (`map(fieldRef,int())`) + wildcardProjection spec-driven; `parseCollation`/`parseJsonArg`/`parseNumericArg`/`parseBooleanArg` retired; one-per-collection guard stays. | D4 | `map(key, value)` |
+| D6 | Delete legacy Mongo parsers | Remove the now-dead `psl-helpers.ts` arg parsers + interpreter-local parsers; grep gate → zero; final `fixtures:check`. | D1–D5 | — |
+
+> **Correction (post-D1 grounding).** Field `@id` and field `@unique` are **presence-only** in Mongo (`getAttribute(field.attributes, 'id'|'unique') !== undefined` — no arguments to parse), so they need no spec migration; `getAttribute` stays for them. Model `@@unique` is handled inside the index loop alongside `@@index`/`@@textIndex`, so it folds into D4, not a separate dispatch. The original "D2: @id/@unique/@@unique" is dropped and the remaining dispatches renumbered.
 
 ## Sequencing
 
-Stack: D1 → (D2, D3, D4 parallelizable after D1) → D5 → D6 → D7. D2/D3/D4 touch disjoint attribute sites and can be dispatched in parallel once D1's wiring lands; D5 depends on D2's model-attribute wiring; D6 builds on D5's index grammar; D7 is the closing sweep once every consumer is migrated.
+Stack: D1 (done) → (D2, D3 disjoint after D1) → D4 → D5 → D6. D2 (`@relation`) and D3 (polymorphism) touch disjoint attribute sites but share `interpreter.ts` + `mongo-attribute-specs.ts` as a write surface, so they run **sequentially on the branch** (not as parallel sub-agents) to avoid clobbering. D4 builds the index grammar; D5 builds on it for `@@textIndex`; D6 is the closing sweep once every consumer is migrated.
 
 ## Sizing note (Open Question 1 in the spec)
 

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/plan.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/plan.md
@@ -1,0 +1,30 @@
+# Slice `mongo-attributes` — dispatch plan
+
+**Spec:** `./spec.md` · **Branch:** `tml-2956-mongo-attributes` (off `origin/main`) · **Linear:** umbrella [TML-2956](https://linear.app/prisma-company/issue/TML-2956).
+
+Substrate-then-consumers within the slice: D1 lands the Mongo-side wiring and proves the seam on the simplest attribute; D2–D4 migrate the simple attributes; D5–D6 tackle the heavy index grammar (and build the kit pieces they consume); D7 removes the legacy parsers behind a grep gate. Each dispatch leaves the Mongo contract-psl suite + `fixtures:check` green.
+
+| # | Dispatch | Outcome | Builds on | New kit |
+| - | -------- | ------- | --------- | ------- |
+| D1 | Mongo `InterpretCtx` wiring + `@map`/`@@map` | `mongo-attribute-specs.ts` exists (`buildFieldInterpretCtx`/`buildModelInterpretCtx`, `interpretFieldAttribute`/`interpretModelAttribute`, `findFieldAttributeNode`/`findModelAttributeNode`); `@map`/`@@map` lowered via a spec. Proves the seam end-to-end. | slice 1 kit | — |
+| D2 | `@id`, `@unique`/`@@unique` | Field `@id`/`@unique` + model `@@unique` spec-driven. | D1 wiring | — |
+| D3 | `@relation` (Mongo) | Mongo `@relation` (name positional/named alias, `fields`, `references`) spec-driven; `parseRelationAttribute` retired. | D1 wiring | — |
+| D4 | `@@discriminator`, `@@base` | Polymorphism attribute **argument shapes** spec-driven; cross-model consistency (`resolvePolymorphism`) untouched. | D1 wiring | — |
+| D5 | `@@index` / model `@@unique` core | Index field-element `oneOf(fieldRef, sortedFieldRef, wildcardPath)` + `type` `oneOf(num/str …)` spec-driven; `parseIndexFieldList`/`parseIndexDirection` retired; `PSL_INVALID_INDEX` + field-existence stay. | D2 (model wiring) | `str(value)`, `sortedFieldRef`, `wildcardPath` |
+| D6 | `@@textIndex` | Collation named args + `weights` (`map(fieldRef,int())`) + wildcardProjection spec-driven; `parseCollation`/`parseJsonArg`/`parseNumericArg`/`parseBooleanArg` retired; one-per-collection guard stays. | D5 | `map(key, value)` |
+| D7 | Delete legacy Mongo parsers | Remove the now-dead `psl-helpers.ts` arg parsers + interpreter-local parsers; grep gate → zero; final `fixtures:check`. | D1–D6 | — |
+
+## Sequencing
+
+Stack: D1 → (D2, D3, D4 parallelizable after D1) → D5 → D6 → D7. D2/D3/D4 touch disjoint attribute sites and can be dispatched in parallel once D1's wiring lands; D5 depends on D2's model-attribute wiring; D6 builds on D5's index grammar; D7 is the closing sweep once every consumer is migrated.
+
+## Sizing note (Open Question 1 in the spec)
+
+Target ≤ ~7 dispatches. If, at D5, the index/textIndex diff plus the earlier attributes can't be held in one code review, split D5–D6 into a sibling slice/PR (`mongo-index`) — mirroring how `@default` split out of `sql-attributes`. Decision deferred to D5; surfaced to the operator then.
+
+## Kit-additions provenance
+
+- `num(value)` — already shipped (SQL slice, D8). Reused by the index `type` set.
+- `str(value)` — D5 (first consumer: index `type` digit-leading members).
+- `sortedFieldRef` / `wildcardPath` — D5 (index element `oneOf`).
+- `map(key, value)` — D6 (`@@textIndex` `weights`). `record(value)` = `map(str(), value)` already exists.

--- a/projects/typed-attribute-parsers/slices/mongo-attributes/spec.md
+++ b/projects/typed-attribute-parsers/slices/mongo-attributes/spec.md
@@ -1,0 +1,77 @@
+# Slice: mongo-attributes
+
+_(In-project slice. Parent: `projects/typed-attribute-parsers/`. Parallel group B of the project plan — independent of the SQL slices, builds only on slice 1's already-merged kit. Outcome it contributes: the **Mongo** family becomes spec-driven, completing "every attribute in every family validates its arguments through the kit".)_
+
+## At a glance
+
+Migrate the **Mongo** family's attribute argument-parsing off `ResolvedAttribute` + hand-written string helpers onto the declarative combinator kit (`interpretAttribute`), exactly as the SQL family already did. Mongo attributes in scope: `@id`, `@unique` / `@@unique`, `@@index`, `@@textIndex`, `@relation`, `@map` / `@@map`, `@@discriminator`, `@@base`.
+
+Current state (grounded):
+- `packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts` (~1363 lines) parses every attribute imperatively via `getPositionalArgument` / `getNamedArgument` and the `psl-helpers.ts` string parsers (`parseIndexFieldList`, `parseFieldList`, `parseRelationAttribute`, `stripQuotes`) plus interpreter-local `parseIndexDirection` / `parseNumericArg` / `parseBooleanArg` / `parseJsonArg` / `parseCollation`.
+- **No kit usage yet** — Mongo does not import `interpretAttribute` / `fieldAttribute` / `modelAttribute` / `InterpretCtx`, and there is no `mongo-attribute-specs.ts` and no Mongo-side `InterpretCtx` wiring.
+
+## Chosen design
+
+Mirror the SQL family's shape, in the Mongo package:
+
+1. **Mongo `InterpretCtx` wiring + wrappers.** A new `mongo-attribute-specs.ts` provides `buildFieldInterpretCtx` / `buildModelInterpretCtx` and `interpretFieldAttribute` / `interpretModelAttribute` (drain parse failures into `diagnostics`, return the typed value or `undefined`) — parallel to SQL's. Plus `findFieldAttributeNode` / `findModelAttributeNode`.
+2. **Per-attribute specs**, composed from kit combinators, replacing each imperative parse site in `interpreter.ts`.
+3. **New shared-kit combinators** (built in `psl-parser`, first-consumed here — the plan's carry-in):
+   - `str(value)` — pinned string literal (parallel to `num(value)` from the SQL slice). First consumer: the index `type` set, whose digit-leading members (`"2dsphere"`, `"2d"`) can only be quoted-string literals.
+   - `map(key, value)` — reads a `{…}` object literal into `Record<K,V>` (ADR § "Generic collections"). First consumer: `@@textIndex` `weights` (`map(fieldRef('self'), int())`). `record(value)` already exists as the `map(str(), value)` shorthand.
+   - `sortedFieldRef(scope)` and `wildcardPath()` — the two non-plain index-element shapes, so a Mongo index element is `oneOf(fieldRef('self'), sortedFieldRef('self'), wildcardPath())` (ADR § "Alternatives and function calls").
+4. **Mixed literal set as `oneOf`** (carry-in): the index `type` (`1`, `-1`, `"text"`, `"2dsphere"`, `"2d"`, `"hashed"`) becomes `oneOf(num(1), num(-1), str('text'), str('2dsphere'), str('2d'), str('hashed'))` — homogeneous-or-mixed with the quoted-vs-bare surface explicit per member (ADR § "Scalars").
+
+**What moves into the grammar (specs):** argument syntax only — the relation args (`name` alias / `fields` / `references`), the index field-list element shapes, the index `type` set, the `@@textIndex` collation named-arg shapes and `weights` map, the `@map` name, `@@discriminator` / `@@base` argument shapes.
+
+**What stays semantic (in the interpreter):** the index-shape validation that is not single-argument syntax — `PSL_INVALID_INDEX` (at-most-one wildcard, unique+wildcard forbidden, hashed→single-field, wildcard+`hashed`/`2dsphere`/`2d` forbidden), `PSL_INDEX_FIELD_NOT_FOUND` (field-existence against the model), the **one-`@@textIndex`-per-collection** rule (stays in Mongo's model-level aggregation, per the project spec — not a per-attribute `refine`), and the polymorphism cross-model rules (`@@discriminator`/`@@base` consistency across models).
+
+**Diagnostic codes:** shape/arity errors that today produce bespoke codes move to `PSL_INVALID_ATTRIBUTE_SYNTAX` where that is honest (operator "Option A", consistent with the SQL slices); genuinely-semantic codes (`PSL_INVALID_INDEX`, `PSL_INDEX_FIELD_NOT_FOUND`, the polymorphism codes) are preserved. Per-case shifts are pre-investigated at dispatch-authoring time and the asserting tests updated.
+
+## Coherence rationale
+
+One outcome — "the Mongo family is spec-driven on every attribute; the Mongo string parsers (`psl-helpers.ts` arg helpers + `parseIndexFieldList` / `parseRelationAttribute` / the interpreter-local collation/number/bool/json parsers) are deleted; no legacy Mongo attribute-argument parser remains (grep gate)." It parallels the SQL family migration and shares no mutable surface with it beyond the already-merged kit.
+
+## Scope
+
+**In:** `mongo-attribute-specs.ts` (wiring + wrappers + per-attribute specs); the `interpretAttribute` call-site migration in `interpreter.ts` for all in-scope attributes; the four new kit combinators (`str(value)`, `map`, `sortedFieldRef`, `wildcardPath`) with unit tests; deletion of the now-dead Mongo string parsers.
+
+**Out:**
+- **The interpreter's semantic checks** — `PSL_INVALID_INDEX` shape rules, `PSL_INDEX_FIELD_NOT_FOUND`, one-`@@textIndex`-per-collection, polymorphism cross-model consistency — all stay.
+- **SQL family** — already migrated (slices `sql-attributes` + `sql-default`).
+- **Language-server autocomplete** — project non-goal / deferred follow-up.
+- **`@db.*` native types** — project-wide out of scope.
+
+## Pre-investigated edge cases
+
+| Edge case | Disposition | Notes |
+| --------- | ----------- | ----- |
+| Index element `wildcard(scope)` / `field(sort: Desc)` / bare field | Grammar: `oneOf(fieldRef('self'), sortedFieldRef('self'), wildcardPath())` | Replaces `parseIndexFieldSegment`'s regexes. `sortedFieldRef` carries the `Asc`/`Desc` → `1`/`-1` direction; `wildcardPath` yields the `$**` / `scope.$**` path. |
+| Index `type` mixed str/num set | Grammar: `oneOf(num(1), num(-1), str('text'), str('2dsphere'), str('2d'), str('hashed'))` | Replaces `parseIndexDirection`. |
+| `@@textIndex` `weights: {field: n}` | Grammar: `map(fieldRef('self'), int())` (new `map` combinator) | Replaces `parseJsonArg` + the manual number-coercion loop. |
+| `@@textIndex` collation (`collationLocale`, `collationStrength`, …) | Grammar: named optional args (str / int / bool) on the spec | Replaces `parseCollation` + `parseNumericArg` / `parseBooleanArg`. The both-or-neither / dependency rules (if any) go in the spec's `refine`. |
+| Index-shape validity (wildcard count, unique+wildcard, hashed single-field, textIndex-per-collection) | Semantic; stays | `PSL_INVALID_INDEX` + the model-level textIndex-count guard remain in `interpreter.ts`. |
+| Index field existence | Semantic; stays | `PSL_INDEX_FIELD_NOT_FOUND` stays (checked against the model's indexable fields). |
+| `@relation` name positional-or-named alias | Grammar: positional `key:'name'` sharing the output key with named `name` | The alias mechanic the kit already models (ADR § "Positional and named arguments"). |
+| `@@discriminator` / `@@base` args | Grammar for arg shapes; cross-model consistency stays semantic | Field name / (base, value) argument shapes move to specs; the `@@discriminator`⇄`@@base` cross-model rules stay in `resolvePolymorphism`. |
+
+## Slice-specific done conditions
+
+- [ ] Every in-scope Mongo attribute is validated + lowered via a spec through `interpretAttribute`.
+- [ ] `psl-helpers.ts` arg-parsing (`getPositionalArgument`, `getNamedArgument`, `parseFieldList`, `parseIndexFieldList` + `parseIndexFieldSegment`, `parseRelationAttribute`, `stripQuotes`) and the interpreter-local `parseIndexDirection` / `parseNumericArg` / `parseBooleanArg` / `parseJsonArg` / `parseCollation` are deleted (`rg` each → zero) for every migrated attribute. Retained: `getMapName`/`getAttribute` only if still needed by surviving semantic code; `lowerFirst` (collection naming) stays.
+- [ ] Semantic codes preserved: `PSL_INVALID_INDEX`, `PSL_INDEX_FIELD_NOT_FOUND`, the polymorphism codes; the one-`@@textIndex`-per-collection guard intact.
+- [ ] `pnpm fixtures:check` clean (byte-identical Mongo contract output); the Mongo contract-psl test suite green; the four new combinators unit-tested; vocab green.
+
+## Open Questions
+
+_Open (surface to operator before the index/textIndex dispatches):_
+
+1. **One slice or two?** This slice migrates the whole Mongo family including the heavy `@@index` / `@@textIndex` (collation + weights + wildcard element grammar). If the diff outgrows a single-sitting review, the index/textIndex portion is the natural split into its own slice/PR (as `@default` was split out of `sql-attributes`). Recommendation: build in the dispatch order below and re-evaluate at D5; split if the review can't hold it.
+2. **`@@textIndex` collation surface.** Confirm whether the collation named args should stay a flat set of optional args on the `@@textIndex` spec (matches today's PSL surface) or move to a nested `map`/object — likely "flat optional args", but confirm against the ADR's native-literal surface policy at dispatch time.
+
+## References
+
+- Parent project: `projects/typed-attribute-parsers/spec.md`; project plan `projects/typed-attribute-parsers/plan.md` (slice `mongo-attributes`, parallel group B, with the D6 carry-in note).
+- SQL precedent to mirror: `packages/2-sql/2-authoring/contract-psl/src/sql-attribute-specs.ts` (wiring + wrappers + specs); the merged `sql-default` slice under `projects/typed-attribute-parsers/slices/sql-default/`.
+- Mongo current state: `packages/2-mongo-family/2-authoring/contract-psl/src/interpreter.ts`, `.../src/psl-helpers.ts`.
+- Kit: `packages/1-framework/2-authoring/psl-parser/src/attribute-spec/**`; ADR 231 (§ "The combinator kit", § "Alternatives and function calls").

--- a/skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md
+++ b/skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md
@@ -1,0 +1,29 @@
+---
+from: "8.0.0-rc.8"
+to: "8.0.0-rc.9"
+changes:
+  - id: mongo-index-projections-use-native-lists
+    summary: |
+      MongoDB wildcard index `include` and `exclude` projections in Prisma schema files must use native PSL lists instead of encoded list strings.
+    detection:
+      glob: "**/*.prisma"
+      matches:
+        - '\b(?:include|exclude)\s*:\s*"\[[^"\r\n]*\]"'
+  - id: mongo-text-index-weights-use-native-records
+    summary: |
+      MongoDB text-index `weights` in Prisma schema files must use native PSL records instead of encoded JSON strings.
+    detection:
+      glob: "**/*.prisma"
+      matches:
+        - '\bweights\s*:\s*"\{\s*(?:\\.|[^"\\])*\}"'
+---
+
+# 8.0.0-rc.8 → 8.0.0-rc.9 — User upgrade instructions
+
+## `mongo-index-projections-use-native-lists`
+
+For every Prisma schema matched by `detection`, replace encoded projection strings with native PSL lists. For example, change `include: "[a, b]"` to `include: ["a", "b"]` and `exclude: "[a]"` to `exclude: ["a"]`. Decode each string's fields in their existing order and preserve whether the argument is `include` or `exclude`.
+
+## `mongo-text-index-weights-use-native-records`
+
+For every Prisma schema matched by `detection`, replace the encoded JSON string passed to `weights` with a native PSL record. For example, change `weights: "{\"title\": 10}"` to `weights: { title: 10 }`, preserving every field name and numeric weight.

--- a/test/integration/test/mongo/migration-psl-authoring.test.ts
+++ b/test/integration/test/mongo/migration-psl-authoring.test.ts
@@ -386,7 +386,7 @@ describe('PSL authoring → migration E2E', { timeout: timeouts.spinUpMongoMemor
         id       ObjectId @id @map("_id")
         metadata String
         tags     String
-        @@index([wildcard()], include: "[metadata, tags]")
+        @@index([wildcard()], include: ["metadata", "tags"])
       }
     `);
 
@@ -403,7 +403,7 @@ describe('PSL authoring → migration E2E', { timeout: timeouts.spinUpMongoMemor
       model Events {
         id       ObjectId @id @map("_id")
         internal String
-        @@index([wildcard()], exclude: "[internal]")
+        @@index([wildcard()], exclude: ["internal"])
       }
     `);
 
@@ -440,7 +440,7 @@ describe('PSL authoring → migration E2E', { timeout: timeouts.spinUpMongoMemor
         id    ObjectId @id @map("_id")
         title String
         body  String
-        @@textIndex([title, body], weights: "{\\"title\\": 10, \\"body\\": 5}", language: "english")
+        @@textIndex([title, body], weights: { title: 10, body: 5 }, language: "english")
       }
     `);
 


### PR DESCRIPTION
## Linked issue

Refs [TML-2956](https://linear.app/prisma-company/issue/TML-2956) — Language Tools Support Prisma Next PSL.

Completes the Mongo-family migration onto the declarative attribute-spec kit introduced by the preceding SQL slices.

## At a glance

```prisma
@@textIndex([name, description], weights: { name: 10, description: 1 })
```

Mongo text-index weights now use a native typed PSL record; wildcard projections similarly use native string lists such as `include: ["metadata", "nested.path"]`.

## Decision

This PR makes Mongo PSL attribute argument parsing spec-driven:

1. Mongo model- and field-level attributes are interpreted through typed `AttributeSpec` definitions and shared wrappers around `interpretAttribute`.
2. Index specs are built from the current model so field references, sorted field calls, and wildcard calls compose from `fieldRef`, `funcCall`, `list`, and `oneOf`.
3. Mongo index values use native combinators: projections are `list(str())`, text weights are `record(int({ min: 1, max: 99_999 }))`, and quoted JSON remains only for the `filter` exception.
4. The legacy attribute string parsers and post-parse normalization they replaced are removed.
5. Consumer schemas receive executable upgrade instructions for the two syntax migrations.

## Reviewer notes

- `include` and `exclude` intentionally accept strings rather than model field references because Mongo wildcard projections may contain arbitrary dotted paths and dynamically shaped document fields.
- Missing model fields are rejected by the typed grammar as `PSL_INVALID_ATTRIBUTE_SYNTAX`; fields that exist but cannot be indexed, such as relation fields, retain semantic index diagnostics.
- `@@textIndex` exposes only its supported arguments. Index-only options that were previously ignored are now rejected as invalid syntax.
- `filter` remains quoted JSON. Native records are introduced specifically for `weights`, where the key/value shape is known and can support future language tooling.

## How it fits together

1. `mongo-attribute-specs.ts` provides model- and field-level interpretation contexts and wrappers that convert parser failures into contract diagnostics.
2. Simple attributes such as `@map`, `@@map`, `@relation`, `@@discriminator`, and `@@base` declare their positional and named arguments directly.
3. Index field elements are assembled per model from `fieldRef('self')`, typed sorted-field `funcCall` arms, and the wildcard function call.
4. `@@index`, `@@unique`, and `@@textIndex` compose those field elements with typed options for collation, projections, filters, and weights.
5. The interpreter consumes the typed output and retains only cross-field and cross-model semantic validation.

## Behavior changes & evidence

- **Mongo attributes now reject malformed arguments through one typed grammar.** The specs and wrappers live in [`mongo-attribute-specs.ts`](packages/2-mongo-family/2-authoring/contract-psl/src/mongo-attribute-specs.ts), with interpreter behavior covered by [`interpreter.test.ts`](packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.test.ts) and [`interpreter.polymorphism.test.ts`](packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts).
- **Index projections use native PSL lists.** `include` and `exclude` are declared as `list(str())`; integration coverage is in [`migration-psl-authoring.test.ts`](test/integration/test/mongo/migration-psl-authoring.test.ts).
- **Text-index weights use a bounded native record.** Keys are preserved, including prototype-named keys, and values must be integers from 1 through 99,999. Combinator behavior is covered by [`attribute-spec-combinators.test.ts`](packages/1-framework/2-authoring/psl-parser/test/attribute-spec-combinators.test.ts), while the retail example and migration snapshots exercise contract and migration regeneration.
- **Pinned combinator literals preserve exact output types.** [`str.ts`](packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts) and [`num.ts`](packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/num.ts) support exact alternatives used by index type and collation specs.

## Compatibility / migration / risk

This intentionally changes two Prisma schema syntaxes:

```prisma
// Before
@@index([wildcard()], include: "[metadata, nested.path]")
@@textIndex([title, body], weights: "{\"title\": 10, \"body\": 5}")

// After
@@index([wildcard()], include: ["metadata", "nested.path"])
@@textIndex([title, body], weights: { title: 10, body: 5 })
```

The migration is recorded in [`skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md`](skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md).

## Testing performed

- `pnpm --filter @prisma-next/mongo-contract-psl build && pnpm --filter @prisma-next/mongo-contract-psl typecheck && pnpm --filter @prisma-next/mongo-contract-psl test` — 155 tests passed.
- `pnpm --filter @prisma-next/psl-parser build && pnpm --filter @prisma-next/psl-parser typecheck && pnpm --filter @prisma-next/psl-parser test` — 635 tests passed.
- `pnpm test:integration` — 2,061 tests passed with 53 expected failures and no type errors.
- `pnpm --filter retail-store test` — 55 tests passed.
- `pnpm build` — 85 tasks passed.
- `pnpm fixtures:check` — passed after updating the retail migration lineage to native weight records.
- `pnpm check:upgrade-coverage` — passed.
- `git diff --check` — passed.

## Skill update

Added executable app upgrade instructions under [`skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/`](skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/) for native Mongo projection lists and text-index weight records.

## Alternatives considered

- **Keep encoded projection and weight strings.** Rejected because their structure would remain opaque to typed parsing and future language tooling, while requiring redundant post-validation.
- **Use model field references for wildcard projections.** Rejected because Mongo permits arbitrary dotted projection paths that need not correspond to declared model fields.
- **Add dedicated sorted-field and wildcard combinators.** Rejected because the existing `oneOf`, `fieldRef`, and typed `funcCall` combinators express the grammar from the model context without expanding the kit.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read `CONTRIBUTING.md` and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title is in `TML-NNNN: <sentence-case title>` form.
- [x] The Skill update section is filled in.
