### PR TITLE
chore: update npm provenance repository

### DIFF
--- a/packages/0-shared/extension-author-tools/package.json
+++ b/packages/0-shared/extension-author-tools/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/0-shared/extension-author-tools"
   },
   "peerDependencies": {

--- a/packages/0-shared/publish-surface/package.json
+++ b/packages/0-shared/publish-surface/package.json
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/0-shared/publish-surface"
   }
 }

--- a/packages/1-framework/0-foundation/contract/package.json
+++ b/packages/1-framework/0-foundation/contract/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/0-foundation/contract"
   }
 }

--- a/packages/1-framework/0-foundation/utils/package.json
+++ b/packages/1-framework/0-foundation/utils/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/0-foundation/utils"
   }
 }

--- a/packages/1-framework/1-core/config/package.json
+++ b/packages/1-framework/1-core/config/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/1-core/config"
   }
 }

--- a/packages/1-framework/1-core/errors/package.json
+++ b/packages/1-framework/1-core/errors/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/1-core/errors"
   }
 }

--- a/packages/1-framework/1-core/framework-components/package.json
+++ b/packages/1-framework/1-core/framework-components/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/1-core/framework-components"
   }
 }

--- a/packages/1-framework/1-core/operations/package.json
+++ b/packages/1-framework/1-core/operations/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/1-core/operations"
   }
 }

--- a/packages/1-framework/1-core/ts-render/package.json
+++ b/packages/1-framework/1-core/ts-render/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/1-core/ts-render"
   }
 }

--- a/packages/1-framework/2-authoring/contract/package.json
+++ b/packages/1-framework/2-authoring/contract/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/2-authoring/contract"
   }
 }

--- a/packages/1-framework/2-authoring/ids/package.json
+++ b/packages/1-framework/2-authoring/ids/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/2-authoring/ids"
   }
 }

--- a/packages/1-framework/2-authoring/psl-parser/package.json
+++ b/packages/1-framework/2-authoring/psl-parser/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/2-authoring/psl-parser"
   }
 }

--- a/packages/1-framework/2-authoring/psl-printer/package.json
+++ b/packages/1-framework/2-authoring/psl-printer/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/2-authoring/psl-printer"
   }
 }

--- a/packages/1-framework/3-tooling/cli-telemetry/package.json
+++ b/packages/1-framework/3-tooling/cli-telemetry/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/cli-telemetry"
   }
 }

--- a/packages/1-framework/3-tooling/cli/package.json
+++ b/packages/1-framework/3-tooling/cli/package.json
@@ -105,7 +105,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/cli"
   }
 }

--- a/packages/1-framework/3-tooling/config-loader/package.json
+++ b/packages/1-framework/3-tooling/config-loader/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/config-loader"
   }
 }

--- a/packages/1-framework/3-tooling/emitter/package.json
+++ b/packages/1-framework/3-tooling/emitter/package.json
@@ -68,7 +68,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/emitter"
   }
 }

--- a/packages/1-framework/3-tooling/language-server/package.json
+++ b/packages/1-framework/3-tooling/language-server/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/language-server"
   }
 }

--- a/packages/1-framework/3-tooling/migration/package.json
+++ b/packages/1-framework/3-tooling/migration/package.json
@@ -120,7 +120,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/migration"
   }
 }

--- a/packages/1-framework/3-tooling/vite-plugin-contract-emit/package.json
+++ b/packages/1-framework/3-tooling/vite-plugin-contract-emit/package.json
@@ -48,7 +48,7 @@
   "types": "./dist/index.d.mts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/1-framework/3-tooling/vite-plugin-contract-emit"
   },
   "peerDependenciesMeta": {

--- a/packages/2-mongo-family/1-foundation/mongo-codec/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-codec/package.json
@@ -50,7 +50,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/1-foundation/mongo-codec"
   }
 }

--- a/packages/2-mongo-family/1-foundation/mongo-contract/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-contract/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/1-foundation/mongo-contract"
   }
 }

--- a/packages/2-mongo-family/1-foundation/mongo-value/package.json
+++ b/packages/2-mongo-family/1-foundation/mongo-value/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/1-foundation/mongo-value"
   }
 }

--- a/packages/2-mongo-family/2-authoring/contract-psl/package.json
+++ b/packages/2-mongo-family/2-authoring/contract-psl/package.json
@@ -57,7 +57,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/2-authoring/contract-psl"
   }
 }

