### PR TITLE
TML-2624: renew the contract package coverage waiver

### DIFF
--- a/coverage.config.json
+++ b/coverage.config.json
@@ -5,11 +5,11 @@
     {
       "package": "1-framework/0-foundation/contract",
       "reason": "S1.C cross-reference encoding added CrossReference shape to Contract.roots and domain field support to canonicalization.ts. The new canonicalization branches (domain-plane key ordering, domain-unbound type params preservation) are exercised end-to-end through emit integration tests but fall ~2% below the 94% branch threshold. Direct canonicalization branch tests deferred to a follow-up slice.",
-      "addedDate": "2026-05-29",
+      "addedDate": "2026-08-28",
       "expiryDays": 90,
       "assignee": null,
       "linear": "TML-2624",
-      "notes": "Recovery via dedicated canonicalization.ts branch tests covering the domain-plane ordering and typeParams preservation paths."
+      "notes": "Recovery via dedicated canonicalization.ts branch tests covering the domain-plane ordering and typeParams preservation paths. Renewed 2026-08-28: expired 2026-08-27 and turned the Coverage check red on every open PR; the underlying coverage situation is unchanged (93.75% branches against a 94% threshold, the same 15 uncovered branches as when the waiver was written) and the recovery above still applies (tracked on the entry's Linear issue)."
     },
     {
       "package": "3-targets/3-targets/sqlite",


### PR DESCRIPTION
Renews the expired coverage waiver for `packages/1-framework/0-foundation/contract`. The 90-day waiver added 2026-05-29 lapsed on 2026-08-27, which flipped the Test job's coverage gate red on every open PR (first observed on #30154, a PR that doesn't touch the package). The underlying situation is unchanged — 93.75% branches vs the 94% floor, the same 15 uncovered branches as when the waiver was written — so this renews rather than fixes, following the file's existing renewal precedent (sqlite 2026-07-27, sql-orm-client 2026-08-21, 2-sql entries 2026-08-17).

**Linear:** TML-2624 (the debt's tracking ticket; the recovery path — dedicated `canonicalization.ts` branch tests — stays named in the entry).

**Scope:** Only `coverage.config.json`, one entry, two fields (`addedDate` → 2026-08-28; renewal sentence appended to `notes`). No code, no thresholds, no other entries.

**Verification:** Diff shows the two-field change. Ran CI's gate locally on main±fix: the only delta is the disappearance of `ERROR: Coverage for branches (93.75%) does not meet … threshold (94%)`; `pnpm coverage:report` exits 0 with the entry back under non-blocking warnings, expires 2026-11-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renewed the coverage waiver for the foundation contract package.
  * Updated waiver records to reflect the recent expiration and unchanged coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->