### PR TITLE
test: add coverage for entity-kinds.ts hydration branches

### DIFF
--- a/packages/2-sql/1-core/contract/test/entity-kinds.test.ts
+++ b/packages/2-sql/1-core/contract/test/entity-kinds.test.ts
@@ -1,8 +1,13 @@
 import { hydrateNamespaceEntities, UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
+import { parseNaming } from '@internal/sql-schema-ir/naming';
 import { describe, expect, it } from 'vitest';
 import { composeSqlEntityKinds, tableEntityKind, valueSetEntityKind } from '../src/entity-kinds';
+import { CheckConstraint } from '../src/ir/check-constraint';
+import { Index } from '../src/ir/sql-index';
 import { StorageTable } from '../src/ir/storage-table';
 import { StorageValueSet } from '../src/ir/storage-value-set';
+import type { SerializedCheckConstraint } from '../src/serialized-check-constraint';
+import type { SerializedIndex } from '../src/serialized-index';
 
 const emptyTableInput = {
   columns: {},
@@ -100,5 +105,67 @@ describe('hydrateNamespaceEntities with SQL kinds (carry)', () => {
       'carry',
     );
     expect(result[UNBOUND_NAMESPACE_ID]).toBeDefined();
+  });
+});
+
+describe('tableEntityKind — construct index/check hydration', () => {
+  it('passes through indexes that are already Index instances unchanged', () => {
+    const idx = new Index({
+      naming: parseNaming('idx_users_email', undefined),
+      columns: ['email'],
+      where: undefined,
+      unique: true,
+      type: undefined,
+      options: undefined,
+    });
+    const result = tableEntityKind.construct({
+      ...emptyTableInput,
+      indexes: [idx],
+    });
+    expect(result.indexes).toEqual([idx]);
+  });
+
+  it('hydrates serialized indexes via indexInputFromSerialized', () => {
+    const serialized: SerializedIndex = {
+      name: 'idx_users_name',
+      unique: false,
+      columns: ['name'],
+    };
+    const result = tableEntityKind.construct({
+      ...emptyTableInput,
+      indexes: [serialized],
+    });
+    expect(result.indexes[0]).toBeInstanceOf(Index);
+    expect(result.indexes[0]?.name).toBe('idx_users_name');
+  });
+
+  it('passes through checks that are already CheckConstraint instances unchanged', () => {
+    const check = new CheckConstraint({
+      naming: parseNaming('chk_users_age', undefined),
+      expression: 'age >= 0',
+    });
+    const result = tableEntityKind.construct({
+      ...emptyTableInput,
+      checks: [check],
+    });
+    expect(result.checks).toEqual([check]);
+  });
+
+  it('hydrates serialized checks via checkConstraintInputFromSerialized', () => {
+    const serialized: SerializedCheckConstraint = {
+      name: 'chk_users_email',
+      expression: "email <> ''",
+    };
+    const result = tableEntityKind.construct({
+      ...emptyTableInput,
+      checks: [serialized],
+    });
+    expect(result.checks?.[0]).toBeInstanceOf(CheckConstraint);
+    expect(result.checks?.[0]?.name).toBe('chk_users_email');
+  });
+
+  it('omits checks entirely when the input has none', () => {
+    const result = tableEntityKind.construct(emptyTableInput);
+    expect(result.checks).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
Adds test coverage for `tableEntityKind.construct` in `packages/2-sql/1-core/contract/src/entity-kinds.ts`, covering both hydration paths (already-constructed `Index`/`CheckConstraint` instances passed through vs. serialized JSON forms hydrated via `indexInputFromSerialized`/`checkConstraintInputFromSerialized`), plus the branch where `checks` is entirely absent from the input.

- `entity-kinds.ts`: 100% statements/branches/functions/lines (up from 83%/43%/60%/83%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that existing indexes and check constraints remain unchanged during table construction.
  * Added tests verifying that serialized indexes and check constraints are restored correctly.
  * Verified that tables omit check constraints when none are provided.
  * Confirmed that supplied index and check constraint objects retain their original identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->