### PR TITLE
ci: shard package tests without weakening coverage gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,22 +162,14 @@ jobs:
         run: pnpm fixtures:check
 
   test-packages:
-    name: Package Tests (${{ matrix.shard }})
+    name: Package Tests (${{ matrix.index }}/4)
     needs: [build, changes]
     if: needs.changes.outputs.inert != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - index: 1
-            shard: 1/4
-          - index: 2
-            shard: 2/4
-          - index: 3
-            shard: 3/4
-          - index: 4
-            shard: 4/4
+        index: [1, 2, 3, 4]
     env:
       TEST_TIMEOUT_MULTIPLIER: 2
     services:
@@ -210,7 +202,7 @@ jobs:
         continue-on-error: true
         env:
           VITEST_COVERAGE_SHARD: ${{ matrix.index }}
-        run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=${{ matrix.shard }}
+        run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=${{ matrix.index }}/4
       # Run-scoped cache keys transport blobs because download-artifact is not
       # allowlisted. Shard-first prefixes support partial reruns without crossing runs.
       - name: Save package coverage shard
@@ -230,6 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_TIMEOUT_MULTIPLIER: 2
+      RUN_TEST_STEPS: ${{ needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
       # Used by examples/prisma-8-cloudflare-worker's vitest-pool-workers
       # integration test. Mirrors the .env.example pattern; the container is
       # brought up by `pnpm db:up` below (docker-compose, not a service
@@ -256,19 +249,21 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Install dependencies (skip bin linking)
-        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
+        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build packages (restored from Turbo cache; needed for bin linking)
-        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
+        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm build
       - name: Link bins
-        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
+        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm install --frozen-lockfile
       - name: Start cloudflare-worker Postgres (5433, pg_stat_statements)
-        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
+        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm --filter prisma-8-cloudflare-worker db:up
+      # GitHub Actions has no step-level matrix, and the merge needs every blob
+      # in this workspace, so the four fan-in restores remain explicit.
       - name: Restore package coverage shard 1
-        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .vitest/blob/blob-1-4.json
@@ -277,7 +272,7 @@ jobs:
             package-coverage-${{ runner.os }}-${{ github.run_id }}-1-
           fail-on-cache-miss: true
       - name: Restore package coverage shard 2
-        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .vitest/blob/blob-2-4.json
@@ -286,7 +281,7 @@ jobs:
             package-coverage-${{ runner.os }}-${{ github.run_id }}-2-
           fail-on-cache-miss: true
       - name: Restore package coverage shard 3
-        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .vitest/blob/blob-3-4.json
@@ -295,7 +290,7 @@ jobs:
             package-coverage-${{ runner.os }}-${{ github.run_id }}-3-
           fail-on-cache-miss: true
       - name: Restore package coverage shard 4
-        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .vitest/blob/blob-4-4.json
@@ -304,16 +299,16 @@ jobs:
             package-coverage-${{ runner.os }}-${{ github.run_id }}-4-
           fail-on-cache-miss: true
       - name: Merge package tests and coverage
-        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         run: pnpm coverage:packages:merge
       - name: Report package coverage
-        if: ${{ !cancelled() && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         run: pnpm coverage:report
       - name: Test examples
-        if: ${{ !cancelled() && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         run: pnpm test:examples
       - name: Check working tree is clean
-        if: ${{ !cancelled() && needs.changes.outputs.inert != 'true' }}
+        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         run: pnpm check:clean-tree
       - name: Propagate prerequisite or package-shard failure
         if: ${{ !cancelled() && (needs.build.result != 'success' || needs.changes.result != 'success' || (needs.changes.outputs.inert != 'true' && needs.test-packages.result != 'success')) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,72 @@ jobs:
         if: needs.changes.outputs.inert != 'true'
         run: pnpm fixtures:check
 
+  test-packages:
+    name: Package Tests (${{ matrix.shard }})
+    needs: [build, changes]
+    if: needs.changes.outputs.inert != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - index: 1
+            shard: 1/4
+          - index: 2
+            shard: 2/4
+          - index: 3
+            shard: 3/4
+          - index: 4
+            shard: 4/4
+    env:
+      TEST_TIMEOUT_MULTIPLIER: 2
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Install dependencies (skip bin linking)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build packages (restored from Turbo cache; needed for bin linking)
+        run: pnpm build
+      - name: Link bins
+        run: pnpm install --frozen-lockfile
+      - name: Run package tests with coverage
+        id: package-tests
+        continue-on-error: true
+        env:
+          VITEST_COVERAGE_SHARD: ${{ matrix.index }}
+        run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=${{ matrix.shard }}
+      # Run-scoped cache keys transport blobs because download-artifact is not
+      # allowlisted. Shard-first prefixes support partial reruns without crossing runs.
+      - name: Save package coverage shard
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .vitest/blob/blob-${{ matrix.index }}-4.json
+          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-${{ matrix.index }}-${{ github.run_attempt }}
+      - name: Propagate package test failure
+        if: steps.package-tests.outcome == 'failure'
+        run: exit 1
+
   test:
     name: Test
-    needs: [build, changes]
+    needs: [build, changes, test-packages]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     env:
       TEST_TIMEOUT_MULTIPLIER: 2
@@ -193,20 +256,56 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Install dependencies (skip bin linking)
-        if: needs.changes.outputs.inert != 'true'
+        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build packages (restored from Turbo cache; needed for bin linking)
-        if: needs.changes.outputs.inert != 'true'
+        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
         run: pnpm build
       - name: Link bins
-        if: needs.changes.outputs.inert != 'true'
+        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
         run: pnpm install --frozen-lockfile
       - name: Start cloudflare-worker Postgres (5433, pg_stat_statements)
-        if: needs.changes.outputs.inert != 'true'
+        if: needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true'
         run: pnpm --filter prisma-8-cloudflare-worker db:up
-      - name: Test packages with coverage
-        if: needs.changes.outputs.inert != 'true'
-        run: pnpm coverage:packages
+      - name: Restore package coverage shard 1
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .vitest/blob/blob-1-4.json
+          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-1-${{ github.run_attempt }}
+          restore-keys: |
+            package-coverage-${{ runner.os }}-${{ github.run_id }}-1-
+          fail-on-cache-miss: true
+      - name: Restore package coverage shard 2
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .vitest/blob/blob-2-4.json
+          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-2-${{ github.run_attempt }}
+          restore-keys: |
+            package-coverage-${{ runner.os }}-${{ github.run_id }}-2-
+          fail-on-cache-miss: true
+      - name: Restore package coverage shard 3
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .vitest/blob/blob-3-4.json
+          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-3-${{ github.run_attempt }}
+          restore-keys: |
+            package-coverage-${{ runner.os }}-${{ github.run_id }}-3-
+          fail-on-cache-miss: true
+      - name: Restore package coverage shard 4
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .vitest/blob/blob-4-4.json
+          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-4-${{ github.run_attempt }}
+          restore-keys: |
+            package-coverage-${{ runner.os }}-${{ github.run_id }}-4-
+          fail-on-cache-miss: true
+      - name: Merge package tests and coverage
+        if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+        run: pnpm coverage:packages:merge
       - name: Report package coverage
         if: ${{ !cancelled() && needs.changes.outputs.inert != 'true' }}
         run: pnpm coverage:report
@@ -214,8 +313,11 @@ jobs:
         if: ${{ !cancelled() && needs.changes.outputs.inert != 'true' }}
         run: pnpm test:examples
       - name: Check working tree is clean
-        if: needs.changes.outputs.inert != 'true'
+        if: ${{ !cancelled() && needs.changes.outputs.inert != 'true' }}
         run: pnpm check:clean-tree
+      - name: Propagate prerequisite or package-shard failure
+        if: ${{ !cancelled() && (needs.build.result != 'success' || needs.changes.result != 'success' || (needs.changes.outputs.inert != 'true' && needs.test-packages.result != 'success')) }}
+        run: exit 1
 
   test-e2e:
     name: E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,26 +203,26 @@ jobs:
         env:
           VITEST_COVERAGE_SHARD: ${{ matrix.index }}
         run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=${{ matrix.index }}/4
-      # Run-scoped cache keys transport blobs because download-artifact is not
-      # allowlisted. Shard-first prefixes support partial reruns without crossing runs.
-      - name: Save package coverage shard
+      - name: Upload package coverage shard
         if: ${{ !cancelled() }}
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: package-coverage-${{ matrix.index }}
           path: .vitest/blob/blob-${{ matrix.index }}-4.json
-          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-${{ matrix.index }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
       - name: Propagate package test failure
         if: steps.package-tests.outcome == 'failure'
         run: exit 1
 
-  test:
-    name: Test
-    needs: [build, changes, test-packages]
-    if: ${{ !cancelled() }}
+  test-examples:
+    name: Test Examples
+    needs: [build, changes]
+    if: needs.changes.outputs.inert != 'true'
     runs-on: ubuntu-latest
     env:
       TEST_TIMEOUT_MULTIPLIER: 2
-      RUN_TEST_STEPS: ${{ needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
       # Used by examples/prisma-8-cloudflare-worker's vitest-pool-workers
       # integration test. Mirrors the .env.example pattern; the container is
       # brought up by `pnpm db:up` below (docker-compose, not a service
@@ -249,69 +249,61 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Install dependencies (skip bin linking)
-        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Build packages (restored from Turbo cache; needed for bin linking)
-        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm build
       - name: Link bins
-        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm install --frozen-lockfile
       - name: Start cloudflare-worker Postgres (5433, pg_stat_statements)
-        if: env.RUN_TEST_STEPS == 'true'
         run: pnpm --filter prisma-8-cloudflare-worker db:up
-      # GitHub Actions has no step-level matrix, and the merge needs every blob
-      # in this workspace, so the four fan-in restores remain explicit.
-      - name: Restore package coverage shard 1
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .vitest/blob/blob-1-4.json
-          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-1-${{ github.run_attempt }}
-          restore-keys: |
-            package-coverage-${{ runner.os }}-${{ github.run_id }}-1-
-          fail-on-cache-miss: true
-      - name: Restore package coverage shard 2
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .vitest/blob/blob-2-4.json
-          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-2-${{ github.run_attempt }}
-          restore-keys: |
-            package-coverage-${{ runner.os }}-${{ github.run_id }}-2-
-          fail-on-cache-miss: true
-      - name: Restore package coverage shard 3
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .vitest/blob/blob-3-4.json
-          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-3-${{ github.run_attempt }}
-          restore-keys: |
-            package-coverage-${{ runner.os }}-${{ github.run_id }}-3-
-          fail-on-cache-miss: true
-      - name: Restore package coverage shard 4
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .vitest/blob/blob-4-4.json
-          key: package-coverage-${{ runner.os }}-${{ github.run_id }}-4-${{ github.run_attempt }}
-          restore-keys: |
-            package-coverage-${{ runner.os }}-${{ github.run_id }}-4-
-          fail-on-cache-miss: true
-      - name: Merge package tests and coverage
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
-        run: pnpm coverage:packages:merge
-      - name: Report package coverage
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
-        run: pnpm coverage:report
       - name: Test examples
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         run: pnpm test:examples
       - name: Check working tree is clean
-        if: ${{ !cancelled() && env.RUN_TEST_STEPS == 'true' }}
         run: pnpm check:clean-tree
-      - name: Propagate prerequisite or package-shard failure
-        if: ${{ !cancelled() && (needs.build.result != 'success' || needs.changes.result != 'success' || (needs.changes.outputs.inert != 'true' && needs.test-packages.result != 'success')) }}
+
+  coverage:
+    name: Coverage
+    needs: [build, changes, test-packages]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.changes.result == 'success' && needs.changes.outputs.inert != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build packages (restored from Turbo cache)
+        run: pnpm build
+      - name: Download package coverage shards
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: package-coverage-*
+          path: .vitest/blob
+          merge-multiple: true
+      - name: Verify package coverage shards
+        run: |
+          test -f .vitest/blob/blob-1-4.json
+          test -f .vitest/blob/blob-2-4.json
+          test -f .vitest/blob/blob-3-4.json
+          test -f .vitest/blob/blob-4-4.json
+      - name: Merge package tests and coverage
+        run: pnpm coverage:packages:merge
+      - name: Report package coverage
+        if: ${{ !cancelled() }}
+        run: pnpm coverage:report
+      - name: Check working tree is clean
+        if: ${{ !cancelled() }}
+        run: pnpm check:clean-tree
+
+  test:
+    name: Test
+    needs: [build, changes, test-packages, test-examples, coverage]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Propagate test failures
+        if: ${{ needs.build.result != 'success' || needs.changes.result != 'success' || (needs.changes.outputs.inert != 'true' && (needs.test-packages.result != 'success' || needs.test-examples.result != 'success' || needs.coverage.result != 'success')) }}
         run: exit 1
 
   test-e2e:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 .env.local
 .env.*.local
 .turbo
+.vitest
 *.tsbuildinfo
 packages/e2e-tests/.tmp-output
 /wip/*

--- a/docs/Testing Guide.md
+++ b/docs/Testing Guide.md
@@ -145,11 +145,13 @@ it('emits contract and verifies it matches on-disk artifacts', async () => {
 
 ## Package coverage
 
-Package coverage policy lives in each Vitest project's adjacent `coverage.config.json`; `vitest.config.ts` contains only test-project configuration. `pnpm coverage:packages` first builds the same package-only prerequisites as `pnpm test:packages`, then runs all 70 package Vitest projects with coverage in exactly one root `vitest run --coverage` process. Ordinary `pnpm test` and `pnpm test:packages` remain the faster noncoverage paths.
+Package coverage policy lives in each Vitest project's adjacent `coverage.config.json`. `pnpm coverage:packages` first builds the same package-only prerequisites as `pnpm test:packages`, then runs every package Vitest project with coverage in one root process. Ordinary `pnpm test` and `pnpm test:packages` remain the faster noncoverage paths.
 
-Each entry in `coverage/coverage-final.json` is attributed to the package that owns the entry's source path, not to a test project. Examples are not coverage projects and remain separately exercised by `pnpm test:examples`.
+CI divides that same root project set into four Vitest shards. Each shard writes a native blob report with coverage thresholds disabled for the partial run. The stable `Test` fan-in job requires all four blobs, runs `pnpm coverage:packages:merge`, and only then applies the full coverage policy. Missing or failed shards therefore cannot produce a passing gate.
 
-`pnpm coverage:report` reads the root run's `coverage/coverage-final.json`, prints package-level threshold diagnostics, and exits nonzero when the policy fails. CI runs this report immediately after `pnpm coverage:packages`, even when the coverage run failed, so available diagnostics are still shown. Root `coverage.config.json` warning-only entries temporarily relax coverage thresholds only; they never suppress Vitest assertion failures, whose root process exit always blocks CI. Fix a threshold miss by covering genuinely untested branches, never by lowering the threshold.
+Each entry in the merged `coverage/coverage-final.json` is attributed to the package that owns the entry's source path, not to a test project. Examples are not coverage projects and remain separately exercised by `pnpm test:examples`.
+
+`pnpm coverage:report` reads `coverage/coverage-final.json`, prints package-level threshold diagnostics, and exits nonzero when the policy fails. CI runs this report after the native Vitest merge even when merged tests or coverage failed, so available diagnostics are still shown. Root `coverage.config.json` warning-only entries temporarily relax coverage thresholds only; they never suppress assertion failures, which block both their shard and the merged `Test` gate. Fix a threshold miss by covering genuinely untested branches, never by lowering the threshold.
 
 ---
 
@@ -1011,6 +1013,9 @@ pnpm coverage:packages
 
 # Alias for the same package-only coverage path
 pnpm test:coverage
+
+# CI fan-in only: merge native shard blobs and generate coverage-final.json
+pnpm coverage:packages:merge
 
 # Report policy results from coverage/coverage-final.json
 pnpm coverage:report

--- a/docs/Testing Guide.md
+++ b/docs/Testing Guide.md
@@ -147,11 +147,11 @@ it('emits contract and verifies it matches on-disk artifacts', async () => {
 
 Package coverage policy lives in each Vitest project's adjacent `coverage.config.json`. `pnpm coverage:packages` first builds the same package-only prerequisites as `pnpm test:packages`, then runs every package Vitest project with coverage in one root process. Ordinary `pnpm test` and `pnpm test:packages` remain the faster noncoverage paths.
 
-CI divides that same root project set into four Vitest shards. Each shard writes a native blob report with coverage thresholds disabled for the partial run. The stable `Test` fan-in job requires all four blobs, runs `pnpm coverage:packages:merge`, and only then applies the full coverage policy. Missing or failed shards therefore cannot produce a passing gate.
+CI divides that same root project set into four Vitest shards. Each shard uploads a native blob report with coverage thresholds disabled for the partial run. The `Coverage` job downloads all matching artifacts into one directory, verifies all four expected blobs are present, runs `pnpm coverage:packages:merge`, and only then applies the full coverage policy. A final lightweight `Test` job preserves the required status name and requires package shards, coverage, and examples to pass. Missing or failed shards therefore cannot produce a passing gate.
 
 Each entry in the merged `coverage/coverage-final.json` is attributed to the package that owns the entry's source path, not to a test project. Examples are not coverage projects and remain separately exercised by `pnpm test:examples`.
 
-`pnpm coverage:report` reads `coverage/coverage-final.json`, prints package-level threshold diagnostics, and exits nonzero when the policy fails. CI runs this report after the native Vitest merge even when merged tests or coverage failed, so available diagnostics are still shown. Root `coverage.config.json` warning-only entries temporarily relax coverage thresholds only; they never suppress assertion failures, which block both their shard and the merged `Test` gate. Fix a threshold miss by covering genuinely untested branches, never by lowering the threshold.
+`pnpm coverage:report` reads `coverage/coverage-final.json`, prints package-level threshold diagnostics, and exits nonzero when the policy fails. CI runs this report in `Coverage` after the native Vitest merge even when merged tests or coverage failed, so available diagnostics are still shown. Root `coverage.config.json` warning-only entries temporarily relax coverage thresholds only; they never suppress assertion failures, which block both their shard and the final `Test` gate. Fix a threshold miss by covering genuinely untested branches, never by lowering the threshold.
 
 ---
 

--- a/docs/onboarding/Testing.md
+++ b/docs/onboarding/Testing.md
@@ -16,7 +16,7 @@ pnpm coverage:packages:merge  # CI fan-in: merge native shard blobs into one cov
 pnpm coverage:report          # Report package policy results from the existing root coverage output
 ```
 
-Package coverage policies live in `coverage.config.json` beside each package's `vitest.config.ts`. A local root run executes all package Vitest projects in one process. CI executes four native Vitest shards with partial-run thresholds disabled, then the stable `Test` job requires every blob and applies thresholds to their merged coverage. Each entry in `coverage/coverage-final.json` is attributed to the package that owns the entry's source path. Examples are tested separately with `pnpm test:examples` and do not contribute to package coverage. Root warning-only entries relax thresholds only; Vitest assertion failures always block.
+Package coverage policies live in `coverage.config.json` beside each package's `vitest.config.ts`. A local root run executes all package Vitest projects in one process. CI executes four native Vitest shards with partial-run thresholds disabled, uploads their blobs, and has `Coverage` verify and merge all four before applying thresholds. A lightweight final `Test` job requires package shards, coverage, and examples to pass while preserving the required status name. Each entry in `coverage/coverage-final.json` is attributed to the package that owns the entry's source path. Examples do not contribute to package coverage. Root warning-only entries relax thresholds only; Vitest assertion failures always block.
 
 > Integration tests (`test/integration`) run against each package's built `dist`, not its source. After changing a package's source, rebuild it (e.g. `pnpm --filter <pkg> build`) before running a bare `vitest` filter, or the test will exercise stale output. The full `pnpm test:integration` pretest builds automatically, so this only bites targeted runs.
 
@@ -26,8 +26,10 @@ CI runs on pull requests via GitHub Actions (`.github/workflows/ci.yml`):
 
 - **typecheck** + **lint**: Run in parallel, no dependencies
 - **build**: Compiles all packages
-- **test-packages**: Runs package tests and coverage across four Vitest shards; requires Postgres
-- **test** (`Test`): Preserves the required check name, requires every package shard, merges coverage before applying package thresholds, reports diagnostics after failures, then tests examples once; requires Postgres
+- **test-packages**: Runs package tests and coverage across four Vitest shards, uploading one blob per shard; requires Postgres
+- **test-examples**: Tests examples concurrently with the package shards; requires Postgres
+- **coverage**: Downloads and verifies every shard blob, merges coverage, and applies package thresholds
+- **test** (`Test`): Preserves the required check name as a lightweight final gate over package shards, coverage, and examples
 - **test-e2e**: Runs after build and requires Postgres
 
 Environment: Node 24.16.0, pnpm 10, Postgres 15. `TEST_TIMEOUT_MULTIPLIER=2` in CI.

--- a/docs/onboarding/Testing.md
+++ b/docs/onboarding/Testing.md
@@ -11,11 +11,12 @@ pnpm test:packages      # Unit tests for packages only
 pnpm test:integration   # Integration tests (pretest builds first)
 pnpm test:e2e           # End-to-end tests
 pnpm test:all           # All tests (packages + examples + integration + e2e)
-pnpm coverage:packages  # Build package prerequisites, then run package coverage once at the root
-pnpm coverage:report    # Report package policy results from the existing root coverage output
+pnpm coverage:packages        # Build package prerequisites, then run package coverage once at the root
+pnpm coverage:packages:merge  # CI fan-in: merge native shard blobs into one coverage report
+pnpm coverage:report          # Report package policy results from the existing root coverage output
 ```
 
-Package coverage policies live in `coverage.config.json` beside each package's `vitest.config.ts`. The root run executes all package Vitest projects in one process. Each entry in `coverage/coverage-final.json` is attributed to the package that owns the entry's source path. Examples are tested separately with `pnpm test:examples` and do not contribute to package coverage. Root warning-only entries relax thresholds only; Vitest assertion failures always block.
+Package coverage policies live in `coverage.config.json` beside each package's `vitest.config.ts`. A local root run executes all package Vitest projects in one process. CI executes four native Vitest shards with partial-run thresholds disabled, then the stable `Test` job requires every blob and applies thresholds to their merged coverage. Each entry in `coverage/coverage-final.json` is attributed to the package that owns the entry's source path. Examples are tested separately with `pnpm test:examples` and do not contribute to package coverage. Root warning-only entries relax thresholds only; Vitest assertion failures always block.
 
 > Integration tests (`test/integration`) run against each package's built `dist`, not its source. After changing a package's source, rebuild it (e.g. `pnpm --filter <pkg> build`) before running a bare `vitest` filter, or the test will exercise stale output. The full `pnpm test:integration` pretest builds automatically, so this only bites targeted runs.
 
@@ -25,7 +26,8 @@ CI runs on pull requests via GitHub Actions (`.github/workflows/ci.yml`):
 
 - **typecheck** + **lint**: Run in parallel, no dependencies
 - **build**: Compiles all packages
-- **test** (`Test & Coverage`): Runs package tests once through the root coverage process, reports package threshold policy even after a failed coverage run, then tests examples once; requires Postgres
+- **test-packages**: Runs package tests and coverage across four Vitest shards; requires Postgres
+- **test** (`Test`): Preserves the required check name, requires every package shard, merges coverage before applying package thresholds, reports diagnostics after failures, then tests examples once; requires Postgres
 - **test-e2e**: Runs after build and requires Postgres
 
 Environment: Node 24.16.0, pnpm 10, Postgres 15. `TEST_TIMEOUT_MULTIPLIER=2` in CI.

--- a/docs/oss/ci-pipeline.md
+++ b/docs/oss/ci-pipeline.md
@@ -4,7 +4,7 @@ This page documents how the pull-request CI pipeline ([`.github/workflows/ci.yml
 
 ## What runs on a PR
 
-`ci.yml` runs eight jobs. Seven do real verification — `Build`, `Type Check`, `Lint`, `Test`, `E2E Tests`, `Integration Tests`, `Coverage` — and a small `Detect inert diff` job classifies the diff (below). A separate `DCO` check and the preview-publish workflow also run. `main` is governed by a repository ruleset that requires the verification contexts plus `DCO` and uses the strict "branch must be up to date" policy. Two consequences drive the whole design:
+`ci.yml` reports stable verification contexts including `Build`, `Type Check`, `Lint`, `Test`, `E2E Tests`, and `Integration Tests`; a small `Detect inert diff` job classifies the diff (below). `Test` is a fan-in over four non-required `Package Tests` shard jobs, so the required check name remains stable while package execution scales horizontally. A separate `DCO` check and the preview-publish workflow also run. `main` is governed by a repository ruleset that requires the verification contexts plus `DCO` and uses the strict "branch must be up to date" policy. Two consequences drive the whole design:
 
 - A required status check that never reports its result **wedges the merge**. So a job that is required can never be skipped at the job level — it must always launch and report.
 - The ruleset is a fixed constraint. The pipeline is designed *around* it; CI changes never edit the ruleset or the set of required check names.
@@ -19,11 +19,11 @@ Every job needs the workspace built. Rather than have each job rebuild the 92-pa
 
 The single-writer rule is load-bearing for both correctness and safety: because only `build` ever writes, the persisted cache contains build outputs only — test and coverage results can never leak into it. (An earlier shape that let every job write the same key let a non-building job win the save race and persist a build-less cache, which made downstream jobs rebuild anyway. Making every job `needs: build` is what fixes it.)
 
-Test, e2e, integration, and coverage **results are never cached.** Their pass/fail is not a pure function of Turbo's declared inputs (services, pass-through env), so a stale cached "pass" could mask a real regression. Tests always execute for real.
+Test, e2e, integration, and coverage results are never reused across workflow runs or commits. Their pass/fail is not a pure function of Turbo's declared inputs (services, pass-through env), so a stale "pass" could mask a real regression. Package coverage shards use `actions/cache/save` and `actions/cache/restore` only as same-run blob transport because `actions/download-artifact` is not allowlisted: keys include the run ID, shard index, and run attempt. Fan-in prefers the current attempt and may fall back only to the same shard from an earlier attempt of that run, which supports “re-run failed jobs” without admitting another commit's results. Every shard must restore before the merge.
 
 ## Skip the heavy work on inert diffs
 
-A PR that only edits documentation should not boot Postgres and run the full test matrix. The `Detect inert diff` job emits an `inert` boolean, and the expensive steps of `Test` / `E2E Tests` / `Integration Tests` / `Coverage` / `Fixtures` guard on it:
+A PR that only edits documentation should not boot Postgres and run the full test matrix. The `Detect inert diff` job emits an `inert` boolean. The non-required package-test matrix is skipped at the job level, while expensive steps of the required `Test` fan-in and the `E2E Tests` / `Integration Tests` / `Fixtures` jobs guard on it:
 
 ```yaml
 - name: Run Integration tests
@@ -31,7 +31,7 @@ A PR that only edits documentation should not boot Postgres and run the full tes
   run: pnpm test:integration
 ```
 
-Because required jobs cannot be skipped at the job level (they would never report), the jobs always launch and report green; only their *steps* are gated. On an inert PR those jobs run their checkout + cache-restore and then skip the heavy work, finishing in seconds. `Type Check` and `Build` always run but are near-free via the Turbo cache, and `Lint` always runs in full — it is exactly what validates the docs/rules/skills/README changes an inert diff is made of.
+Because required jobs cannot be skipped at the job level (they would never report), those jobs always launch and report green; only their *steps* are gated. The package-test shards are implementation details rather than required contexts, so they may be skipped entirely. On an inert PR the stable `Test` fan-in and other required jobs run checkout + cache restore, skip their heavy work, and finish in seconds. `Type Check` and `Build` always run but are near-free via the Turbo cache, and `Lint` always runs in full — it is exactly what validates the docs/rules/skills/README changes an inert diff is made of.
 
 ### The inert predicate
 
@@ -41,7 +41,7 @@ The classification lives in one place — the [`.github/actions/detect-inert-dif
 
 ## Constraints that shaped this
 
-- **Hardened Allowed-Actions policy.** The repository only permits an explicit SHA-pinned allow-list of actions. `actions/download-artifact` is not on it, which is why build outputs are shared through `actions/cache` rather than uploaded/downloaded as artifacts; any new action (including first-party ones) must be added to the allow-list before it can run. See [supply chain](./supply-chain.md).
+- **Hardened Allowed-Actions policy.** The repository only permits an explicit SHA-pinned allow-list of actions. `actions/download-artifact` is not on it, which is why build outputs use the Turbo cache and package coverage blobs use exact-key, same-run cache transport rather than artifacts; any new action (including first-party ones) must be added to the allow-list before it can run. See [supply chain](./supply-chain.md).
 - **No third-party cache action or remote-cache token.** Caching is first-party `actions/cache` only, preserving the fork-PR posture in [supply chain](./supply-chain.md) (fork PRs get cold caches by design).
 - **Least-privilege token.** `ci.yml` grants `GITHUB_TOKEN` only `contents: read`; the caches use the runner's cache runtime token, not `GITHUB_TOKEN`. Checkout steps set `persist-credentials: false`.
 

--- a/docs/oss/ci-pipeline.md
+++ b/docs/oss/ci-pipeline.md
@@ -41,7 +41,7 @@ The classification lives in one place — the [`.github/actions/detect-inert-dif
 
 ## Constraints that shaped this
 
-- **Hardened Allowed-Actions policy.** The repository only permits an explicit SHA-pinned allow-list of actions. Package coverage transport uses SHA-pinned `actions/upload-artifact` and `actions/download-artifact`; both repositories must remain on that allow-list. See [supply chain](./supply-chain.md).
+- **Hardened Allowed-Actions policy.** GitHub-created actions in the `actions` and `github` organizations are allowed as a category, while non-GitHub actions require explicit approval. Package coverage transport uses full-SHA-pinned `actions/upload-artifact` and `actions/download-artifact`, so it needs no individual allow-list entries. See GitHub's [allowed-actions documentation](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#allowing-select-actions-and-reusable-workflows-to-run) and [supply chain](./supply-chain.md).
 - **No third-party cache action or remote-cache token.** Caching is first-party `actions/cache` only, preserving the fork-PR posture in [supply chain](./supply-chain.md) (fork PRs get cold caches by design).
 - **Least-privilege token.** `ci.yml` grants `GITHUB_TOKEN` only `contents: read`; the caches use the runner's cache runtime token, not `GITHUB_TOKEN`. Checkout steps set `persist-credentials: false`.
 

--- a/docs/oss/ci-pipeline.md
+++ b/docs/oss/ci-pipeline.md
@@ -4,7 +4,7 @@ This page documents how the pull-request CI pipeline ([`.github/workflows/ci.yml
 
 ## What runs on a PR
 
-`ci.yml` reports stable verification contexts including `Build`, `Type Check`, `Lint`, `Test`, `E2E Tests`, and `Integration Tests`; a small `Detect inert diff` job classifies the diff (below). `Test` is a fan-in over four non-required `Package Tests` shard jobs, so the required check name remains stable while package execution scales horizontally. A separate `DCO` check and the preview-publish workflow also run. `main` is governed by a repository ruleset that requires the verification contexts plus `DCO` and uses the strict "branch must be up to date" policy. Two consequences drive the whole design:
+`ci.yml` reports stable verification contexts including `Build`, `Type Check`, `Lint`, `Test`, `E2E Tests`, and `Integration Tests`; a small `Detect inert diff` job classifies the diff (below). Four non-required `Package Tests` shards upload native coverage blobs, `Coverage` merges and gates them while `Test Examples` runs concurrently, and a lightweight final `Test` fan-in preserves the required check name. A separate `DCO` check and the preview-publish workflow also run. `main` is governed by a repository ruleset that requires the verification contexts plus `DCO` and uses the strict "branch must be up to date" policy. Two consequences drive the whole design:
 
 - A required status check that never reports its result **wedges the merge**. So a job that is required can never be skipped at the job level — it must always launch and report.
 - The ruleset is a fixed constraint. The pipeline is designed *around* it; CI changes never edit the ruleset or the set of required check names.
@@ -19,11 +19,11 @@ Every job needs the workspace built. Rather than have each job rebuild the 92-pa
 
 The single-writer rule is load-bearing for both correctness and safety: because only `build` ever writes, the persisted cache contains build outputs only — test and coverage results can never leak into it. (An earlier shape that let every job write the same key let a non-building job win the save race and persist a build-less cache, which made downstream jobs rebuild anyway. Making every job `needs: build` is what fixes it.)
 
-Test, e2e, integration, and coverage results are never reused across workflow runs or commits. Their pass/fail is not a pure function of Turbo's declared inputs (services, pass-through env), so a stale "pass" could mask a real regression. Package coverage shards use `actions/cache/save` and `actions/cache/restore` only as same-run blob transport because `actions/download-artifact` is not allowlisted: keys include the run ID, shard index, and run attempt. Fan-in prefers the current attempt and may fall back only to the same shard from an earlier attempt of that run, which supports “re-run failed jobs” without admitting another commit's results. Every shard must restore before the merge.
+Test, e2e, integration, and coverage results are never reused across workflow runs, attempts, or commits. Their pass/fail is not a pure function of Turbo's declared inputs (services, pass-through env), so a stale "pass" could mask a real regression. Package coverage shards upload uniquely named, one-day artifacts scoped to the current workflow attempt. `Coverage` downloads the `package-coverage-*` set into one directory and verifies all four expected blob filenames before merging. GitHub makes prior-attempt artifacts inaccessible, so use **Re-run all jobs**, not **Re-run failed jobs**, when retrying this workflow; a partial rerun safely fails the four-file check.
 
 ## Skip the heavy work on inert diffs
 
-A PR that only edits documentation should not boot Postgres and run the full test matrix. The `Detect inert diff` job emits an `inert` boolean. The non-required package-test matrix is skipped at the job level, while expensive steps of the required `Test` fan-in and the `E2E Tests` / `Integration Tests` / `Fixtures` jobs guard on it:
+A PR that only edits documentation should not boot Postgres and run the full test matrix. The `Detect inert diff` job emits an `inert` boolean. The non-required package-test, example-test, and coverage jobs are skipped at the job level, while expensive steps of the `E2E Tests` / `Integration Tests` / `Fixtures` jobs guard on it:
 
 ```yaml
 - name: Run Integration tests
@@ -31,7 +31,7 @@ A PR that only edits documentation should not boot Postgres and run the full tes
   run: pnpm test:integration
 ```
 
-Because required jobs cannot be skipped at the job level (they would never report), those jobs always launch and report green; only their *steps* are gated. The package-test shards are implementation details rather than required contexts, so they may be skipped entirely. On an inert PR the stable `Test` fan-in and other required jobs run checkout + cache restore, skip their heavy work, and finish in seconds. `Type Check` and `Build` always run but are near-free via the Turbo cache, and `Lint` always runs in full — it is exactly what validates the docs/rules/skills/README changes an inert diff is made of.
+Because required jobs cannot be skipped at the job level (they would never report), those jobs always launch and report green; only their *steps* are gated. Package shards, examples, and coverage are implementation details rather than required contexts, so they may be skipped entirely. On an inert PR the stable `Test` fan-in launches without setup and succeeds once its prerequisite checks are healthy. `Type Check` and `Build` always run but are near-free via the Turbo cache, and `Lint` always runs in full — it is exactly what validates the docs/rules/skills/README changes an inert diff is made of.
 
 ### The inert predicate
 
@@ -41,7 +41,7 @@ The classification lives in one place — the [`.github/actions/detect-inert-dif
 
 ## Constraints that shaped this
 
-- **Hardened Allowed-Actions policy.** The repository only permits an explicit SHA-pinned allow-list of actions. `actions/download-artifact` is not on it, which is why build outputs use the Turbo cache and package coverage blobs use exact-key, same-run cache transport rather than artifacts; any new action (including first-party ones) must be added to the allow-list before it can run. See [supply chain](./supply-chain.md).
+- **Hardened Allowed-Actions policy.** The repository only permits an explicit SHA-pinned allow-list of actions. Package coverage transport uses SHA-pinned `actions/upload-artifact` and `actions/download-artifact`; both repositories must remain on that allow-list. See [supply chain](./supply-chain.md).
 - **No third-party cache action or remote-cache token.** Caching is first-party `actions/cache` only, preserving the fork-PR posture in [supply chain](./supply-chain.md) (fork PRs get cold caches by design).
 - **Least-privilege token.** `ci.yml` grants `GITHUB_TOKEN` only `contents: read`; the caches use the runner's cache runtime token, not `GITHUB_TOKEN`. Checkout steps set `persist-credentials: false`.
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:coverage": "pnpm coverage:packages",
     "coverage:report": "node scripts/coverage-report.mjs",
     "coverage:packages": "turbo run build --filter='!./examples/**' --filter='!./test/**' && vitest run --coverage",
+    "coverage:packages:merge": "vitest --merge-reports=.vitest/blob --coverage",
     "lint": "turbo run lint",
     "lint:agent": "node scripts/run-logged.mjs lint pnpm lint",
     "lint:fix": "pnpm biome check --write .",

--- a/scripts/coverage-config.test.mjs
+++ b/scripts/coverage-config.test.mjs
@@ -254,6 +254,10 @@ describe('coverage config', () => {
       "turbo run build --filter='!./examples/**' --filter='!./test/**' && vitest run --coverage",
     );
     assert.equal(rootManifest.scripts['test:coverage'], 'pnpm coverage:packages');
+    assert.equal(
+      rootManifest.scripts['coverage:packages:merge'],
+      'vitest --merge-reports=.vitest/blob --coverage',
+    );
     assert.equal(rootManifest.scripts['coverage:report'], 'node scripts/coverage-report.mjs');
 
     for await (const path of glob('packages/**/package.json', { cwd: repositoryRoot })) {
@@ -269,27 +273,75 @@ describe('coverage config', () => {
     assert.match(rootVitestConfig, /from ['"]\.\/scripts\/coverage-config['"]/);
     assert.doesNotMatch(rootVitestConfig, /from ['"]\.\/scripts\/coverage-config\.[^'"]+['"]/);
     assert.match(rootVitestConfig, /provider:\s*['"]v8['"]/);
+    assert.match(rootVitestConfig, /process\.env\[['"]VITEST_COVERAGE_SHARD['"]\]/);
+    assert.match(
+      rootVitestConfig,
+      /thresholds:\s*coverageShard\s*\?\s*\{\}\s*:\s*coveragePolicy\.thresholds/,
+    );
     assert.match(rootVitestConfig, /reportOnFailure:\s*true/);
   });
 
-  it('combines package tests and coverage in one CI job', async () => {
+  it('shards package tests and merges coverage behind one Test gate', async () => {
     const repositoryRoot = join(import.meta.dirname, '..');
     const workflow = await readFile(join(repositoryRoot, '.github/workflows/ci.yml'), 'utf8');
+    const shardJob = workflow.match(/\n {2}test-packages:\n(?<body>[\s\S]*?)(?=\n {2}test:\n)/)
+      ?.groups?.body;
     const testJob = workflow.match(/\n {2}test:\n(?<body>[\s\S]*?)(?=\n {2}test-e2e:\n)/)?.groups
       ?.body;
 
+    assert.ok(shardJob);
+    assert.match(shardJob, /^ {4}name: Package Tests \(\$\{\{ matrix\.shard \}\}\)$/m);
+    assert.match(shardJob, /^ {4}if: needs\.changes\.outputs\.inert != 'true'$/m);
+    assert.equal(shardJob.match(/shard: [1-4]\/4/g)?.length, 4);
+    assert.match(shardJob, /VITEST_COVERAGE_SHARD: \$\{\{ matrix\.index \}\}/);
+    assert.match(
+      shardJob,
+      /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=\$\{\{ matrix\.shard \}\}/,
+    );
+    assert.match(shardJob, /uses: actions\/cache\/save@27d5ce7f107fe9357f9df03efb73ab90386fccae/);
+    assert.match(shardJob, /path: \.vitest\/blob\/blob-\$\{\{ matrix\.index \}\}-4\.json/);
+    assert.match(
+      shardJob,
+      /key: package-coverage-\$\{\{ runner\.os \}\}-\$\{\{ github\.run_id \}\}-\$\{\{ matrix\.index \}\}-\$\{\{ github\.run_attempt \}\}/,
+    );
+    assert.match(
+      shardJob,
+      /continue-on-error: true[\s\S]*if: steps\.package-tests\.outcome == 'failure'\n {8}run: exit 1/,
+    );
+
     assert.ok(testJob);
     assert.match(testJob, /^ {4}name: Test$/m);
+    assert.match(testJob, /^ {4}needs: \[build, changes, test-packages\]$/m);
+    assert.equal(
+      testJob.match(/uses: actions\/cache\/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae/g)
+        ?.length,
+      4,
+    );
+    assert.equal(testJob.match(/fail-on-cache-miss: true/g)?.length, 4);
+    assert.equal(
+      testJob.match(
+        /path: \.vitest\/blob\/blob-([1-4])-4\.json\n {10}key: package-coverage-\$\{\{ runner\.os \}\}-\$\{\{ github\.run_id \}\}-\1-\$\{\{ github\.run_attempt \}\}\n {10}restore-keys: \|\n {12}package-coverage-\$\{\{ runner\.os \}\}-\$\{\{ github\.run_id \}\}-\1-/g,
+      )?.length,
+      4,
+    );
+    assert.match(testJob, /needs\.test-packages\.result != 'success'[\s\S]*run: exit 1/);
     assert.match(
       testJob,
-      /run: pnpm coverage:packages\n {6}- name: Report package coverage\n {8}if: \$\{\{ !cancelled\(\) && needs\.changes\.outputs\.inert != 'true' \}\}\n {8}run: pnpm coverage:report/,
+      /run: pnpm coverage:packages:merge\n {6}- name: Report package coverage\n {8}if: \$\{\{ !cancelled\(\) && needs\.changes\.outputs\.inert != 'true' \}\}\n {8}run: pnpm coverage:report/,
     );
     assert.match(
       testJob,
       /- name: Test examples\n {8}if: \$\{\{ !cancelled\(\) && needs\.changes\.outputs\.inert != 'true' \}\}\n {8}run: pnpm test:examples/,
     );
     assert.doesNotMatch(workflow, /\n {2}coverage:\n/);
-    assert.equal(workflow.match(/run: pnpm coverage:packages/g)?.length, 1);
+    assert.equal(
+      workflow.match(
+        /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob/g,
+      )?.length,
+      1,
+    );
+    assert.equal(workflow.match(/run: pnpm coverage:packages:merge/g)?.length, 1);
+    assert.equal(workflow.match(/run: pnpm coverage:report/g)?.length, 1);
     assert.equal(workflow.match(/run: pnpm test:examples/g)?.length, 1);
   });
 });

--- a/scripts/coverage-config.test.mjs
+++ b/scripts/coverage-config.test.mjs
@@ -290,13 +290,14 @@ describe('coverage config', () => {
       ?.body;
 
     assert.ok(shardJob);
-    assert.match(shardJob, /^ {4}name: Package Tests \(\$\{\{ matrix\.shard \}\}\)$/m);
+    assert.match(shardJob, /^ {4}name: Package Tests \(\$\{\{ matrix\.index \}\}\/4\)$/m);
     assert.match(shardJob, /^ {4}if: needs\.changes\.outputs\.inert != 'true'$/m);
-    assert.equal(shardJob.match(/shard: [1-4]\/4/g)?.length, 4);
+    assert.match(shardJob, /index: \[1, 2, 3, 4\]/);
+    assert.doesNotMatch(shardJob, /^\s+shard:/m);
     assert.match(shardJob, /VITEST_COVERAGE_SHARD: \$\{\{ matrix\.index \}\}/);
     assert.match(
       shardJob,
-      /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=\$\{\{ matrix\.shard \}\}/,
+      /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=\$\{\{ matrix\.index \}\}\/4/,
     );
     assert.match(shardJob, /uses: actions\/cache\/save@27d5ce7f107fe9357f9df03efb73ab90386fccae/);
     assert.match(shardJob, /path: \.vitest\/blob\/blob-\$\{\{ matrix\.index \}\}-4\.json/);
@@ -312,6 +313,18 @@ describe('coverage config', () => {
     assert.ok(testJob);
     assert.match(testJob, /^ {4}name: Test$/m);
     assert.match(testJob, /^ {4}needs: \[build, changes, test-packages\]$/m);
+    assert.match(
+      testJob,
+      /RUN_TEST_STEPS: \$\{\{ needs\.build\.result == 'success' && needs\.changes\.result == 'success' && needs\.changes\.outputs\.inert != 'true' \}\}/,
+    );
+    assert.equal(
+      testJob.match(
+        /needs\.build\.result == 'success' && needs\.changes\.result == 'success' && needs\.changes\.outputs\.inert != 'true'/g,
+      )?.length,
+      1,
+    );
+    assert.match(testJob, /if: env\.RUN_TEST_STEPS == 'true'/);
+    assert.match(testJob, /GitHub Actions has no step-level matrix/);
     assert.equal(
       testJob.match(/uses: actions\/cache\/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae/g)
         ?.length,
@@ -327,16 +340,16 @@ describe('coverage config', () => {
     assert.match(testJob, /needs\.test-packages\.result != 'success'[\s\S]*run: exit 1/);
     assert.match(
       testJob,
-      /run: pnpm coverage:packages:merge\n {6}- name: Report package coverage\n {8}if: \$\{\{ !cancelled\(\) && needs\.changes\.outputs\.inert != 'true' \}\}\n {8}run: pnpm coverage:report/,
+      /run: pnpm coverage:packages:merge\n {6}- name: Report package coverage\n {8}if: \$\{\{ !cancelled\(\) && env\.RUN_TEST_STEPS == 'true' \}\}\n {8}run: pnpm coverage:report/,
     );
     assert.match(
       testJob,
-      /- name: Test examples\n {8}if: \$\{\{ !cancelled\(\) && needs\.changes\.outputs\.inert != 'true' \}\}\n {8}run: pnpm test:examples/,
+      /- name: Test examples\n {8}if: \$\{\{ !cancelled\(\) && env\.RUN_TEST_STEPS == 'true' \}\}\n {8}run: pnpm test:examples/,
     );
     assert.doesNotMatch(workflow, /\n {2}coverage:\n/);
     assert.equal(
       workflow.match(
-        /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob/g,
+        /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=\$\{\{ matrix\.index \}\}\/4/g,
       )?.length,
       1,
     );

--- a/scripts/coverage-config.test.mjs
+++ b/scripts/coverage-config.test.mjs
@@ -281,10 +281,16 @@ describe('coverage config', () => {
     assert.match(rootVitestConfig, /reportOnFailure:\s*true/);
   });
 
-  it('shards package tests and merges coverage behind one Test gate', async () => {
+  it('fans sharded coverage artifacts into one stable Test gate', async () => {
     const repositoryRoot = join(import.meta.dirname, '..');
     const workflow = await readFile(join(repositoryRoot, '.github/workflows/ci.yml'), 'utf8');
-    const shardJob = workflow.match(/\n {2}test-packages:\n(?<body>[\s\S]*?)(?=\n {2}test:\n)/)
+    const shardJob = workflow.match(
+      /\n {2}test-packages:\n(?<body>[\s\S]*?)(?=\n {2}test-examples:\n)/,
+    )?.groups?.body;
+    const examplesJob = workflow.match(
+      /\n {2}test-examples:\n(?<body>[\s\S]*?)(?=\n {2}coverage:\n)/,
+    )?.groups?.body;
+    const coverageJob = workflow.match(/\n {2}coverage:\n(?<body>[\s\S]*?)(?=\n {2}test:\n)/)
       ?.groups?.body;
     const testJob = workflow.match(/\n {2}test:\n(?<body>[\s\S]*?)(?=\n {2}test-e2e:\n)/)?.groups
       ?.body;
@@ -293,66 +299,58 @@ describe('coverage config', () => {
     assert.match(shardJob, /^ {4}name: Package Tests \(\$\{\{ matrix\.index \}\}\/4\)$/m);
     assert.match(shardJob, /^ {4}if: needs\.changes\.outputs\.inert != 'true'$/m);
     assert.match(shardJob, /index: \[1, 2, 3, 4\]/);
-    assert.doesNotMatch(shardJob, /^\s+shard:/m);
     assert.match(shardJob, /VITEST_COVERAGE_SHARD: \$\{\{ matrix\.index \}\}/);
     assert.match(
       shardJob,
       /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=\$\{\{ matrix\.index \}\}\/4/,
     );
-    assert.match(shardJob, /uses: actions\/cache\/save@27d5ce7f107fe9357f9df03efb73ab90386fccae/);
-    assert.match(shardJob, /path: \.vitest\/blob\/blob-\$\{\{ matrix\.index \}\}-4\.json/);
     assert.match(
       shardJob,
-      /key: package-coverage-\$\{\{ runner\.os \}\}-\$\{\{ github\.run_id \}\}-\$\{\{ matrix\.index \}\}-\$\{\{ github\.run_attempt \}\}/,
+      /uses: actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/,
     );
+    assert.match(shardJob, /name: package-coverage-\$\{\{ matrix\.index \}\}/);
+    assert.match(shardJob, /path: \.vitest\/blob\/blob-\$\{\{ matrix\.index \}\}-4\.json/);
+    assert.match(shardJob, /if-no-files-found: error/);
+    assert.match(shardJob, /include-hidden-files: true/);
     assert.match(
       shardJob,
       /continue-on-error: true[\s\S]*if: steps\.package-tests\.outcome == 'failure'\n {8}run: exit 1/,
     );
 
+    assert.ok(examplesJob);
+    assert.match(examplesJob, /^ {4}name: Test Examples$/m);
+    assert.match(examplesJob, /^ {4}needs: \[build, changes\]$/m);
+    assert.match(examplesJob, /run: pnpm test:examples/);
+
+    assert.ok(coverageJob);
+    assert.match(coverageJob, /^ {4}name: Coverage$/m);
+    assert.match(coverageJob, /^ {4}needs: \[build, changes, test-packages\]$/m);
+    assert.doesNotMatch(coverageJob, /^ {4}services:/m);
+    assert.match(
+      coverageJob,
+      /uses: actions\/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/,
+    );
+    assert.match(coverageJob, /pattern: package-coverage-\*/);
+    assert.match(coverageJob, /path: \.vitest\/blob/);
+    assert.match(coverageJob, /merge-multiple: true/);
+    assert.equal(coverageJob.match(/test -f \.vitest\/blob\/blob-[1-4]-4\.json/g)?.length, 4);
+    assert.match(
+      coverageJob,
+      /run: pnpm coverage:packages:merge\n {6}- name: Report package coverage\n {8}if: \$\{\{ !cancelled\(\) \}\}\n {8}run: pnpm coverage:report/,
+    );
+
     assert.ok(testJob);
     assert.match(testJob, /^ {4}name: Test$/m);
-    assert.match(testJob, /^ {4}needs: \[build, changes, test-packages\]$/m);
     assert.match(
       testJob,
-      /RUN_TEST_STEPS: \$\{\{ needs\.build\.result == 'success' && needs\.changes\.result == 'success' && needs\.changes\.outputs\.inert != 'true' \}\}/,
+      /^ {4}needs: \[build, changes, test-packages, test-examples, coverage\]$/m,
     );
-    assert.equal(
-      testJob.match(
-        /needs\.build\.result == 'success' && needs\.changes\.result == 'success' && needs\.changes\.outputs\.inert != 'true'/g,
-      )?.length,
-      1,
-    );
-    assert.match(testJob, /if: env\.RUN_TEST_STEPS == 'true'/);
-    assert.match(testJob, /GitHub Actions has no step-level matrix/);
-    assert.equal(
-      testJob.match(/uses: actions\/cache\/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae/g)
-        ?.length,
-      4,
-    );
-    assert.equal(testJob.match(/fail-on-cache-miss: true/g)?.length, 4);
-    assert.equal(
-      testJob.match(
-        /path: \.vitest\/blob\/blob-([1-4])-4\.json\n {10}key: package-coverage-\$\{\{ runner\.os \}\}-\$\{\{ github\.run_id \}\}-\1-\$\{\{ github\.run_attempt \}\}\n {10}restore-keys: \|\n {12}package-coverage-\$\{\{ runner\.os \}\}-\$\{\{ github\.run_id \}\}-\1-/g,
-      )?.length,
-      4,
-    );
-    assert.match(testJob, /needs\.test-packages\.result != 'success'[\s\S]*run: exit 1/);
-    assert.match(
-      testJob,
-      /run: pnpm coverage:packages:merge\n {6}- name: Report package coverage\n {8}if: \$\{\{ !cancelled\(\) && env\.RUN_TEST_STEPS == 'true' \}\}\n {8}run: pnpm coverage:report/,
-    );
-    assert.match(
-      testJob,
-      /- name: Test examples\n {8}if: \$\{\{ !cancelled\(\) && env\.RUN_TEST_STEPS == 'true' \}\}\n {8}run: pnpm test:examples/,
-    );
-    assert.doesNotMatch(workflow, /\n {2}coverage:\n/);
-    assert.equal(
-      workflow.match(
-        /run: pnpm coverage:packages --reporter=default --reporter=github-actions --reporter=blob --shard=\$\{\{ matrix\.index \}\}\/4/g,
-      )?.length,
-      1,
-    );
+    assert.match(testJob, /needs\.test-packages\.result != 'success'/);
+    assert.match(testJob, /needs\.test-examples\.result != 'success'/);
+    assert.match(testJob, /needs\.coverage\.result != 'success'/);
+    assert.match(testJob, /run: exit 1/);
+
+    assert.doesNotMatch(workflow, /actions\/cache\/(?:save|restore)@/);
     assert.equal(workflow.match(/run: pnpm coverage:packages:merge/g)?.length, 1);
     assert.equal(workflow.match(/run: pnpm coverage:report/g)?.length, 1);
     assert.equal(workflow.match(/run: pnpm test:examples/g)?.length, 1);

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
     "test": {
       "dependsOn": ["^build"],
       "inputs": ["src/**", "test/**", "dist/**"],
-      "env": ["TEST_TIMEOUT_MULTIPLIER"],
+      "env": ["TEST_TIMEOUT_MULTIPLIER", "VITEST_COVERAGE_SHARD"],
       "passThroughEnv": [
         "WRANGLER_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE",
         "CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 import { composeCoverageConfig } from './scripts/coverage-config';
 
 const coveragePolicy = composeCoverageConfig(import.meta.dirname);
+const coverageShard = process.env['VITEST_COVERAGE_SHARD'];
 
 export default defineConfig({
   test: {
@@ -27,9 +28,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reportsDirectory: resolve(import.meta.dirname, 'coverage'),
-      reporter: ['text', 'json'],
+      reporter: coverageShard ? [] : ['text', 'json'],
       reportOnFailure: true,
       ...coveragePolicy,
+      thresholds: coverageShard ? {} : coveragePolicy.thresholds,
     },
   },
 });


### PR DESCRIPTION
## Linked issue

n/a — infrastructure change without a Linear ticket.

## At a glance

```yaml
# Package Tests (1/4 ... 4/4)
- run: pnpm coverage:packages --reporter=blob --shard=${{ matrix.index }}/4
- uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

# Coverage
- uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
  with:
    pattern: package-coverage-*
    merge-multiple: true
- run: pnpm coverage:packages:merge
- run: pnpm coverage:report
```

Package tests now execute on four runners, while a separate `Coverage` job evaluates thresholds once against the combined native Vitest report. `Test Examples` runs concurrently, and a lightweight final `Test` job preserves the required status name.

## Summary

The package-test portion of `Test` was the remaining serial CI bottleneck. This change shards that work horizontally while keeping one authoritative coverage gate and the existing required `Test` status context.

## Decision

This PR ships three connected CI changes:

1. Run package tests and V8 coverage across four native Vitest shards, each uploading one uniquely named blob artifact.
2. Download and require all four blob reports in a separate `Coverage` fan-in job, merge their coverage counters with Vitest, and only then apply the existing package-level thresholds and warning policy.
3. Run examples concurrently and preserve assertion failures, inert-diff behavior, and the required `Test` check name through a lightweight final gate.

## Reviewer notes

- Shards use SHA-pinned `actions/upload-artifact`; `Coverage` uses SHA-pinned `actions/download-artifact` with `pattern: package-coverage-*` and `merge-multiple: true`. Both are GitHub-created actions in the `actions` organization, so the existing GitHub-actions category permits them without individual allow-list entries.
- Uploads set `include-hidden-files: true` because Vitest writes blobs below `.vitest/blob`, and `if-no-files-found: error` prevents a shard from silently publishing nothing.
- GitHub does not expose artifacts from an earlier workflow attempt to rerun jobs. Use **Re-run all jobs**, not **Re-run failed jobs**; a partial rerun fails safely when `Coverage` verifies the four expected files.
- Coverage thresholds and file reporters are deliberately disabled only in partial shard processes. The merge process runs without the shard marker and therefore restores the complete policy.
- The stable required status remains `Test`; the four `Package Tests (N/4)` jobs, `Coverage`, and `Test Examples` are implementation details behind its final result.
- The hosted four-runner transport can only execute in GitHub Actions. A local two-shard smoke test proved Vitest's blob names, merged counters, and final-only 100% threshold behavior.

## How it fits together

1. [`vitest.config.ts`](vitest.config.ts) recognizes shard collection through `VITEST_COVERAGE_SHARD`, keeps the full include/exclude policy, and suppresses only partial-run thresholds and coverage output.
2. [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs `vitest --coverage --reporter=blob --shard=N/4` on four PostgreSQL-backed runners. Each shard still reports test failures, uploads exactly one hidden blob file, and explicitly propagates a failing outcome after the upload.
3. `Coverage` downloads all `package-coverage-*` artifacts into `.vitest/blob` and checks for `blob-1-4.json` through `blob-4-4.json` before doing any merge.
4. [`pnpm coverage:packages:merge`](package.json) invokes Vitest's native `--merge-reports` path, which combines Istanbul counters rather than averaging percentages and replays failed tests.
5. The existing [`pnpm coverage:report`](scripts/coverage-report.mjs) attributes merged source entries to packages and enforces their thresholds. `Test Examples` runs concurrently, while the final `Test` job fails if any package shard, coverage, example, or prerequisite job failed.

## Behavior changes & evidence

- **Package tests execute across four CI runners instead of one.** The matrix and fan-in are in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), with the expected orchestration locked by [`scripts/coverage-config.test.mjs`](scripts/coverage-config.test.mjs).
- **Coverage gates see the complete combined run.** Shard-aware configuration lives in [`vitest.config.ts`](vitest.config.ts), while the native merge command is declared in [`package.json`](package.json) and existing package aggregation remains in [`scripts/coverage-report.mjs`](scripts/coverage-report.mjs).
- **Missing shards, assertion failures, and partial reruns cannot silently pass.** Unique artifact names, hidden-file uploads, all four required filenames, and the final failure fan-in are asserted by [`scripts/coverage-config.test.mjs`](scripts/coverage-config.test.mjs).
- **The CI contract is documented for future changes.** The rationale and operational flow are recorded in [`docs/oss/ci-pipeline.md`](docs/oss/ci-pipeline.md) and the package coverage guides.

## Testing performed

- `pnpm build` — 85 tasks passed
- `pnpm test:scripts` — 498 tests passed
- `node --test scripts/coverage-config.test.mjs scripts/coverage-report.test.mjs` — 34 tests passed
- `pnpm lint:workflows`
- `pnpm exec biome check vitest.config.ts scripts/coverage-config.test.mjs package.json turbo.json`
- `pnpm exec turbo run build --dry=json`
- Parsed `.github/workflows/ci.yml` with the installed `yaml` package
- `git diff --check`
- Synthetic two-shard Vitest 5 smoke test — generated both expected blob files, merged both source maps, replayed both tests, and passed combined 100% thresholds

## Skill update

n/a — internal CI orchestration only; no user-facing CLI, API, configuration, error, or terminology changes.

## Alternatives considered

- **Use cache transport:** cache prefix matching restores only one matching entry rather than all shard outputs, which would require four explicit restores. Cache fallback also suggests cross-attempt reuse that GitHub's artifact model intentionally avoids.
- **Merge raw JSON manually:** Vitest's blob merger already preserves test failures, project metadata, and Istanbul hit counters, avoiding a custom coverage-merging implementation.
- **Apply thresholds in every shard:** each shard sees only partial execution, so this would create false failures and would not represent repository coverage.
- **Keep the single runner and increase workers:** package coverage is already worker-capped to protect PGlite/PostgreSQL stability; horizontal runners improve wall time without oversubscribing one machine.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read `CONTRIBUTING.md` and the change is scoped to one logical concern.
- [x] Tests are updated.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — n/a, this infrastructure change has no Linear ticket and follows the repository's conventional-title precedent.
- [x] The **Skill update** section is filled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package tests now run across four parallel CI shards.
  * Added coverage report merging for sharded test runs.
  * Coverage thresholds are applied after all shard results are combined.
  * Example tests now run as a dedicated CI check.

* **Documentation**
  * Updated testing and CI guides with the new sharded coverage workflow and command.

* **Chores**
  * Excluded Vitest cache files from version control.
  * Improved CI checks and diagnostics for incomplete or failed test shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->