### PR TITLE
#30153: Export reusable where filter types

### DIFF
--- a/examples/prisma-8-demo/src/orm-client/find-user-by-id.ts
+++ b/examples/prisma-8-demo/src/orm-client/find-user-by-id.ts
@@ -1,15 +1,7 @@
 import type { Runtime } from '@prisma/orm-postgres/family-runtime';
-import type { DefaultModelRow } from '@prisma/orm-postgres/orm-client';
-import type { Contract } from '../prisma/contract.d';
 import { createOrmClient } from './client';
-
-type UserId = DefaultModelRow<Contract, 'User'>['id'];
 
 export async function ormClientFindUserById(id: string, runtime: Runtime) {
   const db = createOrmClient(runtime);
-  return db.User.first({ id: toUserId(id) });
-}
-
-function toUserId(value: string): UserId {
-  return value as UserId;
+  return db.User.first({ id });
 }

--- a/examples/prisma-8-demo/test/sql-builder-filter.types.test-d.ts
+++ b/examples/prisma-8-demo/test/sql-builder-filter.types.test-d.ts
@@ -1,6 +1,6 @@
 import type { WhereFilter } from '@prisma/orm-postgres/builder/types';
 import { expectTypeOf, test } from 'vitest';
-import type { Contract } from '../src/prisma/contract.d';
+import type { Contract } from '../src/prisma/contract';
 import { db } from '../src/prisma/db';
 
 const userId = '00000000-0000-0000-0000-000000000001';

--- a/examples/prisma-8-demo/test/sql-builder-filter.types.test-d.ts
+++ b/examples/prisma-8-demo/test/sql-builder-filter.types.test-d.ts
@@ -1,0 +1,28 @@
+import type { WhereFilter } from '@prisma/orm-postgres/builder/types';
+import { expectTypeOf, test } from 'vitest';
+import type { Contract } from '../src/prisma/contract.d';
+import { db } from '../src/prisma/db';
+
+const userId = '00000000-0000-0000-0000-000000000001';
+const users = db.sql.public.user.select('id', 'email', 'createdAt');
+
+function userById(id: string): WhereFilter<Contract, 'public', 'user'> {
+  return (fields, operators) => operators.eq(fields.id, id);
+}
+
+test('userById returns a reusable SQL builder where filter', () => {
+  const filteredUsers = users.where(userById(userId));
+
+  expectTypeOf(filteredUsers).not.toBeNever();
+});
+
+test('invalid SQL builder fields fail where the filter is constructed', () => {
+  function invalidUserById(id: string): WhereFilter<Contract, 'public', 'user'> {
+    return (fields, operators) => {
+      // @ts-expect-error — user has no userId column
+      return operators.eq(fields.userId, id);
+    };
+  }
+
+  users.where(invalidUserById(userId));
+});

--- a/examples/prisma-8-demo/test/user-filter.types.test-d.ts
+++ b/examples/prisma-8-demo/test/user-filter.types.test-d.ts
@@ -1,0 +1,45 @@
+import type { RelationPredicate, ShorthandWhereFilter } from '@prisma/orm-postgres/orm-client';
+import { expectTypeOf, test } from 'vitest';
+import { createOrmClient } from '../src/orm-client/client';
+import type { Contract } from '../src/prisma/contract.d';
+
+const userId = '00000000-0000-0000-0000-000000000001';
+
+function userById(id: string): ShorthandWhereFilter<Contract, 'public', 'User'> {
+  return { id };
+}
+
+function userByIdPredicate(id: string): RelationPredicate<Contract, 'public', 'User'> {
+  return (user) => user.id.eq(id);
+}
+
+test('shorthand and predicate helpers return reusable User where filters', () => {
+  const db = createOrmClient(null as never);
+  const shorthandUsers = db.User.where(userById(userId));
+  const predicateUsers = db.User.where(userByIdPredicate(userId));
+
+  expectTypeOf(shorthandUsers).not.toBeNever();
+  expectTypeOf(predicateUsers).not.toBeNever();
+});
+
+test('invalid shorthand fields fail where the filter is constructed', () => {
+  function invalidUserById(id: string): ShorthandWhereFilter<Contract, 'public', 'User'> {
+    return {
+      // @ts-expect-error — User has no userId field
+      userId: id,
+    };
+  }
+
+  const db = createOrmClient(null as never);
+  db.User.where(invalidUserById(userId));
+});
+
+test('invalid predicate fields fail where the filter is constructed', () => {
+  function invalidUserByIdPredicate(id: string): RelationPredicate<Contract, 'public', 'User'> {
+    // @ts-expect-error — User has no userId field
+    return (user) => user.userId.eq(id);
+  }
+
+  const db = createOrmClient(null as never);
+  db.User.where(invalidUserByIdPredicate(userId));
+});

--- a/examples/prisma-8-demo/test/user-filter.types.test-d.ts
+++ b/examples/prisma-8-demo/test/user-filter.types.test-d.ts
@@ -1,7 +1,7 @@
 import type { RelationPredicate, ShorthandWhereFilter } from '@prisma/orm-postgres/orm-client';
 import { expectTypeOf, test } from 'vitest';
 import { createOrmClient } from '../src/orm-client/client';
-import type { Contract } from '../src/prisma/contract.d';
+import type { Contract } from '../src/prisma/contract';
 
 const userId = '00000000-0000-0000-0000-000000000001';
 

