### PR TITLE
fix(target-postgres): measure identifier length in bytes, not characters

### DIFF
--- a/packages/3-targets/3-targets/postgres/src/core/sql-utils.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/sql-utils.ts
@@ -14,13 +14,25 @@ import { postgresError } from './errors';
 
 const MAX_IDENTIFIER_LENGTH = 63;
 
+const utf8 = new TextEncoder();
+
+/**
+ * UTF-8 byte length — the unit PostgreSQL measures identifiers and enum labels
+ * in. `NAMEDATALEN - 1` is 63 *bytes*, so a name written in non-ASCII
+ * characters can sit well under 63 characters and still overrun. Both length
+ * checks in this module read through here so they cannot drift apart.
+ */
+function byteLength(value: string): number {
+  return utf8.encode(value).length;
+}
+
 /**
  * Validates and quotes a PostgreSQL identifier (table, column, type, schema names).
  *
  * Security validations:
  * - Rejects null bytes which could cause truncation or unexpected behavior
  * - Rejects empty identifiers
- * - Warns on identifiers exceeding PostgreSQL's 63-character limit
+ * - Warns on identifiers exceeding PostgreSQL's 63-byte limit
  *
  * @throws `CONTRACT.IDENTIFIER_INVALID` structured error If the identifier contains null bytes or is empty
  */
@@ -35,9 +47,9 @@ export function quoteIdentifier(identifier: string): string {
       meta: { value: identifier.replace(/\0/g, '\\0'), context: 'identifier' },
     });
   }
