### PR TITLE
fix(adapter-better-sqlite3): infer Bytes for Buffer BLOB values

### DIFF
--- a/packages/adapter-better-sqlite3/src/conversion.test.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.test.ts
@@ -8,7 +8,7 @@ describe('getColumnTypes', () => {
     ['Buffer', Buffer.from([0xde, 0xad, 0xbe, 0xef])],
     ['Uint8Array', new Uint8Array([0xde, 0xad, 0xbe, 0xef])],
     ['ArrayBuffer', new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer],
-  ])('should infer Bytes for a %s value in a column with no declared type', (_name, value) => {
+  ])('infers Bytes for a %s value in a column with no declared type', (_name, value) => {
     const row: Row = { length: 1, 0: value as Row[number] }
     expect(getColumnTypes([null], [row])).toEqual([ColumnTypeEnum.Bytes])
   })

--- a/packages/adapter-better-sqlite3/src/conversion.test.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.test.ts
@@ -1,0 +1,15 @@
+import { ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+import { describe, expect, it } from 'vitest'
+
+import { getColumnTypes, type Row } from './conversion'
+
+describe('getColumnTypes', () => {
+  it.each([
+    ['Buffer', Buffer.from([0xde, 0xad, 0xbe, 0xef])],
+    ['Uint8Array', new Uint8Array([0xde, 0xad, 0xbe, 0xef])],
+    ['ArrayBuffer', new Uint8Array([0xde, 0xad, 0xbe, 0xef]).buffer],
+  ])('should infer Bytes for a %s value in a column with no declared type', (_name, value) => {
+    const row: Row = { length: 1, 0: value as Row[number] }
+    expect(getColumnTypes([null], [row])).toEqual([ColumnTypeEnum.Bytes])
+  })
+})

--- a/packages/adapter-better-sqlite3/src/conversion.ts
+++ b/packages/adapter-better-sqlite3/src/conversion.ts
@@ -129,7 +129,7 @@ function inferColumnType(value: NonNullable<Value>): ColumnType {
 }
 
 function inferObjectType(value: {}): ColumnType {
-  if (value instanceof ArrayBuffer) {
+  if (value instanceof ArrayBuffer || value instanceof Uint8Array) {
     return ColumnTypeEnum.Bytes
   }
   throw new UnexpectedTypeError(value)


### PR DESCRIPTION
## Description

better-sqlite3 hands back BLOB values as Node `Buffer`s, but `inferObjectType` only recognized `ArrayBuffer`. So a BLOB from an untyped column or expression, like `SELECT X'DEADBEEF'`, threw `UnexpectedTypeError` instead of mapping to `Bytes`. `Buffer` is a `Uint8Array` subclass, so this checks for `Uint8Array` alongside `ArrayBuffer`.

Fixes #29868


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic data type detection for binary values.
  - `Uint8Array` values are now correctly recognized as byte data, alongside existing support for `ArrayBuffer` and `Buffer`.

- **Tests**
  - Added coverage to verify binary type detection across supported buffer formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->