--- a/packages/2-sql/4-lanes/sql-builder/README.md
+++ b/packages/2-sql/4-lanes/sql-builder/README.md
@@ -52,6 +52,24 @@ const counts = await db.posts
   .all();
 ```
 
+### Reusable where filters
+
+Use `WhereFilter<Contract, Namespace, Table>` when a SQL-builder predicate needs to be constructed outside `.where()`. The contract coordinate preserves field and operator autocomplete and reports invalid predicates where the helper is authored.
+
+```typescript
+import type { WhereFilter } from '@prisma/orm-postgres/builder/types';
+import type { Contract } from './prisma/contract.d';
+
+function userById(id: string): WhereFilter<Contract, 'public', 'user'> {
+  return (fields, operators) => operators.eq(fields.id, id);
+}
+
+const plan = db.sql.public.user
+  .select('id', 'email')
+  .where(userById('00000000-0000-0000-0000-000000000001'))
+  .build();
+```
+
 ## Architecture
 
 - **Domain:** SQL

--- a/packages/2-sql/4-lanes/sql-builder/README.md
+++ b/packages/2-sql/4-lanes/sql-builder/README.md
@@ -52,24 +52,6 @@ const counts = await db.posts
   .all();
 ```
 
-### Reusable where filters
-
-Use `WhereFilter<Contract, Namespace, Table>` when a SQL-builder predicate needs to be constructed outside `.where()`. The contract coordinate preserves field and operator autocomplete and reports invalid predicates where the helper is authored.
-
-```typescript
-import type { WhereFilter } from '@prisma/orm-postgres/builder/types';
-import type { Contract } from './prisma/contract.d';
-
-function userById(id: string): WhereFilter<Contract, 'public', 'user'> {
-  return (fields, operators) => operators.eq(fields.id, id);
-}
-
-const plan = db.sql.public.user
-  .select('id', 'email')
-  .where(userById('00000000-0000-0000-0000-000000000001'))
-  .build();
-```
-
 ## Architecture
 
 - **Domain:** SQL

--- a/packages/2-sql/4-lanes/sql-builder/src/exports/types.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/exports/types.ts
@@ -13,4 +13,4 @@ export type { GroupedQuery } from '../types/grouped-query';
 export type { DeleteQuery, InsertQuery, UpdateQuery } from '../types/mutation-query';
 export type { ContractRawTag, RawLane, RawTagFor } from '../types/raw-query';
 export type { SelectQuery } from '../types/select-query';
-export type { TableProxy } from '../types/table-proxy';
+export type { TableProxy, WhereFilter } from '../types/table-proxy';

--- a/packages/2-sql/4-lanes/sql-builder/src/index.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/index.ts
@@ -5,4 +5,4 @@ export type { Db } from './types/db';
 export type { GroupedQuery } from './types/grouped-query';
 export type { DeleteQuery, InsertQuery, UpdateQuery } from './types/mutation-query';
 export type { SelectQuery } from './types/select-query';
-export type { TableProxy } from './types/table-proxy';
+export type { TableProxy, WhereFilter } from './types/table-proxy';

--- a/packages/2-sql/4-lanes/sql-builder/src/types/db.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/db.ts
@@ -36,6 +36,11 @@ export type UnboundTables<C extends TableProxyContract> = {
   readonly [Name in TableNamesAcrossNamespaces<C>]: TableInAnyNamespace<C, Name>;
 };
 
+export type TableNamesInNamespace<
+  C extends TableProxyContract,
+  NsId extends keyof C['storage']['namespaces'],
+> = keyof TablesInNamespace<C['storage']['namespaces'][NsId]> & string;
+
 export type TableNamesAcrossNamespaces<C extends TableProxyContract> = {
   [NSId in keyof C['storage']['namespaces']]: keyof TablesInNamespace<
     C['storage']['namespaces'][NSId]

--- a/packages/2-sql/4-lanes/sql-builder/src/types/table-proxy.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/types/table-proxy.ts
@@ -7,7 +7,7 @@ import type {
   StorageColumnMapAt,
   StorageTable,
 } from '@internal/sql-contract/types';
-import type { Expression, FieldProxy, Functions } from '../expression';
+import type { Expression, ExpressionBuilder, FieldProxy, Functions } from '../expression';
 import type {
   DefaultScope,
   EmptyRow,
@@ -17,7 +17,7 @@ import type {
   Scope,
   StorageTableToScopeTable,
 } from '../scope';
-import type { NamespaceTable, TableProxyContract } from './db';
+import type { NamespaceTable, TableNamesInNamespace, TableProxyContract } from './db';
 import type { DeleteQuery, InsertQuery, InsertValues, UpdateQuery } from './mutation-query';
 import type { ContractColumnRef } from './raw-query';
 import type { WithJoin, WithSelect } from './shared';
@@ -92,6 +92,15 @@ export type ContractToQC<
   readonly resolvedColumnOutputTypes: ResolvedColumnTypes<C, NsId, Name>;
   readonly aggregateTypes: ExtractAggregateTypes<C>;
 };
+
+export type WhereFilter<
+  C extends TableProxyContract,
+  NsId extends keyof C['storage']['namespaces'] & string,
+  Name extends TableNamesInNamespace<C, NsId>,
+> = ExpressionBuilder<
+  DefaultScope<Name, NamespaceTable<C, NsId, Name>>,
+  ContractToQC<C, NsId, Name>
+>;
 
 export interface TableProxy<
   C extends TableProxyContract,

--- a/packages/2-sql/4-lanes/sql-builder/test/types/where-filter.types.test-d.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/types/where-filter.types.test-d.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf, test } from 'vitest';
+import type { WhereFilter } from '../../src/exports/types';
+import type { Contract } from '../fixtures/generated/contract';
+
+test('WhereFilter binds fields and operators to a contract table', () => {
+  const userById =
+    (id: number): WhereFilter<Contract, 'public', 'users'> =>
+    (fields, operators) =>
+      operators.eq(fields.id, id);
+
+  expectTypeOf(userById).parameter(0).toEqualTypeOf<number>();
+});
+
+test('WhereFilter rejects fields outside the contract table', () => {
+  const invalidUserById =
+    (id: number): WhereFilter<Contract, 'public', 'users'> =>
+    (fields, operators) =>
+      // @ts-expect-error — users has no userId column
+      operators.eq(fields.userId, id);
+
+  expectTypeOf(invalidUserById).parameter(0).toEqualTypeOf<number>();
+});