--- a/packages/2-mongo-family/2-authoring/contract-ts/package.json
+++ b/packages/2-mongo-family/2-authoring/contract-ts/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/2-authoring/contract-ts"
   }
 }

--- a/packages/2-mongo-family/3-tooling/emitter/package.json
+++ b/packages/2-mongo-family/3-tooling/emitter/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/3-tooling/emitter"
   }
 }

--- a/packages/2-mongo-family/3-tooling/mongo-schema-ir/package.json
+++ b/packages/2-mongo-family/3-tooling/mongo-schema-ir/package.json
@@ -53,7 +53,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/3-tooling/mongo-schema-ir"
   }
 }

--- a/packages/2-mongo-family/4-query/query-ast/package.json
+++ b/packages/2-mongo-family/4-query/query-ast/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/4-query/query-ast"
   }
 }

--- a/packages/2-mongo-family/5-query-builders/orm/package.json
+++ b/packages/2-mongo-family/5-query-builders/orm/package.json
@@ -60,7 +60,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/5-query-builders/orm"
   }
 }

--- a/packages/2-mongo-family/5-query-builders/query-builder/package.json
+++ b/packages/2-mongo-family/5-query-builders/query-builder/package.json
@@ -52,7 +52,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/5-query-builders/query-builder"
   }
 }

--- a/packages/2-mongo-family/6-transport/mongo-lowering/package.json
+++ b/packages/2-mongo-family/6-transport/mongo-lowering/package.json
@@ -54,7 +54,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/6-transport/mongo-lowering"
   }
 }

--- a/packages/2-mongo-family/6-transport/mongo-wire/package.json
+++ b/packages/2-mongo-family/6-transport/mongo-wire/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/6-transport/mongo-wire"
   }
 }

--- a/packages/2-mongo-family/7-runtime/package.json
+++ b/packages/2-mongo-family/7-runtime/package.json
@@ -63,7 +63,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/7-runtime"
   }
 }

--- a/packages/2-mongo-family/9-family/package.json
+++ b/packages/2-mongo-family/9-family/package.json
@@ -66,7 +66,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-mongo-family/9-family"
   }
 }

--- a/packages/2-sql/1-core/contract/package.json
+++ b/packages/2-sql/1-core/contract/package.json
@@ -66,7 +66,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/1-core/contract"
   }
 }

--- a/packages/2-sql/1-core/errors/package.json
+++ b/packages/2-sql/1-core/errors/package.json
@@ -45,7 +45,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/1-core/errors"
   }
 }

--- a/packages/2-sql/1-core/operations/package.json
+++ b/packages/2-sql/1-core/operations/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/1-core/operations"
   }
 }

--- a/packages/2-sql/1-core/schema-ir/package.json
+++ b/packages/2-sql/1-core/schema-ir/package.json
@@ -52,7 +52,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/1-core/schema-ir"
   }
 }

--- a/packages/2-sql/2-authoring/contract-psl/package.json
+++ b/packages/2-sql/2-authoring/contract-psl/package.json
@@ -58,7 +58,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/2-authoring/contract-psl"
   }
 }

--- a/packages/2-sql/2-authoring/contract-ts/package.json
+++ b/packages/2-sql/2-authoring/contract-ts/package.json
@@ -63,7 +63,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/2-authoring/contract-ts"
   }
 }

--- a/packages/2-sql/3-tooling/emitter/package.json
+++ b/packages/2-sql/3-tooling/emitter/package.json
@@ -53,7 +53,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/3-tooling/emitter"
   }
 }

--- a/packages/2-sql/4-lanes/relational-core/package.json
+++ b/packages/2-sql/4-lanes/relational-core/package.json
@@ -66,7 +66,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/4-lanes/relational-core"
   }
 }

--- a/packages/2-sql/4-lanes/sql-builder/package.json
+++ b/packages/2-sql/4-lanes/sql-builder/package.json
@@ -61,7 +61,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/4-lanes/sql-builder"
   }
 }

--- a/packages/2-sql/5-runtime/package.json
+++ b/packages/2-sql/5-runtime/package.json
@@ -62,7 +62,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/5-runtime"
   }
 }

--- a/packages/2-sql/9-family/package.json
+++ b/packages/2-sql/9-family/package.json
@@ -72,7 +72,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/2-sql/9-family"
   }
 }

--- a/packages/3-extensions/arktype-json/package.json
+++ b/packages/3-extensions/arktype-json/package.json
@@ -64,7 +64,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/arktype-json"
   }
 }

