### PR TITLE
fix(adapter-pg): serialize queries on single-connection clients

### DIFF
--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -153,3 +153,82 @@ describe('PrismaPgAdapterFactory', () => {
     await adapter.dispose()
   })
 })
+
+describe('query serialization', () => {
+  const query = (sql: string): SqlQuery => ({ sql, args: [], argTypes: [] })
+  const emptyResult = { rows: [], fields: [], rowCount: 0 }
+
+  function trackingQueryMock() {
+    let inFlight = 0
+    let maxInFlight = 0
+    const started: string[] = []
+    const mock = vi.fn(async ({ text }: { text: string }) => {
+      started.push(text)
+      maxInFlight = Math.max(maxInFlight, ++inFlight)
+      await new Promise((resolve) => setImmediate(resolve))
+      inFlight--
+      return emptyResult
+    })
+    return { mock, started, maxInFlight: () => maxInFlight }
+  }
+
+  async function connectedAdapter() {
+    const factory = new PrismaPgAdapterFactory('postgresql://test:test@localhost:5432/test')
+    return await factory.connect()
+  }
+
+  it('serializes concurrent queries on a transaction connection', async () => {
+    const adapter = await connectedAdapter()
+    const { mock, maxInFlight } = trackingQueryMock()
+    const mockConnection = { on: vi.fn(), removeListener: vi.fn(), query: mock, release: vi.fn() }
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const transaction = await adapter.startTransaction()
+    await Promise.all([
+      transaction.queryRaw(query('SELECT 1')),
+      transaction.queryRaw(query('SELECT 2')),
+      transaction.queryRaw(query('SELECT 3')),
+    ])
+
+    // A pg.PoolClient is a single connection: queries must never overlap.
+    expect(maxInFlight()).toBe(1)
+    await transaction.commit()
+    await adapter.dispose()
+  })
+
+  it('does not serialize queries on the pool', async () => {
+    const adapter = await connectedAdapter()
+    const { mock, maxInFlight } = trackingQueryMock()
+    adapter['client'].query = mock
+
+    await Promise.all([
+      adapter.queryRaw(query('SELECT 1')),
+      adapter.queryRaw(query('SELECT 2')),
+      adapter.queryRaw(query('SELECT 3')),
+    ])
+
+    // The pool handles concurrency itself; serializing here would limit the
+    // whole application to one query at a time.
+    expect(maxInFlight()).toBe(3)
+    await adapter.dispose()
+  })
+
+  it('keeps serializing after a failed query', async () => {
+    const adapter = await connectedAdapter()
+    const mock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyResult) // BEGIN
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue(emptyResult)
+    const mockConnection = { on: vi.fn(), removeListener: vi.fn(), query: mock, release: vi.fn() }
+    adapter['client'].connect = vi.fn().mockResolvedValue(mockConnection)
+
+    const tx = await adapter.startTransaction()
+    const failing = tx.queryRaw(query('SELECT 1'))
+    const following = tx.queryRaw(query('SELECT 2'))
+
+    await expect(failing).rejects.toThrow()
+    await expect(following).resolves.toBeDefined()
+    await adapter.dispose()
+  })
+})

--- a/packages/adapter-pg/src/__tests__/pg.test.ts
+++ b/packages/adapter-pg/src/__tests__/pg.test.ts
@@ -1,3 +1,5 @@
+import timers from 'node:timers/promises'
+
 import { getLogs } from '@prisma/debug'
 import type { SqlQuery } from '@prisma/driver-adapter-utils'
 import pg, { DatabaseError } from 'pg'