--- a/packages/3-extensions/sql-orm-client/src/collection-internal-types.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection-internal-types.ts
@@ -133,9 +133,13 @@ export type IncludeRefinementValue<
       : IncludeRelationValue<TContract, ParentModelName, RelName, V, NsId>
     : IncludeRelationValue<TContract, ParentModelName, RelName, DefaultIncludedRow, NsId>;
 
-export type WhereInput<TContract extends Contract<SqlStorage>, ModelName extends string> =
-  | ((model: ModelAccessor<TContract, ModelName>) => AnyExpression)
-  | ShorthandWhereFilter<TContract, ModelName>;
+export type WhereInput<
+  TContract extends Contract<SqlStorage>,
+  NsId extends string,
+  ModelName extends string,
+> =
+  | ((model: ModelAccessor<TContract, ModelName, NsId>) => AnyExpression)
+  | ShorthandWhereFilter<TContract, NsId, ModelName>;
 
 export interface IncludeRefinementEvaluation {
   readonly nestedState: import('./types').CollectionState;

--- a/packages/3-extensions/sql-orm-client/src/collection.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection.ts
@@ -335,7 +335,7 @@ class CollectionImpl<
     ) => WhereArg,
   ): Collection<TContract, ModelName, Row, WithWhereState<State>>;
   where(
-    filters: ShorthandWhereFilter<TContract, ModelName, State['nsId']>,
+    filters: ShorthandWhereFilter<TContract, State['nsId'], ModelName>,
   ): Collection<TContract, ModelName, Row, WithWhereState<State>>;
   where(
     input:
@@ -356,12 +356,12 @@ class CollectionImpl<
             State['nsId']
           >,
         ) => WhereArg)
