### PR TITLE
fix(contract): preserve empty model fields

### DIFF
--- a/packages/1-framework/0-foundation/contract/src/canonicalization.ts
+++ b/packages/1-framework/0-foundation/contract/src/canonicalization.ts
@@ -1,4 +1,5 @@
 import { isArrayEqual } from '@internal/utils/array-equal';
+import { blindCast } from '@internal/utils/casts';
 import { ifDefined } from '@internal/utils/defined';
 import type { JsonObject } from '@internal/utils/json';
 import { matchesPathPattern, type PathPattern } from './canonicalization-path-match';
@@ -47,6 +48,14 @@ const DOMAIN_MODEL_RELATIONS_PATTERN = [
   'models',
   '*',
   'relations',
+] as const satisfies PathPattern;
+const DOMAIN_MODEL_FIELDS_PATTERN = [
+  'domain',
+  'namespaces',
+  '*',
+  'models',
+  '*',
+  'fields',
 ] as const satisfies PathPattern;
 const DOMAIN_MODEL_STORAGE_PATTERN = [
   'domain',
@@ -142,6 +151,7 @@ function omitDefaults(
         'defaults',
       ]);
       const isExtensionNamespace = currentPath.length === 2 && currentPath[0] === 'extensions';
+      const isModelFields = matchesPathPattern(currentPath, DOMAIN_MODEL_FIELDS_PATTERN);
       const isModelRelations = matchesPathPattern(currentPath, DOMAIN_MODEL_RELATIONS_PATTERN);
       const isModelStorage = matchesPathPattern(currentPath, DOMAIN_MODEL_STORAGE_PATTERN);
 