@@ -165,7 +167,7 @@ describe('query serialization', () => {
     const mock = vi.fn(async ({ text }: { text: string }) => {
       started.push(text)
       maxInFlight = Math.max(maxInFlight, ++inFlight)
-      await new Promise((resolve) => setImmediate(resolve))
+      await timers.setImmediate()
       inFlight--
       return emptyResult
     })

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -37,7 +37,9 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
   // be serialized. `pg.Pool` handles concurrency itself and must not be
   // serialized, or the whole pool would be limited to one query at a time.
   protected readonly serializeQueries: boolean = true
-  #queryLock: Promise<unknown> = Promise.resolve()
+  // Resolve-only lock: it tracks completion of the previous query and can
+  // never carry its error, so a failed query rejects only its own caller.
+  #queryLock: Promise<void> = Promise.resolve()
 
   constructor(
     protected readonly client: ClientT,
@@ -110,11 +112,14 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
       return this.#performIO(query)
     }
     const previous = this.#queryLock
-    const current = previous.then(() => this.#performIO(query))
-    // Keep the lock chain alive even if the query fails; the failure still
-    // propagates to the caller through `current`.
-    this.#queryLock = current.catch(() => {})
-    return current
+    let release!: () => void
+    this.#queryLock = new Promise((resolve) => (release = resolve))
+    await previous
+    try {
+      return await this.#performIO(query)
+    } finally {
+      release()
+    }
   }
 
   async #performIO(query: SqlQuery): Promise<pg.QueryArrayResult<any>> {

--- a/packages/adapter-pg/src/pg.ts
+++ b/packages/adapter-pg/src/pg.ts
@@ -32,6 +32,13 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
   readonly provider = 'postgres'
   readonly adapterName = packageName
 
+  // `pg.Client` and `pg.PoolClient` are single connections and don't support
+  // concurrent queries (deprecated in pg@8, an error in pg@9), so queries must
+  // be serialized. `pg.Pool` handles concurrency itself and must not be
+  // serialized, or the whole pool would be limited to one query at a time.
+  protected readonly serializeQueries: boolean = true
+  #queryLock: Promise<unknown> = Promise.resolve()
+
   constructor(
     protected readonly client: ClientT,
     protected readonly pgOptions?: PrismaPgOptions,
@@ -99,6 +106,18 @@ class PgQueryable<ClientT extends StdClient | TransactionClient> implements SqlQ
    * marked as unhealthy.
    */
   private async performIO(query: SqlQuery): Promise<pg.QueryArrayResult<any>> {
+    if (!this.serializeQueries) {
+      return this.#performIO(query)
+    }
+    const previous = this.#queryLock
+    const current = previous.then(() => this.#performIO(query))
+    // Keep the lock chain alive even if the query fails; the failure still
+    // propagates to the caller through `current`.
+    this.#queryLock = current.catch(() => {})
+    return current
+  }
+
+  async #performIO(query: SqlQuery): Promise<pg.QueryArrayResult<any>> {
     const { sql, args } = query
     const values = args.map((arg, i) => mapArg(arg, query.argTypes[i]))
 
@@ -197,6 +216,8 @@ export type UserDefinedTypeParser = (oid: number, value: unknown, adapter: SqlQu
 export type StatementNameGenerator = (query: SqlQuery) => string
 
 export class PrismaPgAdapter extends PgQueryable<StdClient> implements SqlDriverAdapter {
+  protected override readonly serializeQueries = false
+
   constructor(
     client: StdClient,
     protected readonly pgOptions?: PrismaPgOptions,

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
@@ -95,6 +95,47 @@ test('merges chunked query results without overflowing the stack', async () => {
   expect(result).toHaveLength(rowsPerLaterChunk)
 })
 
+// Loading sibling relations concurrently is intentional: adapters whose connection
+// cannot run queries concurrently (e.g. a single pg connection) are responsible for
+// serializing them in `performIO` (see https://github.com/prisma/prisma/issues/29407).
+// This pins the interpreter side of that contract so join loading stays parallel.
+test('loads join children in parallel', async () => {
+  let inFlight = 0
+  let maxInFlight = 0
+  const queryable: SqlQueryable = {
+    provider: 'postgres',
+    adapterName: 'test',
+    queryRaw: async () => {
+      maxInFlight = Math.max(maxInFlight, ++inFlight)
+      await new Promise((resolve) => setImmediate(resolve))
+      inFlight--
+      return userResultSet(1, 'Alice')
+    },
+    executeRaw: () => Promise.resolve(0),
+  }
+
+  const joinChild = (parentField: string) => ({
+    child: queryNode(`SELECT * FROM ${parentField}`),
+    on: [['id', 'id']] as [string, string][],
+    parentField,
+    isRelationUnique: true,
+  })
+
+  const queryPlan: QueryPlanNode = {
+    type: 'join',
+    args: {
+      parent: queryNode('SELECT * FROM users'),
+      children: [joinChild('posts'), joinChild('profile'), joinChild('settings')],
+      canAssumeStrictEquality: true,
+    },
+  }
+
+  const interpreter = QueryInterpreter.forSql({ tracingHelper: noopTracingHelper })
+  await interpreter.run(queryPlan, { queryable, transactionManager: { enabled: false }, scope: {} })
+
+  expect(maxInFlight).toBe(3)
+})
+
 class MockTransactionAdapter implements SqlDriverAdapter {
   adapterName = 'mock-adapter'
   provider = 'postgres' as const

--- a/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
+++ b/packages/client-engine-runtime/src/interpreter/query-interpreter.test.ts
@@ -1,3 +1,5 @@
+import timers from 'node:timers/promises'
+
 import {
   ColumnTypeEnum,
   SqlDriverAdapter,
@@ -107,16 +109,16 @@ test('loads join children in parallel', async () => {
     adapterName: 'test',
     queryRaw: async () => {
       maxInFlight = Math.max(maxInFlight, ++inFlight)
-      await new Promise((resolve) => setImmediate(resolve))
+      await timers.setImmediate()
       inFlight--
       return userResultSet(1, 'Alice')
     },
     executeRaw: () => Promise.resolve(0),
   }
 
-  const joinChild = (parentField: string) => ({
+  const joinChild = (parentField: string): Extract<QueryPlanNode, { type: 'join' }>['args']['children'][number] => ({
     child: queryNode(`SELECT * FROM ${parentField}`),
-    on: [['id', 'id']] as [string, string][],
+    on: [['id', 'id']],
     parentField,
     isRelationUnique: true,
   })


### PR DESCRIPTION
## Problem

`@prisma/adapter-pg` emits `DeprecationWarning: Calling client.query() when the client is already executing a query` whenever a query with 2+ sibling relations runs inside a transaction. The query interpreter's `join` node loads relations concurrently; a `pg.Pool` tolerates this, but a transaction's single `pg.PoolClient` does not — and pg@9 will make it a hard error.

Fixes #29407.

## Fix

Per @aqrln's review on #29468, serialization is done in the base `PgQueryable.performIO` rather than in `PgTransaction` — the constraint is the single connection, not transactions per se. `PrismaPgAdapter` opts out via a `serializeQueries` flag: the pool manages its own concurrency, and serializing it would cap the whole application at one query at a time. A small promise-chain lock replaces #29468's `async-mutex` dependency.

The interpreter is deliberately untouched: join fan-out stays parallel (a regression test now pins this) and adapters own the serialization.

## Tests

- transaction connection never sees overlapping `client.query()` calls (fails without the fix)
- pool queries stay parallel — guards against reintroducing a global bottleneck
- a failed query releases the lock, so an error can't deadlock the rest of the transaction
- interpreter: `join` children still load in parallel

## Credit

This supersedes #29468 by @matingathani, who identified the issue and proposed the original mutex approach — picking it up as the review feedback has been open since 2026-07-28. Thanks also to @tensordreams for their contributions to that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction query handling so queries execute sequentially and continue correctly after a query failure.
  * Preserved concurrent query execution for connection pools and join-related child queries.

* **Tests**
  * Added coverage for transaction serialization, pool concurrency, failure recovery, and concurrent join queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->