--- a/packages/3-extensions/middleware-cache/package.json
+++ b/packages/3-extensions/middleware-cache/package.json
@@ -48,7 +48,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/middleware-cache"
   }
 }

--- a/packages/3-extensions/mongo/package.json
+++ b/packages/3-extensions/mongo/package.json
@@ -75,7 +75,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/mongo"
   }
 }

--- a/packages/3-extensions/paradedb/package.json
+++ b/packages/3-extensions/paradedb/package.json
@@ -67,7 +67,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/paradedb"
   }
 }

--- a/packages/3-extensions/pgvector/package.json
+++ b/packages/3-extensions/pgvector/package.json
@@ -77,7 +77,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/pgvector"
   }
 }

--- a/packages/3-extensions/postgis/package.json
+++ b/packages/3-extensions/postgis/package.json
@@ -72,7 +72,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/postgis"
   }
 }

--- a/packages/3-extensions/postgres/package.json
+++ b/packages/3-extensions/postgres/package.json
@@ -80,7 +80,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/postgres"
   }
 }

--- a/packages/3-extensions/sql-orm-client/package.json
+++ b/packages/3-extensions/sql-orm-client/package.json
@@ -67,7 +67,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/sql-orm-client"
   }
 }

--- a/packages/3-extensions/sqlite/package.json
+++ b/packages/3-extensions/sqlite/package.json
@@ -70,7 +70,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/sqlite"
   }
 }

--- a/packages/3-extensions/supabase/package.json
+++ b/packages/3-extensions/supabase/package.json
@@ -87,7 +87,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-extensions/supabase"
   }
 }

--- a/packages/3-mongo-target/1-mongo-target/package.json
+++ b/packages/3-mongo-target/1-mongo-target/package.json
@@ -76,7 +76,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-mongo-target/1-mongo-target"
   },
   "prismaNext": {

--- a/packages/3-mongo-target/2-mongo-adapter/package.json
+++ b/packages/3-mongo-target/2-mongo-adapter/package.json
@@ -77,7 +77,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-mongo-target/2-mongo-adapter"
   }
 }

--- a/packages/3-mongo-target/3-mongo-driver/package.json
+++ b/packages/3-mongo-target/3-mongo-driver/package.json
@@ -56,7 +56,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-mongo-target/3-mongo-driver"
   }
 }

--- a/packages/3-targets/3-targets/postgres/package.json
+++ b/packages/3-targets/3-targets/postgres/package.json
@@ -98,7 +98,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/3-targets/postgres"
   },
   "prismaNext": {

--- a/packages/3-targets/3-targets/sqlite/package.json
+++ b/packages/3-targets/3-targets/sqlite/package.json
@@ -80,7 +80,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/3-targets/sqlite"
   }
 }

--- a/packages/3-targets/6-adapters/postgres-codec-testkit/package.json
+++ b/packages/3-targets/6-adapters/postgres-codec-testkit/package.json
@@ -57,7 +57,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/6-adapters/postgres-codec-testkit"
   }
 }

--- a/packages/3-targets/6-adapters/postgres/package.json
+++ b/packages/3-targets/6-adapters/postgres/package.json
@@ -75,7 +75,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/6-adapters/postgres"
   }
 }

--- a/packages/3-targets/6-adapters/sqlite-codec-testkit/package.json
+++ b/packages/3-targets/6-adapters/sqlite-codec-testkit/package.json
@@ -53,7 +53,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/6-adapters/sqlite-codec-testkit"
   }
 }

--- a/packages/3-targets/6-adapters/sqlite/package.json
+++ b/packages/3-targets/6-adapters/sqlite/package.json
@@ -72,7 +72,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/6-adapters/sqlite"
   }
 }

--- a/packages/3-targets/7-drivers/postgres/package.json
+++ b/packages/3-targets/7-drivers/postgres/package.json
@@ -62,7 +62,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/7-drivers/postgres"
   }
 }

--- a/packages/3-targets/7-drivers/sqlite/package.json
+++ b/packages/3-targets/7-drivers/sqlite/package.json
@@ -55,7 +55,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/3-targets/7-drivers/sqlite"
   }
 }

--- a/packages/9-public/@prisma/orm-extension-arktype-json/package.json
+++ b/packages/9-public/@prisma/orm-extension-arktype-json/package.json
@@ -47,7 +47,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-extension-arktype-json"
   }
 }

