### PR TITLE
ci: fix the prisma-cli publish notification (event type, repo name)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -304,4 +304,4 @@ jobs:
             -H "Authorization: Bearer $DISPATCH_PAT" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/prisma/prisma-cli/dispatches \
-            -d "{\"event_type\":\"family-published\",\"client_payload\":{\"repo\":\"prisma/prisma\",\"version\":\"$VERSION\"}}"
+            -d "{\"event_type\":\"product-published\",\"client_payload\":{\"repo\":\"prisma/orm\",\"version\":\"$VERSION\"}}"


### PR DESCRIPTION
## Linked issue

n/a — small change; fallout from the repository rename (prisma/prisma → prisma/orm).

## Summary

The publish workflow's "Notify prisma-cli" step never reached its consumer. It sent `event_type: family-published`, but prisma-cli's `update-product-versions.yml` triggers on `product-published`, so the auto-repin only ever ran from its daily scheduled backstop. The payload also still named this repo `prisma/prisma`. The step now sends `product-published` with `repo: prisma/orm`.

## Testing performed

- Verified the receiving side: `prisma/prisma-cli` `.github/workflows/update-product-versions.yml` triggers on `repository_dispatch: types: [product-published]` and reads nothing from the payload, so the `repo` field is informational.
- The diff changes only characters inside an existing quoted scalar; no YAML structure changed.

## Skill update

n/a — internal only (CI workflow; no user-facing surface).

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco). The DCO status check will block merge if any commit is missing a `Signed-off-by:` trailer.
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated (n/a — CI workflow change, no test surface).
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this rename fallout; the title follows the repo's convention for such chores (cf. #30145).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

- The event-type mismatch predates the rename. prisma-cli's consumer workflow was created on 2026-08-17 listening for `product-published` (prisma/prisma-cli#192); this sender, added on 2026-08-13, was never updated. The daily cron masked the dead letter — a lost dispatch delays the repin by at most a day, which is why nothing visibly broke.
- Companion PRs update the other side of the rename: `prisma/orm` `v7` branch (`github.repository` guards), `prisma/engines-wrapper` (workflow dispatch target), and `prisma/prisma-engines` (Makefile clone URL).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publication notification event type to `product-published`.
  * Repository and version information in the notification remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->