@@ -161,6 +171,7 @@ function omitDefaults(
         !isRequiredMeta &&
         !isRequiredExecutionDefaults &&
         !isExtensionNamespace &&
+        !isModelFields &&
         !isModelRelations &&
         !isModelStorage &&
         !isNullableField &&
@@ -186,9 +197,10 @@ function sortObjectKeys(obj: unknown): unknown {
   }
 
   const sorted: Record<string, unknown> = {};
-  const keys = Object.keys(obj).sort();
+  const record = Object.fromEntries(Object.entries(obj));
+  const keys = Object.keys(record).sort();
   for (const key of keys) {
-    sorted[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+    sorted[key] = sortObjectKeys(record[key]);
   }
 
   return sorted;
@@ -266,14 +278,17 @@ export function canonicalizeContractToObject(
     ...ifDefined('defaultControlPolicy', serialized['defaultControlPolicy']),
     meta: serialized['meta'],
   };
-  const withDefaultsOmitted = omitDefaults(normalized, [], options.shouldPreserveEmpty) as Record<
-    string,
-    unknown
-  >;
+  const withDefaultsOmitted = blindCast<
+    Record<string, unknown>,
+    'omitDefaults preserves the record shape of its normalized contract input'
+  >(omitDefaults(normalized, [], options.shouldPreserveEmpty));
   const withSortedStorage = options.sortStorage
     ? { ...withDefaultsOmitted, storage: options.sortStorage(withDefaultsOmitted['storage']) }
     : withDefaultsOmitted;
-  const withSortedKeys = sortObjectKeys(withSortedStorage) as Record<string, unknown>;
+  const withSortedKeys = blindCast<
+    Record<string, unknown>,
+    'sortObjectKeys preserves the record shape of its contract input'
+  >(sortObjectKeys(withSortedStorage));
   return orderTopLevel(withSortedKeys);
 }
 

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -1,7 +1,10 @@
+import { canonicalizeContractToObject } from '@internal/contract/hashing';
 import type { Contract } from '@internal/contract/types';
 import { crossRef } from '@internal/contract/types';
 import type { CodecLookup } from '@internal/framework-components/codec';
 import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
+import { MongoContractSchema } from '@internal/mongo-contract';
+import { mongoContractCanonicalizationHooks } from '@internal/mongo-contract/canonicalization-hooks';
 
 function modelsOf(ir: Contract): Record<string, unknown> {
   return ir.domain.namespaces[UNBOUND_NAMESPACE_ID]!.models;
@@ -10,6 +13,7 @@ function modelsOf(ir: Contract): Record<string, unknown> {
 import { buildSymbolTable, type SymbolTable } from '@internal/psl-parser';
 import type { SourceFile } from '@internal/psl-parser/syntax';
 import { parse } from '@internal/psl-parser/syntax';
+import type { JsonObject } from '@internal/utils/json';
 import { describe, expect, it } from 'vitest';
 import { interpretPslDocumentToMongoContract } from '../src/interpreter';
 import { expectInvalidAttributeSyntax } from './interpreter-test-helpers';
@@ -129,6 +133,38 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
       `);
 
       expect(modelsOf(ir)['Bug']).toMatchObject({ base: crossRef('Task') });
+    });
+
+    it('preserves empty fields on a field-less variant through canonicalization', () => {
+      const ir = interpretOk(`
+        model Post {
+          id    ObjectId @id @map("_id")
+          title String
+          kind  String
+
+          @@discriminator(kind)
+          @@map("posts")
+        }
+
+        model Note {
+          @@base(Post, "note")
+        }
+      `);
+
+      expect(modelsOf(ir)['Note']).toMatchObject({ fields: {} });
+
+      const canonical = canonicalizeContractToObject(ir, {
+        serializeContract: (contract) => JSON.parse(JSON.stringify(contract)) as JsonObject,
+        shouldPreserveEmpty: mongoContractCanonicalizationHooks.shouldPreserveEmpty,
+      });
+      const note = (
+        canonical['domain'] as {
+          namespaces: Record<string, { models: Record<string, unknown> }>;
+        }
+      ).namespaces[UNBOUND_NAMESPACE_ID]!.models['Note'];
+
+      expect(note).toMatchObject({ fields: {} });
+      expect(() => MongoContractSchema.assert(canonical)).not.toThrow();
     });
 
     it('variant inherits base collection (single-collection)', () => {

--- a/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/test/interpreter.polymorphism.test.ts
@@ -151,7 +151,7 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
         }
       `);
 
-      expect(modelsOf(ir)['Note']).toMatchObject({ fields: {} });
+      expect(modelsOf(ir)['Note']).toHaveProperty('fields', {});
 
       const canonical = canonicalizeContractToObject(ir, {
         serializeContract: (contract) => JSON.parse(JSON.stringify(contract)) as JsonObject,
@@ -163,7 +163,7 @@ describe('interpretPslDocumentToMongoContract — polymorphism', () => {
         }
       ).namespaces[UNBOUND_NAMESPACE_ID]!.models['Note'];
 
-      expect(note).toMatchObject({ fields: {} });
+      expect(note).toHaveProperty('fields', {});
       expect(() => MongoContractSchema.assert(canonical)).not.toThrow();
     });
 


### PR DESCRIPTION
## Linked issue

Fixes #30130

Refs prisma/prisma-next#1070
## Summary

Field-less variant models correctly produce `fields: {}` during PSL interpretation, but contract canonicalization removed that empty object even though `fields` is a required model property.

This change preserves empty model `fields` during canonicalization so emitted contracts remain structurally valid.

## Testing performed

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:packages`
- Targeted `@internal/contract` tests
- Targeted `@internal/mongo-contract-psl` tests
- Targeted Mongo emitter tests
- `git diff --check`

The full package suite had unrelated transient failures under load; the affected package suites passed when rerun separately.

## Skill update

n/a — internal only

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco). The DCO status check will block merge if any commit is missing a `Signed-off-by:` trailer.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated (or `n/a` if the change is doc-only / refactor with no behavioural delta).
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form (Linear ticket prefix + concise title naming the concrete deliverable). See `.claude/skills/create-pr/SKILL.md` for the full convention.
- [x] The **Skill update** section above is filled in (or stated `n/a — internal only`).

## Notes for the reviewer

This issue was originally reported as prisma/prisma-next#1070 and has now been re-filed in the current repository as #30130 after Prisma Next moved to `prisma/prisma` as Prisma ORM v8.

The fix is applied in generic contract canonicalization rather than the Mongo-specific canonicalization hook because `fields` is a required model property at the framework contract level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Preserved empty model-field containers during contract canonicalization, preventing field-less variants from losing their expected structure.
- Ensured field-less polymorphic variants remain compatible with Mongo schema validation.
- Maintained consistent canonicalized output without changing existing runtime behavior.

## Tests

- Added regression coverage confirming field-less variants retain `fields: {}` before and after canonicalization and pass Mongo schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->