--- a/packages/9-public/@prisma/orm-extension-middleware-cache/package.json
+++ b/packages/9-public/@prisma/orm-extension-middleware-cache/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-extension-middleware-cache"
   }
 }

--- a/packages/9-public/@prisma/orm-extension-paradedb/package.json
+++ b/packages/9-public/@prisma/orm-extension-paradedb/package.json
@@ -45,7 +45,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-extension-paradedb"
   }
 }

--- a/packages/9-public/@prisma/orm-extension-pgvector/package.json
+++ b/packages/9-public/@prisma/orm-extension-pgvector/package.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-extension-pgvector"
   }
 }

--- a/packages/9-public/@prisma/orm-extension-postgis/package.json
+++ b/packages/9-public/@prisma/orm-extension-postgis/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-extension-postgis"
   }
 }

--- a/packages/9-public/@prisma/orm-extension-supabase/package.json
+++ b/packages/9-public/@prisma/orm-extension-supabase/package.json
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-extension-supabase"
   }
 }

--- a/packages/9-public/@prisma/orm-family-mongo/package.json
+++ b/packages/9-public/@prisma/orm-family-mongo/package.json
@@ -83,7 +83,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-family-mongo"
   }
 }

--- a/packages/9-public/@prisma/orm-family-sql/package.json
+++ b/packages/9-public/@prisma/orm-family-sql/package.json
@@ -107,7 +107,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-family-sql"
   }
 }

--- a/packages/9-public/@prisma/orm-framework/package.json
+++ b/packages/9-public/@prisma/orm-framework/package.json
@@ -109,7 +109,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-framework"
   }
 }

--- a/packages/9-public/@prisma/orm-mongo/package.json
+++ b/packages/9-public/@prisma/orm-mongo/package.json
@@ -128,7 +128,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-mongo"
   }
 }

--- a/packages/9-public/@prisma/orm-postgres/package.json
+++ b/packages/9-public/@prisma/orm-postgres/package.json
@@ -186,7 +186,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-postgres"
   }
 }

--- a/packages/9-public/@prisma/orm-sqlite/package.json
+++ b/packages/9-public/@prisma/orm-sqlite/package.json
@@ -167,7 +167,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-sqlite"
   }
 }

--- a/packages/9-public/@prisma/orm-target-mongo/package.json
+++ b/packages/9-public/@prisma/orm-target-mongo/package.json
@@ -57,7 +57,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-target-mongo"
   }
 }

--- a/packages/9-public/@prisma/orm-target-postgres/package.json
+++ b/packages/9-public/@prisma/orm-target-postgres/package.json
@@ -91,7 +91,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-target-postgres"
   }
 }

--- a/packages/9-public/@prisma/orm-target-sqlite/package.json
+++ b/packages/9-public/@prisma/orm-target-sqlite/package.json
@@ -75,7 +75,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-target-sqlite"
   }
 }

--- a/packages/9-public/@prisma/orm-toolchain/package.json
+++ b/packages/9-public/@prisma/orm-toolchain/package.json
@@ -99,7 +99,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/9-public/@prisma/orm-toolchain"
   }
 }

--- a/scripts/validate-package-manifests.mjs
+++ b/scripts/validate-package-manifests.mjs
@@ -68,7 +68,7 @@ export function classifyPackage(pkgJson) {
   return null;
 }
 
-const REQUIRED_REPO_URL = 'https://github.com/prisma/prisma.git';
+const REQUIRED_REPO_URL = 'https://github.com/prisma/orm.git';
 
 /**
  * Classifies a publishable `package.json` against the repository rule.

--- a/scripts/validate-package-manifests.test.mjs
+++ b/scripts/validate-package-manifests.test.mjs
@@ -7,7 +7,7 @@ import {
   runCheck,
 } from './validate-package-manifests.mjs';
 
-const REPO_URL = 'https://github.com/prisma/prisma.git';
+const REPO_URL = 'https://github.com/prisma/orm.git';
 
 function recorder() {
   const calls = [];


### PR DESCRIPTION
## Summary

- update package repository metadata from `prisma/prisma` to `prisma/orm`
- update the manifest provenance guard and its tests

## Validation

- `node --test scripts/validate-package-manifests.test.mjs`
- `node scripts/validate-package-manifests.mjs`
- parsed all package manifests as JSON
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository metadata to reference the Prisma ORM repository.
  * Updated package manifest validation and its tests to recognize the new canonical repository URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->