### PR TITLE
chore: update npm provenance repository

### DIFF
--- a/packages/adapter-better-sqlite3/package.json
+++ b/packages/adapter-better-sqlite3/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-better-sqlite3"
   },
   "scripts": {

--- a/packages/adapter-d1/package.json
+++ b/packages/adapter-d1/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-d1"
   },
   "scripts": {

--- a/packages/adapter-libsql/package.json
+++ b/packages/adapter-libsql/package.json
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-libsql"
   },
   "scripts": {

--- a/packages/adapter-mariadb/package.json
+++ b/packages/adapter-mariadb/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-planetscale"
   },
   "scripts": {

--- a/packages/adapter-mssql/package.json
+++ b/packages/adapter-mssql/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-mssql"
   },
   "scripts": {

--- a/packages/adapter-neon/package.json
+++ b/packages/adapter-neon/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-neon"
   },
   "scripts": {

--- a/packages/adapter-pg/package.json
+++ b/packages/adapter-pg/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-pg"
   },
   "scripts": {

--- a/packages/adapter-planetscale/package.json
+++ b/packages/adapter-planetscale/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-planetscale"
   },
   "scripts": {

--- a/packages/adapter-ppg/package.json
+++ b/packages/adapter-ppg/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/adapter-ppg"
   },
   "scripts": {

--- a/packages/bundled-js-drivers/package.json
+++ b/packages/bundled-js-drivers/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/bundled-js-drivers"
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
   "main": "build/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/cli"
   },
   "homepage": "https://www.prisma.io",

--- a/packages/client-common/package.json
+++ b/packages/client-common/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client-common"
   },
   "license": "Apache-2.0",

--- a/packages/client-engine-runtime/package.json
+++ b/packages/client-engine-runtime/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client-engine-runtime"
   },
   "license": "Apache-2.0",

--- a/packages/client-generator-js/package.json
+++ b/packages/client-generator-js/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client-generator-js"
   },
   "license": "Apache-2.0",

--- a/packages/client-generator-registry/package.json
+++ b/packages/client-generator-registry/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client-generator-registry"
   },
   "license": "Apache-2.0",

--- a/packages/client-generator-ts/package.json
+++ b/packages/client-generator-ts/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client-generator-ts"
   },
   "license": "Apache-2.0",

--- a/packages/client-runtime-utils/package.json
+++ b/packages/client-runtime-utils/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client-runtime-utils"
   },
   "license": "Apache-2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -121,7 +121,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/client"
   },
   "author": "Tim Suchanek <suchanek@prisma.io>",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/config"
   },
   "license": "Apache-2.0",

--- a/packages/credentials-store/package.json
+++ b/packages/credentials-store/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/credentials-store"
   },
   "license": "Apache-2.0",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/debug"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/dmmf/package.json
+++ b/packages/dmmf/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/dmmf"
   },
   "license": "Apache-2.0",

--- a/packages/driver-adapter-utils/package.json
+++ b/packages/driver-adapter-utils/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/driver-adapter-utils"
   },
   "scripts": {

--- a/packages/engines/package.json
+++ b/packages/engines/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/engines"
   },
   "license": "Apache-2.0",

--- a/packages/fetch-engine/package.json
+++ b/packages/fetch-engine/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/fetch-engine"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/generator-helper/package.json
+++ b/packages/generator-helper/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/generator-helper"
   },
   "author": "Tim Suchanek <suchanek@prisma.io>",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/generator"
   },
   "license": "Apache-2.0",

--- a/packages/get-dmmf/package.json
+++ b/packages/get-dmmf/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/get-dmmf"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/get-platform/package.json
+++ b/packages/get-platform/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/get-platform"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/instrumentation-contract/package.json
+++ b/packages/instrumentation-contract/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/instrumentation-contract"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/instrumentation"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -8,7 +8,7 @@
   "author": "Tim Suchanek <suchanek@prisma.io>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/integration-tests"
   },
   "devDependencies": {

--- a/packages/internals/package.json
+++ b/packages/internals/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/internals"
   },
   "homepage": "https://www.prisma.io",

--- a/packages/json-protocol/package.json
+++ b/packages/json-protocol/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/json-protocol"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -6,7 +6,7 @@
   "types": "dist/migrate/src/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/migrate"
   },
   "author": "Tim Suchanek <suchanek@prisma.io>",

--- a/packages/nextjs-monorepo-workaround-plugin/package.json
+++ b/packages/nextjs-monorepo-workaround-plugin/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/nextjs-monorepo-workaround-plugin"
   },
   "scripts": {

--- a/packages/param-graph-builder/package.json
+++ b/packages/param-graph-builder/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/param-graph-builder"
   },
   "license": "Apache-2.0",

--- a/packages/param-graph/package.json
+++ b/packages/param-graph/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/param-graph"
   },
   "license": "Apache-2.0",

--- a/packages/prisma7/package.json
+++ b/packages/prisma7/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/prisma7"
   },
   "main": "index.js",

--- a/packages/query-plan-executor/package.json
+++ b/packages/query-plan-executor/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/query-plan-executor"
   },
   "license": "Apache-2.0",

--- a/packages/schema-files-loader/package.json
+++ b/packages/schema-files-loader/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/schema-files-loader"
   },
   "license": "Apache-2.0",

--- a/packages/sqlcommenter-query-insights/package.json
+++ b/packages/sqlcommenter-query-insights/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/sqlcommenter-query-insights"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/sqlcommenter-query-tags/package.json
+++ b/packages/sqlcommenter-query-tags/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/sqlcommenter-query-tags"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/sqlcommenter-trace-context/package.json
+++ b/packages/sqlcommenter-trace-context/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/sqlcommenter-trace-context"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/sqlcommenter/package.json
+++ b/packages/sqlcommenter/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://www.prisma.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/sqlcommenter"
   },
   "bugs": "https://github.com/prisma/prisma/issues",

--- a/packages/ts-builders/package.json
+++ b/packages/ts-builders/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/ts-builders"
   },
   "license": "Apache-2.0",

--- a/packages/type-benchmark-tests/package.json
+++ b/packages/type-benchmark-tests/package.json
@@ -6,7 +6,7 @@
   "description": "This package is intended for Prisma's internal use and only performs type benchmark tests.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/prisma/prisma.git",
+    "url": "https://github.com/prisma/orm.git",
     "directory": "packages/type-benchmark-tests"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- update package repository metadata from `prisma/prisma` to `prisma/orm`
- keep npm provenance metadata aligned with the renamed GitHub repository on the `v7` release line

## Validation

- verified no package manifests reference `https://github.com/prisma/prisma.git`
- parsed all 173 package manifests as JSON
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository links across Prisma packages to point to the new ORM repository.
  * No functional behavior or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->