### PR TITLE
fix(deps): bump deepmerge-ts from 7.1.5 to 8.0.1

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,7 @@
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
     "c12": "3.3.4",
-    "deepmerge-ts": "7.1.5",
+    "deepmerge-ts": "8.0.1",
     "effect": "3.20.0",
     "empathic": "2.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1177,8 +1177,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4(magicast@0.5.2)
       deepmerge-ts:
-        specifier: 7.1.5
-        version: 7.1.5
+        specifier: 8.0.1
+        version: 8.0.1
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5522,8 +5522,8 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.2.2:
@@ -12639,7 +12639,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.2.2: {}
 


### PR DESCRIPTION
## What this fixes

`pnpm audit --prod` is what `test-template.yml` gates on, and on `v7` it currently reports one high advisory: [GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx) / CVE-2026-40345, uncontrolled recursion in `deepmerge-ts`, reached through `packages__config>deepmerge-ts`. Patched in 8.0.0.

Since `@prisma/config` pins the exact version, every downstream install is held at 7.1.5 and package managers cannot dedupe up to a patched release, so consumers have to carry their own `overrides` / `resolutions` to clear the finding.

## Changes

Bumps `deepmerge-ts` from 7.1.5 to 8.0.1 in `packages/config`, plus the lockfile.

I bumped the manifest instead of adding a `pnpm-workspace.yaml` override, since everything in that block is a transitive dependency. `deepmerge-ts` is declared directly by `@prisma/config`, so an override would quiet the audit here while the published manifest still pointed downstream at 7.1.5.

8.0.0 is a major release, so I checked its breaking changes against the only call site, the `deepmerge` passed as the c12 `merger` in `loadConfigTsOrJs`:

- Map values now merge recursively by default, and config objects do not carry Maps.
- `deepmergeInto` is not used here, only the plain `deepmerge` export is.
- The `DeepMergeMetaMetaData` and `DeepMergeIntoFunctionUtils` renames touch types this package never references.

The `@ts-expect-error` above `merger` is still required, so the c12 type mismatch it covers is unchanged.

## How I checked

- `pnpm audit --prod`: `No known vulnerabilities found`, against 1 high before the bump
- `pnpm --filter @prisma/config test`: 142 passed, 2 skipped
- `pnpm --filter "@prisma/config..." build` and `tsc --noEmit -p packages/config` both clean
- `CI=true pnpm install --frozen-lockfile` passes
- Advisory itself: merging two self-referential objects throws `RangeError: Maximum call stack size exceeded` on 7.1.5 and returns normally on 8.0.1

Fixes #30052