-      | ShorthandWhereFilter<TContract, ModelName, State['nsId']>,
+      | ShorthandWhereFilter<TContract, State['nsId'], ModelName>,
   ): Collection<TContract, ModelName, Row, WithWhereState<State>> {
     const whereArg =
       typeof input === 'function'
         ? input(
-            createModelAccessor<TContract, ModelName, State['variantName']>(
+            createModelAccessor<TContract, ModelName, State['variantName'], State['nsId']>(
               this.ctx.context,
               this.namespaceId,
               this.modelName,
@@ -717,15 +717,25 @@ class CollectionImpl<
   orderBy(
     selection:
       | ((
-          model: VariantAwareModelAccessor<TContract, ModelName, State['variantName']>,
+          model: VariantAwareModelAccessor<
+            TContract,
+            ModelName,
+            State['variantName'],
+            State['nsId']
+          >,
         ) => OrderByItem)
       | ReadonlyArray<
           (
-            model: VariantAwareModelAccessor<TContract, ModelName, State['variantName']>,
+            model: VariantAwareModelAccessor<
+              TContract,
+              ModelName,
+              State['variantName'],
+              State['nsId']
+            >,
           ) => OrderByItem
         >,
   ): Collection<TContract, ModelName, Row, WithOrderByState<State>> {
-    const accessor = createModelAccessor<TContract, ModelName, State['variantName']>(
+    const accessor = createModelAccessor<TContract, ModelName, State['variantName'], State['nsId']>(
       this.ctx.context,
       this.namespaceId,
       this.modelName,
@@ -1065,7 +1075,7 @@ class CollectionImpl<
     configure?: (meta: MetaBuilder<'read'>) => void,
   ): Promise<Row | null>;
   async first(
-    filter: ShorthandWhereFilter<TContract, ModelName, State['nsId']>,
+    filter: ShorthandWhereFilter<TContract, State['nsId'], ModelName>,
     configure?: (meta: MetaBuilder<'read'>) => void,
   ): Promise<Row | null>;
   async first(
@@ -1078,7 +1088,7 @@ class CollectionImpl<
             State['nsId']
           >,
         ) => WhereArg)
-      | ShorthandWhereFilter<TContract, ModelName, State['nsId']>,
+      | ShorthandWhereFilter<TContract, State['nsId'], ModelName>,
     configure?: (meta: MetaBuilder<'read'>) => void,
   ): Promise<Row | null> {
     const scoped =
@@ -2339,7 +2349,7 @@ class CollectionImpl<
         this.namespaceId,
         this.modelName,
         blindCast<
-          ShorthandWhereFilter<TContract, ModelName>,
+          ShorthandWhereFilter<TContract, State['nsId'], ModelName>,
           'identity columns were resolved from this model before building the shorthand filter'
         >(criterion),
       ) ?? null
@@ -2359,7 +2369,7 @@ class CollectionImpl<
       this.namespaceId,
       this.modelName,
       blindCast<
-        ShorthandWhereFilter<TContract, ModelName>,
+        ShorthandWhereFilter<TContract, State['nsId'], ModelName>,
         'mutation reload criterion contains resolved fields for this model'
       >(criterion),
     );

--- a/packages/3-extensions/sql-orm-client/src/filters.ts
+++ b/packages/3-extensions/sql-orm-client/src/filters.ts
@@ -32,12 +32,13 @@ export function all(): AnyExpression {
 
 export function shorthandToWhereExpr<
   TContract extends Contract<SqlStorage>,
+  NsId extends string,
   ModelName extends string,
 >(
   context: ExecutionContext<TContract>,
-  namespaceId: string,
+  namespaceId: NsId,
   modelName: ModelName,
-  filters: ShorthandWhereFilter<TContract, ModelName>,
+  filters: ShorthandWhereFilter<TContract, NsId, ModelName>,
 ): AnyExpression | undefined {
   const contract = context.contract;
   const tableName = resolveModelTableName(contract, namespaceId, modelName);

--- a/packages/3-extensions/sql-orm-client/src/grouped-collection.ts
+++ b/packages/3-extensions/sql-orm-client/src/grouped-collection.ts
@@ -78,7 +78,7 @@ export class GroupedCollection<
   private readonly contract: TContract;
   readonly modelName: ModelName;
   readonly tableName: string;
-  readonly namespaceId: string;
+  readonly namespaceId: NsId;
   readonly preGroupState: CollectionState;
   readonly groupByFields: readonly string[];
   readonly groupByColumns: readonly string[];
@@ -94,7 +94,10 @@ export class GroupedCollection<
     this.contract = ctx.context.contract;
     this.modelName = modelName;
     this.tableName = options.tableName;
-    this.namespaceId = options.namespaceId;
+    this.namespaceId = blindCast<
+      NsId,
+      'GroupedCollection preserves the namespace type supplied by its parent collection'
+    >(options.namespaceId);
     this.preGroupState = options.preGroupState;
     this.groupByFields = options.groupByFields;
     this.groupByColumns = options.groupByColumns;
@@ -167,7 +170,7 @@ export class GroupedCollection<
         { meta: { method: 'orderBy', model: this.modelName } },
       );
     }
-    const accessor = createModelAccessor<TContract, ModelName>(
+    const accessor = createModelAccessor<TContract, ModelName, undefined, NsId>(
       this.ctx.context,
       this.namespaceId,
       this.modelName,

--- a/packages/3-extensions/sql-orm-client/src/model-accessor.ts
+++ b/packages/3-extensions/sql-orm-client/src/model-accessor.ts
@@ -47,9 +47,11 @@ function hasThrough(relation: ResolvedModelRelation): relation is ResolvedModelR
   return relation.through !== undefined;
 }
 
-type RelationPredicateInput<TContract extends Contract<SqlStorage>, ModelName extends string> =
-  | ((model: ModelAccessor<TContract, ModelName>) => AnyExpression)
-  | Record<string, unknown>;
+type RelationPredicateInput<
+  TContract extends Contract<SqlStorage>,
+  NsId extends string,
+  ModelName extends string,
+> = ((model: ModelAccessor<TContract, ModelName, NsId>) => AnyExpression) | Record<string, unknown>;
 
 type RelationFilterMode = 'some' | 'every' | 'none';
 type RelationFilterPlan =
@@ -188,12 +190,13 @@ export function createModelAccessor<
   TContract extends Contract<SqlStorage>,
   ModelName extends string,
   VariantName extends string | undefined = undefined,
+  NsId extends string = string,
 >(
   context: ExecutionContext<TContract>,
-  namespaceId: string,
+  namespaceId: NsId,
   modelName: ModelName,
   variantName?: VariantName,
-): VariantAwareModelAccessor<TContract, ModelName, VariantName> {
+): VariantAwareModelAccessor<TContract, ModelName, VariantName, NsId> {
   const tableName = resolveModelTableName(context.contract, namespaceId, modelName);
   return createModelAccessorInScope(
     context,
@@ -206,15 +209,16 @@ export function createModelAccessor<
 
 function createModelAccessorInScope<
   TContract extends Contract<SqlStorage>,
+  NsId extends string,
   ModelName extends string,
   VariantName extends string | undefined = undefined,
 >(
   context: ExecutionContext<TContract>,
-  namespaceId: string,
+  namespaceId: NsId,
   modelName: ModelName,
   variantName: VariantName | undefined,
   scope: ModelAccessorScope,
-): VariantAwareModelAccessor<TContract, ModelName, VariantName> {
+): VariantAwareModelAccessor<TContract, ModelName, VariantName, NsId> {
   const contract = context.contract;
   const fieldToColumn = getFieldToColumnMap(contract, namespaceId, modelName);
   const tableName = resolveModelTableName(contract, namespaceId, modelName);
@@ -436,14 +440,14 @@ function createRelationFilterAccessor<
   parentModelName: ParentModelName,
   parentScope: ModelAccessorScope,
   relation: ResolvedModelRelation,
-): RelationFilterAccessor<TContract, string> {
+): RelationFilterAccessor<TContract, string, string> {
   const relatedTableName = resolveModelTableName(
     context.contract,
     relation.toNamespace,
     relation.to,
   );
 
-  const relationAccessor: RelationFilterAccessor<TContract, string> = {
+  const relationAccessor: RelationFilterAccessor<TContract, string, string> = {
     some: (predicate) =>
       buildExistsExpr(
         context,
@@ -488,7 +492,7 @@ function buildExistsExpr<TContract extends Contract<SqlStorage>>(
   relation: ResolvedModelRelation,
   options: {
     readonly mode: RelationFilterMode;
-    readonly predicate: RelationPredicateInput<TContract, string> | undefined;
+    readonly predicate: RelationPredicateInput<TContract, string, string> | undefined;
   },
 ): AnyExpression {
   if (hasThrough(relation)) {
@@ -544,7 +548,7 @@ function buildManyToManyExistsExpr<TContract extends Contract<SqlStorage>>(
   relation: ResolvedModelRelationWithThrough,
   options: {
     readonly mode: RelationFilterMode;
-    readonly predicate: RelationPredicateInput<TContract, string> | undefined;
+    readonly predicate: RelationPredicateInput<TContract, string, string> | undefined;
   },
 ): AnyExpression {
   const { through } = relation;
@@ -662,7 +666,7 @@ function toRelationWhereExpr<TContract extends Contract<SqlStorage>>(
   context: ExecutionContext<TContract>,
   relatedNamespaceId: string,
   relatedModelName: string,
-  predicate: RelationPredicateInput<TContract, string> | undefined,
+  predicate: RelationPredicateInput<TContract, string, string> | undefined,
   scope: ModelAccessorScope,
 ): AnyExpression | undefined {
   if (!predicate) {

--- a/packages/3-extensions/sql-orm-client/src/types.ts
+++ b/packages/3-extensions/sql-orm-client/src/types.ts
@@ -299,10 +299,11 @@ type OpMatchesField<Op, CodecId extends string, CT extends Record<string, unknow
 
 type FieldOperations<
   TContract extends Contract<SqlStorage>,
+  NsId extends string,
   ModelName extends string,
   FieldName extends string,
 > =
-  FieldCodecId<TContract, ModelName, FieldName> extends infer CodecId extends string
+  FieldCodecId<TContract, ModelName, FieldName, NsId> extends infer CodecId extends string
     ? ExtractQueryOperationTypes<TContract> extends infer AllOps
       ? {
           [OpName in keyof AllOps & string as OpMatchesField<
@@ -413,22 +414,29 @@ export const COMPARISON_METHODS_META = {
 
 type ComparisonMethodsMeta = typeof COMPARISON_METHODS_META;
 
-export type RelationPredicate<TContract extends Contract<SqlStorage>, ModelName extends string> = (
-  model: ModelAccessor<TContract, ModelName>,
-) => AnyExpression;
+type DomainNamespaceId<TContract extends Contract<SqlStorage>> =
+  keyof TContract['domain']['namespaces'] & string;
+
+export type RelationPredicate<
+  TContract extends Contract<SqlStorage>,
+  NsId extends DomainNamespaceId<TContract>,
+  ModelName extends string,
+> = (model: ModelAccessor<TContract, ModelName, NsId>) => AnyExpression;
 
 export type RelationPredicateInput<
   TContract extends Contract<SqlStorage>,
+  NsId extends DomainNamespaceId<TContract>,
   ModelName extends string,
-> = RelationPredicate<TContract, ModelName> | Record<string, unknown>;
+> = RelationPredicate<TContract, NsId, ModelName> | Record<string, unknown>;
 
 export type RelationFilterAccessor<
   TContract extends Contract<SqlStorage>,
+  RelatedNsId extends DomainNamespaceId<TContract>,
   RelatedModelName extends string,
 > = {
-  some(predicate?: RelationPredicateInput<TContract, RelatedModelName>): AnyExpression;
-  every(predicate: RelationPredicateInput<TContract, RelatedModelName>): AnyExpression;
-  none(predicate?: RelationPredicateInput<TContract, RelatedModelName>): AnyExpression;
+  some(predicate?: RelationPredicateInput<TContract, RelatedNsId, RelatedModelName>): AnyExpression;
+  every(predicate: RelationPredicateInput<TContract, RelatedNsId, RelatedModelName>): AnyExpression;
+  none(predicate?: RelationPredicateInput<TContract, RelatedNsId, RelatedModelName>): AnyExpression;
 };
 
 type ScalarModelAccessor<
@@ -444,13 +452,18 @@ type ScalarModelAccessor<
       FieldJsType<TContract, ModelName, K, NsId>,
       FieldTraits<TContract, ModelName, K, NsId>
     > &
-    FieldOperations<TContract, ModelName, K>;
+    FieldOperations<TContract, NsId, ModelName, K>;
 };
 
-type RelationModelAccessor<TContract extends Contract<SqlStorage>, ModelName extends string> = {
-  [K in RelationNames<TContract, ModelName>]: RelationFilterAccessor<
+type RelationModelAccessor<
+  TContract extends Contract<SqlStorage>,
+  ModelName extends string,
+  NsId extends string = never,
+> = {
+  [K in RelationNames<TContract, ModelName, NsId>]: RelationFilterAccessor<
     TContract,
-    RelatedModelName<TContract, ModelName, K> & string
+    RelationTargetNamespace<TContract, ModelName, K, NsId>,
+    RelatedModelName<TContract, ModelName, K, NsId> & string
   >;
 };
 
@@ -458,7 +471,8 @@ export type ModelAccessor<
   TContract extends Contract<SqlStorage>,
   ModelName extends string,
   NsId extends string = never,
-> = ScalarModelAccessor<TContract, ModelName, NsId> & RelationModelAccessor<TContract, ModelName>;
+> = ScalarModelAccessor<TContract, ModelName, NsId> &
+  RelationModelAccessor<TContract, ModelName, NsId>;
 
 /**
  * The predicate accessor for a collection narrowed to a variant. When a real
@@ -476,8 +490,8 @@ export type VariantAwareModelAccessor<
   ? VariantName extends VariantNames<TContract, ModelName, NsId>
     ? ScalarModelAccessor<TContract, ModelName, NsId> &
         ScalarModelAccessor<TContract, VariantName, NsId> &
-        RelationModelAccessor<TContract, ModelName> &
-        RelationModelAccessor<TContract, VariantName>
+        RelationModelAccessor<TContract, ModelName, NsId> &
+        RelationModelAccessor<TContract, VariantName, NsId>
     : ModelAccessor<TContract, ModelName, NsId>
   : ModelAccessor<TContract, ModelName, NsId>;
 
@@ -896,8 +910,8 @@ export type HavingBuilder<
 
 export type ShorthandWhereFilter<
   TContract extends Contract<SqlStorage>,
+  NsId extends DomainNamespaceId<TContract>,
   ModelName extends string,
-  NsId extends string = never,
 > = Partial<{
   [K in keyof DefaultModelRow<TContract, ModelName, NsId> & string]:
     | DefaultModelRow<TContract, ModelName, NsId>[K]
@@ -1905,6 +1919,10 @@ export type RelatedModelName<
       : never
     : never;
 
+type ContractNamespaceKey<TContract extends Contract<SqlStorage>, NsId extends string> = {
+  [K in keyof TContract['domain']['namespaces'] & string]: NsId extends K ? K : never;
+}[keyof TContract['domain']['namespaces'] & string];
+
 // The namespace coordinate the relation's target model lives in, read from the
 // relation's `to.namespace`. Lets a relation reached through an explicit
 // namespace facet resolve its included row at the target namespace rather than
@@ -1922,7 +1940,7 @@ export type RelationTargetNamespace<
     ? Rels extends Record<string, unknown>
       ? RelName extends keyof Rels
         ? Rels[RelName] extends { readonly to: { readonly namespace: infer N extends string } }
-          ? N
+          ? ContractNamespaceKey<TContract, N>
           : never
         : never
       : never

--- a/packages/3-extensions/sql-orm-client/test/codec-async.types.test-d.ts
+++ b/packages/3-extensions/sql-orm-client/test/codec-async.types.test-d.ts
@@ -38,7 +38,7 @@ type UserRow = DefaultModelRow<Contract, 'User'>;
 type UserCreate = CreateInput<Contract, 'User'>;
 type UserUpdate = MutationUpdateInput<Contract, 'User'>;
 type UserUnique = UniqueConstraintCriterion<Contract, 'User'>;
-type UserWhere = ShorthandWhereFilter<Contract, 'User'>;
+type UserWhere = ShorthandWhereFilter<Contract, 'public', 'User'>;
 type UserInferRoot = InferRootRow<Contract, 'User'>;
 
 test('DefaultModelRow exposes plain `string` for pg/text@1 columns', () => {

--- a/packages/3-extensions/sql-orm-client/test/orm-namespace-unique-fields.types.test-d.ts
+++ b/packages/3-extensions/sql-orm-client/test/orm-namespace-unique-fields.types.test-d.ts
@@ -1,6 +1,7 @@
 import type { ExecutionContext } from '@internal/sql-relational-core/query-lane-context';
 import { expectTypeOf, test } from 'vitest';
 import { orm } from '../src/orm';
+import type { RelationPredicate, ShorthandWhereFilter } from '../src/types';
 import { createMockRuntime, type TestContract } from './helpers';
 
 /**
@@ -225,6 +226,35 @@ interface WriteCollisionContract extends Omit<TestContract, 'domain' | 'storage'
 
 declare const writeContext: ExecutionContext<WriteCollisionContract>;
 const writeDb = orm({ runtime: createMockRuntime(), context: writeContext });
+
+test('standalone filters require and honor the namespace before the model name', () => {
+  const publicFilter: ShorthandWhereFilter<WriteCollisionContract, 'public', 'User'> = {
+    email: 'a@example.com',
+  };
+  const authPredicate: RelationPredicate<WriteCollisionContract, 'auth', 'User'> = (user) =>
+    user.token.eq('tok');
+
+  writeDb.public.User.where(publicFilter);
+  writeDb.auth.User.where(authPredicate);
+
+  // @ts-expect-error namespace coordinate is required
+  const missingNamespace: ShorthandWhereFilter<WriteCollisionContract, 'User'> = {};
+  // @ts-expect-error namespace coordinate is required
+  const missingPredicateNamespace: RelationPredicate<WriteCollisionContract, 'User'> =
+    authPredicate;
+  // @ts-expect-error namespace must exist in the contract
+  const unknownNamespace: ShorthandWhereFilter<WriteCollisionContract, 'missing', 'User'> = {};
+  void missingNamespace;
+  void missingPredicateNamespace;
+  void unknownNamespace;
+
+  const wrongPublicFilter: ShorthandWhereFilter<WriteCollisionContract, 'public', 'User'> = {
+    // @ts-expect-error token belongs to auth.User, not public.User
+    token: 'tok',
+  };
+
+  writeDb.public.User.where(wrongPublicFilter);
+});
 
 test('the auth-namespace User facet resolves create/where inputs to its own field `token`', async () => {
   await writeDb.auth.User.create({ token: 'tok' });

--- a/skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md
+++ b/skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md
@@ -16,6 +16,9 @@ changes:
       glob: "**/*.prisma"
       matches:
         - '\bweights\s*:\s*"\{\s*(?:\\.|[^"\\])*\}"'
+  - id: namespace-qualify-sql-orm-filter-types
+    summary: |
+      SQL ORM reusable filter types now require the domain namespace before the model name: `<Contract, Namespace, Model>`.
 ---
 
 # 8.0.0-rc.8 → 8.0.0-rc.9 — User upgrade instructions
@@ -27,3 +30,7 @@ For every Prisma schema matched by `detection`, replace encoded projection strin
 ## `mongo-text-index-weights-use-native-records`
 
 For every Prisma schema matched by `detection`, replace the encoded JSON string passed to `weights` with a native PSL record. For example, change `weights: "{\"title\": 10}"` to `weights: { title: 10 }`, preserving every field name and numeric weight.
+
+## `namespace-qualify-sql-orm-filter-types`
+
+Find TypeScript references to `ShorthandWhereFilter`, `RelationPredicate`, `RelationPredicateInput`, and `RelationFilterAccessor`. Add the model's domain namespace as the second generic argument and place the model name third. Rewrite `ShorthandWhereFilter<Contract, Model>` as `ShorthandWhereFilter<Contract, Namespace, Model>` and `ShorthandWhereFilter<Contract, Model, Namespace>` as `ShorthandWhereFilter<Contract, Namespace, Model>`. Rewrite the relation types from `<Contract, Model>` to `<Contract, Namespace, Model>`. Use the namespace facet through which the model is queried, such as `'public'` for `db.public.User`.

--- a/skills/prisma-8/upgrading/extension/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md
+++ b/skills/prisma-8/upgrading/extension/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md
@@ -5,6 +5,9 @@ changes:
   - id: remove-nested-relations-from-sql-orm-upsert-and-batch-create
     summary: |
       SQL ORM `upsert({ create })`, `createAll()`, and `createAndCount()` payloads no longer accept nested relation mutation callbacks, which these operations cannot execute. Remove the callbacks and create related records separately, or use ordinary `create()` when the records must be created as one nested relation operation.
+  - id: namespace-qualify-sql-orm-filter-types
+    summary: |
+      SQL ORM reusable filter types now require the domain namespace before the model name: `<Contract, Namespace, Model>`.
 ---
 
 # 8.0.0-rc.8 → 8.0.0-rc.9 — Extension author upgrade instructions
@@ -12,3 +15,7 @@ changes:
 ## `remove-nested-relations-from-sql-orm-upsert-and-batch-create`
 
 Find SQL ORM calls to `upsert()`, `createAll()`, and `createAndCount()` whose create payloads contain relation fields assigned callback functions. Remove those callbacks and create the related records separately. When the operation requires nested relation creation, replace it with ordinary `create()`, which continues to accept and execute relation mutation callbacks.
+
+## `namespace-qualify-sql-orm-filter-types`
+
+Find TypeScript references to `ShorthandWhereFilter`, `RelationPredicate`, `RelationPredicateInput`, and `RelationFilterAccessor`. Add the model's domain namespace as the second generic argument and place the model name third. Rewrite `ShorthandWhereFilter<Contract, Model>` as `ShorthandWhereFilter<Contract, Namespace, Model>` and `ShorthandWhereFilter<Contract, Model, Namespace>` as `ShorthandWhereFilter<Contract, Namespace, Model>`. Rewrite the relation types from `<Contract, Model>` to `<Contract, Namespace, Model>`. For predicates targeting a relation, use the namespace declared by that relation's `to.namespace` coordinate.


### PR DESCRIPTION
## Linked issue

Closes #30153

## At a glance

SQL builder:

```ts
import type { WhereFilter } from '@prisma/orm-postgres/builder/types';
import type { Contract } from '../src/prisma/contract';
import { db } from '../src/prisma/db';

const users = db.sql.public.user.select('id', 'email', 'createdAt');

function userById(id: string): WhereFilter<Contract, 'public', 'user'> {
  return (fields, operators) => operators.eq(fields.id, id);
}

users.where(userById('00000000-0000-0000-0000-000000000001'));
```

SQL ORM, with shorthand and predicate forms side by side:

```ts
import type { RelationPredicate, ShorthandWhereFilter } from '@prisma/orm-postgres/orm-client';
import { createOrmClient } from '../src/orm-client/client';
import type { Contract } from '../src/prisma/contract';

function userById(id: string): ShorthandWhereFilter<Contract, 'public', 'User'> {
  return { id };
}

function userByIdPredicate(id: string): RelationPredicate<Contract, 'public', 'User'> {
  return (user) => user.id.eq(id);
}

const db = createOrmClient(null as never);
const userId = '00000000-0000-0000-0000-000000000001';
db.User.where(userById(userId));
db.User.where(userByIdPredicate(userId));
```

These real integration-test examples show the new SQL builder annotation and the namespace-qualified ORM annotations in use. In both lanes, field mistakes are reported inside the helper body while the returned filter passes directly to `.where()`.

## Decision

This PR ships three connected pieces:

1. A public SQL builder `WhereFilter<Contract, Namespace, Table>` type exported from `@prisma/orm-postgres/builder/types`.
2. Namespace-precise SQL ORM standalone filters using the existing `ShorthandWhereFilter<Contract, Namespace, Model>` and `RelationPredicate<Contract, Namespace, Model>` names.
3. Compile-only integration coverage and RC upgrade instructions that prove and explain the public API through the PostgreSQL facade.

## Summary

Extracting a SQL builder `where()` callback currently loses contextual typing unless users reconstruct internal signatures or cast the result. This change adds a supported public builder type for that pattern and makes the existing SQL ORM reusable filter types namespace-precise, keeping errors and autocomplete at the helper definition where they are actionable.

## Reviewer notes

- The SQL ORM generic change is intentionally breaking: namespace is now required and appears before model. Existing annotations need the migration recorded in this PR.
- Relation predicates carry the target namespace from `relation.to.namespace`; emitted branded namespace IDs are normalized back to concrete contract namespace keys.
- Runtime query behavior and generated SQL are unchanged. The small `find-user-by-id` cleanup removes an unnecessary ID cast discovered while adding the public-facade integration type tests.

## How it fits together

1. [`WhereFilter`](packages/2-sql/4-lanes/sql-builder/src/types/table-proxy.ts) binds the existing expression callback to the selected table's `DefaultScope` and contract query context, then [`exports/types.ts`](packages/2-sql/4-lanes/sql-builder/src/exports/types.ts) exposes only that consumer-facing type.
2. [`types.ts`](packages/3-extensions/sql-orm-client/src/types.ts) makes the domain namespace a required coordinate for ORM shorthand filters, predicates, and relation filter accessors, so fields and operations resolve against one exact model facet.
3. [`collection.ts`](packages/3-extensions/sql-orm-client/src/collection.ts) and [`model-accessor.ts`](packages/3-extensions/sql-orm-client/src/model-accessor.ts) carry that namespace through `.where()`, `.first()`, ordering, grouped collections, and nested relation accessors.
4. Public-facade type tests in the PostgreSQL demo exercise both authoring forms and pin negative diagnostics to nonexistent fields inside the helper bodies.
5. The app and extension upgrade transitions explain how to migrate existing ORM filter annotations.

## Behavior changes & evidence

- **SQL builder filters can be named, parameterized, and reused with table-specific fields and operators.** The public surface is defined in [`table-proxy.ts`](packages/2-sql/4-lanes/sql-builder/src/types/table-proxy.ts) and [`exports/types.ts`](packages/2-sql/4-lanes/sql-builder/src/exports/types.ts), with package and facade evidence in [`where-filter.types.test-d.ts`](packages/2-sql/4-lanes/sql-builder/test/types/where-filter.types.test-d.ts) and [`sql-builder-filter.types.test-d.ts`](examples/prisma-8-demo/test/sql-builder-filter.types.test-d.ts).
- **SQL ORM shorthand and predicate helpers retain model-specific autocomplete and local diagnostics.** Namespace-aware definitions live in [`types.ts`](packages/3-extensions/sql-orm-client/src/types.ts) and flow through [`collection.ts`](packages/3-extensions/sql-orm-client/src/collection.ts) and [`model-accessor.ts`](packages/3-extensions/sql-orm-client/src/model-accessor.ts); [`user-filter.types.test-d.ts`](examples/prisma-8-demo/test/user-filter.types.test-d.ts) proves both forms through `@prisma/orm-postgres/orm-client`.
- **Namespace collisions resolve to the correct model facet.** [`orm-namespace-unique-fields.types.test-d.ts`](packages/3-extensions/sql-orm-client/test/orm-namespace-unique-fields.types.test-d.ts) proves that `public.User` and `auth.User` expose different fields and that missing or unknown namespace coordinates fail at compile time.
- **Existing ORM filter annotations receive an explicit migration path.** The app and extension transitions in [`8.0.0-rc.8-to-8.0.0-rc.9`](skills/prisma-8/upgrading/app/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md) and its [`extension counterpart`](skills/prisma-8/upgrading/extension/upgrades/8.0.0-rc.8-to-8.0.0-rc.9/instructions.md) describe adding and reordering the namespace coordinate.

## Testing performed

- `pnpm --filter @internal/sql-builder test` — 13 test files, 171 tests passed.
- `pnpm --filter @internal/sql-orm-client test` — 70 test files, 772 tests passed, no type errors.
- `pnpm --filter prisma-8-demo test` — 14 test files, 73 tests passed, including all 26 repository integration cases.
- `pnpm --filter @internal/sql-builder typecheck`
- `pnpm --filter @internal/sql-orm-client typecheck`
- `pnpm --filter prisma-8-demo typecheck`
- `pnpm lint:deps`
- `pnpm lint:skills`
- `pnpm check:upgrade-coverage`
- `git diff --check`

## Skill update

The public ORM type signature change is recorded for both application and extension consumers in the `8.0.0-rc.8` → `8.0.0-rc.9` upgrade instructions. `pnpm lint:skills` and `pnpm check:upgrade-coverage` pass.

## Alternatives considered

- **Export the builder machinery directly.** Exposing `Scope`, `QueryContext`, `ExpressionBuilder`, and `FieldProxy` would let consumers reconstruct the callback type, but would make internal query representation part of the supported API. `WhereFilter` supplies the useful contract coordinate without that leakage.
- **Add `PredicateFor` and a union-shaped `WhereInput`.** `WhereFilter` matches the method it targets, while the existing `ShorthandWhereFilter` and `RelationPredicate` names keep the ORM's object and callback authoring forms explicit instead of hiding them behind one broad union.
- **Keep namespace optional or after model.** Optional namespace lookup becomes imprecise when model names collide. Requiring `<Contract, Namespace, Model>` matches the contract coordinate order and guarantees useful autocomplete.
- **Document `Parameters<...>` or casts as the workaround.** Those approaches duplicate complexity at every helper and can move diagnostics to the eventual `.where()` call. A first-class exported type keeps the error at its source.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title uses the linked GitHub issue prefix because this issue has no Linear ticket.
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

The main compatibility consideration is the intentionally required ORM namespace coordinate; matching app and extension upgrade instructions ship in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SQL ORM filter and relation types now support namespace-qualified model references.
  - Added reusable, publicly available filter type support for SQL builder workflows.
  - Namespace-aware typing improves autocomplete and validation across filtering, sorting, and relation queries.

- **Bug Fixes**
  - Invalid fields and unknown namespaces are now rejected more reliably during TypeScript checks.

- **Documentation**
  - Added upgrade guidance for updating reusable ORM filter type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->