### PR TITLE
fix(adapter-pg,adapter-neon,adapter-ppg): support TIMETZ[] columns

### DIFF
--- a/packages/adapter-neon/src/__tests__/timetz-array.test.ts
+++ b/packages/adapter-neon/src/__tests__/timetz-array.test.ts
@@ -1,0 +1,17 @@
+import { ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+import { describe, expect, it } from 'vitest'
+
+import { customParsers, fieldToColumnType } from '../conversion'
+
+const TIMETZ_ARRAY_OID = 1270
+
+describe('TIMETZ[]', () => {
+  it('maps the timetz array OID to TimeArray instead of throwing', () => {
+    expect(fieldToColumnType(TIMETZ_ARRAY_OID)).toBe(ColumnTypeEnum.TimeArray)
+  })
+
+  it('normalizes elements the same way scalar TIMETZ does', () => {
+    const parse = customParsers[TIMETZ_ARRAY_OID] as (value: string) => string[]
+    expect(parse('{10:30:00+02,11:00:00-05:00,12:00:00}')).toEqual(['10:30:00', '11:00:00', '12:00:00'])
+  })
+})

--- a/packages/adapter-neon/src/conversion.ts
+++ b/packages/adapter-neon/src/conversion.ts
@@ -32,6 +32,7 @@ const ArrayColumnType = {
   TEXT_ARRAY: 1009,
   TIMESTAMP_ARRAY: 1115,
   TIMESTAMPTZ_ARRAY: 1185,
+  TIMETZ_ARRAY: 1270,
   TIME_ARRAY: 1183,
   UUID_ARRAY: 2951,
   VARBIT_ARRAY: 1563,
@@ -238,6 +239,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.DATE_ARRAY:
       return ColumnTypeEnum.DateArray
     case ArrayColumnType.TIME_ARRAY:
+    case ArrayColumnType.TIMETZ_ARRAY:
       return ColumnTypeEnum.TimeArray
     case ArrayColumnType.TIMESTAMP_ARRAY:
       return ColumnTypeEnum.DateTimeArray
@@ -374,6 +376,9 @@ export const customParsers = {
   [ScalarColumnType.TIME]: normalize_time,
   [ArrayColumnType.TIME_ARRAY]: normalize_array(normalize_time),
   [ScalarColumnType.TIMETZ]: normalize_timez,
+  // Elements are normalized exactly like scalar TIMETZ, offset-stripping included, to keep
+  // array and scalar TIMETZ byte-for-byte consistent. See #7915/#7917 for the offset semantics.
+  [ArrayColumnType.TIMETZ_ARRAY]: normalize_array(normalize_timez),
   [ScalarColumnType.DATE]: normalize_date,
   [ArrayColumnType.DATE_ARRAY]: normalize_array(normalize_date),
   [ScalarColumnType.TIMESTAMP]: normalize_timestamp,

--- a/packages/adapter-pg/src/__tests__/timetz-array.test.ts
+++ b/packages/adapter-pg/src/__tests__/timetz-array.test.ts
@@ -1,0 +1,17 @@
+import { ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+import { describe, expect, it } from 'vitest'
+
+import { customParsers, fieldToColumnType } from '../conversion'
+
+const TIMETZ_ARRAY_OID = 1270
+
+describe('TIMETZ[]', () => {
+  it('maps the timetz array OID to TimeArray instead of throwing', () => {
+    expect(fieldToColumnType(TIMETZ_ARRAY_OID)).toBe(ColumnTypeEnum.TimeArray)
+  })
+
+  it('normalizes elements the same way scalar TIMETZ does', () => {
+    const parse = customParsers[TIMETZ_ARRAY_OID] as (value: string) => string[]
+    expect(parse('{10:30:00+02,11:00:00-05:00,12:00:00}')).toEqual(['10:30:00', '11:00:00', '12:00:00'])
+  })
+})

--- a/packages/adapter-pg/src/conversion.ts
+++ b/packages/adapter-pg/src/conversion.ts
@@ -42,6 +42,7 @@ const ArrayColumnType = {
   TEXT_ARRAY: 1009,
   TIMESTAMP_ARRAY: 1115,
   TIMESTAMPTZ_ARRAY: 1185,
+  TIMETZ_ARRAY: 1270,
   TIME_ARRAY: 1183,
   UUID_ARRAY: 2951,
   VARBIT_ARRAY: 1563,
@@ -249,6 +250,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.DATE_ARRAY:
       return ColumnTypeEnum.DateArray
     case ArrayColumnType.TIME_ARRAY:
+    case ArrayColumnType.TIMETZ_ARRAY:
       return ColumnTypeEnum.TimeArray
     case ArrayColumnType.TIMESTAMP_ARRAY:
       return ColumnTypeEnum.DateTimeArray
@@ -387,6 +389,9 @@ export const customParsers = {
   [ScalarColumnType.TIME]: normalize_time,
   [ArrayColumnType.TIME_ARRAY]: normalize_array(normalize_time),
   [ScalarColumnType.TIMETZ]: normalize_timez,
+  // Elements are normalized exactly like scalar TIMETZ, offset-stripping included, to keep
+  // array and scalar TIMETZ byte-for-byte consistent. See #7915/#7917 for the offset semantics.
+  [ArrayColumnType.TIMETZ_ARRAY]: normalize_array(normalize_timez),
   [ScalarColumnType.DATE]: normalize_date,
   [ArrayColumnType.DATE_ARRAY]: normalize_array(normalize_date),
   [ScalarColumnType.TIMESTAMP]: normalize_timestamp,

--- a/packages/adapter-ppg/src/conversion.test.ts
+++ b/packages/adapter-ppg/src/conversion.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'vitest'
+import { ColumnTypeEnum } from '@prisma/driver-adapter-utils'
+import { describe, expect, it, test } from 'vitest'
 
-import { ArrayColumnType, builtinParsers, ScalarColumnType } from './conversion'
+import { ArrayColumnType, builtinParsers, fieldToColumnType, ScalarColumnType } from './conversion'
 
 function getParser(oid: number) {
   const entry = builtinParsers.find((p) => p.oid === oid)
@@ -158,6 +159,17 @@ describe('conversion', () => {
       expect(Buffer.isBuffer(result![0])).toBe(true)
       expect(result![0]!.toString()).toBe('aGVsbG8=')
       expect(result![1]).toBeNull()
+    })
+  })
+
+  describe('TIMETZ[]', () => {
+    it('maps the timetz array OID to TimeArray instead of throwing', () => {
+      expect(fieldToColumnType(ArrayColumnType.TIMETZ_ARRAY)).toBe(ColumnTypeEnum.TimeArray)
+    })
+
+    it('normalizes elements the same way scalar TIMETZ does', () => {
+      const parse = getParser(ArrayColumnType.TIMETZ_ARRAY)
+      expect(parse('{10:30:00+02,11:00:00-05:00,12:00:00}')).toEqual(['10:30:00', '11:00:00', '12:00:00'])
     })
   })
 })

--- a/packages/adapter-ppg/src/conversion.ts
+++ b/packages/adapter-ppg/src/conversion.ts
@@ -171,6 +171,7 @@ export const ArrayColumnType = {
   TEXT_ARRAY: 1009,
   TIMESTAMP_ARRAY: 1115,
   TIMESTAMPTZ_ARRAY: 1185,
+  TIMETZ_ARRAY: 1270,
   TIME_ARRAY: 1183,
   UUID_ARRAY: 2951,
   VARBIT_ARRAY: 1563,
@@ -246,6 +247,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case ArrayColumnType.DATE_ARRAY:
       return ColumnTypeEnum.DateArray
     case ArrayColumnType.TIME_ARRAY:
+    case ArrayColumnType.TIMETZ_ARRAY:
       return ColumnTypeEnum.TimeArray
     case ArrayColumnType.TIMESTAMP_ARRAY:
       return ColumnTypeEnum.DateTimeArray
@@ -284,6 +286,9 @@ export const builtinParsers = Object.entries({
   [ScalarColumnType.TIME]: normalize_time,
   [ArrayColumnType.TIME_ARRAY]: normalize_array(normalize_time),
   [ScalarColumnType.TIMETZ]: normalize_timez,
+  // Elements are normalized exactly like scalar TIMETZ, offset-stripping included, to keep
+  // array and scalar TIMETZ byte-for-byte consistent. See #7915/#7917 for the offset semantics.
+  [ArrayColumnType.TIMETZ_ARRAY]: normalize_array(normalize_timez),
   [ScalarColumnType.DATE]: normalize_date,
   [ArrayColumnType.DATE_ARRAY]: normalize_array(normalize_date),
   [ScalarColumnType.TIMESTAMP]: normalize_timestamp,


### PR DESCRIPTION
Fixes #29397
Base branch: `v7` (the Prisma 8 `main` tree no longer contains the `adapter-*` packages).

## Problem

Any query touching a `timetz[]` column fails with a deserialization error surfaced as `P2010`:

```
Error in performing request: UnsupportedNativeDataType
```

Root cause (posted on #29397): in `packages/adapter-pg/src/conversion.ts`, the `ArrayColumnType`
map has no entry for `TIMETZ_ARRAY` (OID 1270), `fieldToColumnType` therefore has no case for it,
and no parser is registered for it. The OID is below `FIRST_NORMAL_OBJECT_ID`, so it is not treated
as a user type either and falls straight through to `default:`, which throws
`UnsupportedNativeDataType`. Scalar `timetz` (OID 1266) is handled; only the array form is missing.

`adapter-neon` and `adapter-ppg` carry copies of the same conversion table and have the identical
gap, so all three are fixed here.

## Change

For each of the three adapters:

1. `TIMETZ_ARRAY: 1270` added to `ArrayColumnType`.
2. `fieldToColumnType` maps it to `ColumnTypeEnum.TimeArray`, alongside `TIME_ARRAY` — matching how
   scalar `TIMETZ` already shares `ColumnTypeEnum.Time` with `TIME`.
3. The array parser is registered as `normalize_array(normalize_timez)`, i.e. the element
   normalizer is the *existing* scalar `TIMETZ` normalizer, used as-is.

## Scope: array mapping only

This PR is deliberately "stop throwing" and nothing more.

`normalize_timez` strips the UTC offset from the value, which is the behavior discussed in #7915 /
#7917. That behavior is **intentionally reused unchanged** here, so `timetz[]` elements deserialize
byte-for-byte identically to a scalar `timetz` column on the same connection. Whatever the
maintainers decide about `timetz` offset semantics will then apply to scalars and arrays together,
with no separate array code path to remember. This PR does not preempt that decision.

## Tests

- `packages/adapter-pg/src/__tests__/timetz-array.test.ts` (new)
- `packages/adapter-neon/src/__tests__/timetz-array.test.ts` (new)
- `packages/adapter-ppg/src/conversion.test.ts` (new `describe('TIMETZ[]')` block, following the
  file's existing `getParser(oid)` pattern)

Each asserts that OID 1270 maps to `TimeArray` and that the registered parser normalizes elements
exactly like the scalar path (`'{10:30:00+02,11:00:00-05:00,12:00:00}'` →
`['10:30:00', '11:00:00', '12:00:00']`).

Verified failing on `v7` before the fix with `UnsupportedNativeDataType`, passing after. Full unit
suites for all three adapter packages are green (`adapter-pg` 57, `adapter-neon` 10, `adapter-ppg`
43 tests).

Not covered: an end-to-end `driver-adapters` integration test against a real `timetz[]` column,
since that would need a schema fixture in the functional test suite. Happy to add one if you'd
prefer the coverage there instead of / in addition to the unit level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PostgreSQL `TIMETZ[]` columns across Neon, PostgreSQL, and PPG adapters.
  * `TIMETZ[]` values are now recognized as time arrays and normalized consistently with scalar `TIMETZ` values.

* **Tests**
  * Added coverage verifying type detection and timezone-offset normalization for `TIMETZ[]` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->