-  if (identifier.length > MAX_IDENTIFIER_LENGTH) {
+  if (byteLength(identifier) > MAX_IDENTIFIER_LENGTH) {
     console.warn(
-      `Identifier "${identifier.slice(0, 20)}..." exceeds PostgreSQL's ${MAX_IDENTIFIER_LENGTH}-character limit and will be truncated`,
+      `Identifier "${identifier.slice(0, 20)}..." exceeds PostgreSQL's ${MAX_IDENTIFIER_LENGTH}-byte limit and will be truncated`,
     );
   }
   return `"${identifier.replace(/"/g, '""')}"`;
@@ -95,7 +107,7 @@ export function quoteQualifiedName(name: string): string {
  * @throws `CONTRACT.IDENTIFIER_INVALID` structured error If the value exceeds the maximum length
  */
 export function validateEnumValueLength(value: string, enumTypeName: string): void {
-  if (new TextEncoder().encode(value).length > MAX_IDENTIFIER_LENGTH) {
+  if (byteLength(value) > MAX_IDENTIFIER_LENGTH) {
     throw postgresError(
       'CONTRACT.IDENTIFIER_INVALID',
       `Enum value "${value.slice(0, 20)}..." for type "${enumTypeName}" exceeds PostgreSQL's ` +

--- a/packages/3-targets/3-targets/postgres/test/sql-utils.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/sql-utils.test.ts
@@ -68,8 +68,41 @@ describe('quoteIdentifier', () => {
 
     expect(result).toBe(`"${identifier}"`);
     expect(warnSpy).toHaveBeenCalledWith(
-      `Identifier "${identifier.slice(0, 20)}..." exceeds PostgreSQL's 63-character limit and will be truncated`,
+      `Identifier "${identifier.slice(0, 20)}..." exceeds PostgreSQL's 63-byte limit and will be truncated`,
     );
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns for a multibyte identifier over 63 bytes but under 63 characters', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A Cyrillic column name: 50 characters, 96 UTF-8 bytes. Postgres measures
+    // the byte length, so it stores this name truncated to 63 bytes — the
+    // declared object can then never be matched against the live one.
+    const identifier = 'электронная_почта_адрес_подтверждена_пользователем';
+
+    const result = quoteIdentifier(identifier);
+
+    expect(identifier.length).toBeLessThanOrEqual(63);
+    expect(new TextEncoder().encode(identifier).length).toBeGreaterThan(63);
+    expect(result).toBe(`"${identifier}"`);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Identifier "${identifier.slice(0, 20)}..." exceeds PostgreSQL's 63-byte limit and will be truncated`,
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('stays silent for a multibyte identifier that is exactly 63 bytes', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // '€' (U+20AC) is 3 UTF-8 bytes: 21 characters = 63 bytes, exactly at the limit.
+    const identifier = '€'.repeat(21);
+
+    const result = quoteIdentifier(identifier);
+
+    expect(new TextEncoder().encode(identifier).length).toBe(63);
+    expect(result).toBe(`"${identifier}"`);
+    expect(warnSpy).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
   });


### PR DESCRIPTION
## Linked issue

n/a — small change

## Summary

`quoteIdentifier` warned when an identifier exceeded 63 **characters**, but
PostgreSQL measures `NAMEDATALEN - 1` in **bytes**. A name written in non-ASCII
characters can sit well under 63 characters and still overrun — a 50-character
Cyrillic column name is 96 UTF-8 bytes — so the warning never fired and the
object was silently truncated server-side, leaving the declared name unable to
match the live one.

`validateEnumValueLength`, in the same module, already measured bytes via
`TextEncoder`. Both checks now read through one `byteLength` helper so they
cannot drift apart again, and the warning text says "byte" rather than
"character".

The warn-vs-throw split between the two functions is left alone: it mirrors
PostgreSQL, where an over-long enum label raises `invalid enum label` but an
over-long identifier is truncated by `pg_mbcliplen`. The file already documents
that distinction.

## Testing performed

- `npx vitest run` in `packages/3-targets/3-targets/postgres` — **1589 tests,
  92 of 93 files**. The one failing file, `test/migrations/render-typescript.test.ts`,
  fails to load on a missing `@internal/cli/migration-cli` build artifact; it is
  unrelated and fails identically on `main`.
- `npx vitest run test/sql-utils.test.ts` — **33 passed**; with
  `src/core/sql-utils.ts` reverted to `main`, **2 failed / 31 passed**.
- `biome check` on both changed files — exit 0.
- `scripts/lint-deps-focused.mjs` on both changed files — no dependency
  violations.
- The pre-commit and commit-msg hooks both ran and passed.

I did not run `pnpm test:packages`, `test:integration` or the e2e suites — this
workspace is only partially built, so those results would not be meaningful.

## Skill update

n/a — internal only. The change is a length-check unit and a `console.warn`
string; no CLI flag, public API, `prisma.config.ts` field, error code or
glossary term is affected.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title follows the conventional-commit form that
      `skills-contrib/contrib-pr/SKILL.md` specifies for outside contributions
      (the `TML-NNNN` prefix in this checklist is a Linear ticket reference I do
      not have — say the word if you would rather I retitle).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

**On duplication.** `packages/2-sql/1-core/schema-ir/src/naming.ts` already has a
`byteLength` helper with the same shape, and this package does import from that
package's `./naming` subpath elsewhere — so consolidating is possible, and it
would need only an `export` added there. I kept the helper local to stay within
one logical concern, but I am happy to switch to importing it if you would
rather have one copy. That is your call, not mine to make in this PR.

**One caveat, pre-existing.** `TextEncoder` measures UTF-8, while PostgreSQL's
limit is bytes in the *server* encoding. On a non-UTF-8 database the new warning
could fire early. Nothing in `packages/3-targets/*/src` reads `client_encoding`,
and `naming.ts` makes the same UTF-8 assumption, so this is consistent with the
rest of the repo rather than something the change introduces.

**Tests.** The Cyrillic case is the regression test — it fails on `main`. The
`'€'.repeat(21)` case is exactly 63 bytes and passes either way; it is there
because there was no exactly-63 boundary test before, and it is what catches a
`>` → `>=` slip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL identifier and enum-value length validation to measure UTF-8 byte length accurately.
  * Warnings now correctly reflect PostgreSQL’s 63-byte identifier limit, including for multibyte characters.
  * Updated validation behavior for values exactly at or exceeding the byte limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->