### PR TITLE
ci: update github.repository checks for the rename to prisma/orm

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on the main repo (not on forks): neither the CodSpeed token nor write
     # access to the `gh-pages` benchmark history is available to a fork.
-    if: github.repository == 'prisma/prisma'
+    if: github.repository == 'prisma/orm'
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,8 +61,8 @@ env:
   FAILURE_TITLE_TEMPLATE: >-
     ${{
       github.event.inputs.targetVersion &&
-      format('prisma/prisma Release {0} from {1} on latest tag failed :x:', github.event.inputs.targetVersion, github.ref_name) ||
-      'prisma/prisma Release failed :x:'
+      format('prisma/orm Release {0} from {1} on latest tag failed :x:', github.event.inputs.targetVersion, github.ref_name) ||
+      'prisma/orm Release failed :x:'
     }}
 
 jobs:
@@ -165,7 +165,7 @@ jobs:
       - name: Slack Notification on Success
         uses: rtCamp/action-slack-notify@c33737706dea87cd7784c687dadc9adf1be59990 # v2.3.2
         env:
-          SLACK_TITLE: 'prisma/prisma Release ${{ needs.release.outputs.prismaVersion }} succeeded :white_check_mark:'
+          SLACK_TITLE: 'prisma/orm Release ${{ needs.release.outputs.prismaVersion }} succeeded :white_check_mark:'
           SLACK_COLOR: '#55ff55'
           SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_FEED_WEBHOOK }}
           SLACK_CHANNEL: feed-prisma-publish

--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -197,7 +197,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -265,7 +265,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -332,7 +332,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -387,7 +387,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -510,7 +510,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -1051,7 +1051,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason =='buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason =='buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288
@@ -1272,7 +1272,7 @@ jobs:
       - name: Upload test results to BuildPulse for flaky test detection
         # Only run this step for branches where we have access to secrets.
         # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/prisma'
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled() && inputs.reason == 'buildpulse' && github.repository == 'prisma/orm'
         uses: buildpulse/buildpulse-action@d0d30f53585cf16b2e01811a5a753fd47968654a # v0.11.0
         with:
           account: 17219288

--- a/.github/workflows/v7-update-engines-version.yml
+++ b/.github/workflows/v7-update-engines-version.yml
@@ -154,7 +154,7 @@ jobs:
           number: ${{ steps.cpr.outputs.pull-request-number }}
 
       #
-      # Integration Engine PR for end to end testing (From prisma/prisma-engines to prisma/prisma and finally npm)
+      # Integration Engine PR for end to end testing (From prisma/prisma-engines to prisma/orm and finally npm)
       # This will create a draft PR as we don't want to merge it
       # But we want to publish it to npm
       # For that we can create an `integration/` branch


### PR DESCRIPTION
## Summary

The repository was renamed from prisma/prisma to prisma/orm, so `github.repository == 'prisma/prisma'` is now always false. Two things have been silently skipped on this branch since the rename:

- the eight BuildPulse upload steps in `.github/workflows/test-template.yml`
- the benchmark job in `.github/workflows/benchmark.yml`

This PR updates those guards to `'prisma/orm'`. The guards keep their purpose: forks still see a different `github.repository`, so they still skip these steps.

Also updated, cosmetic only: the Slack release titles in `publish.yml` and one comment in `v7-update-engines-version.yml`.

## Testing performed

- `grep -rP "prisma/prisma(?![-_A-Za-z])" .github/workflows/` finds no remaining bare references. `@prisma/prisma-schema-wasm` and `prisma/prisma-engines` references are intentionally untouched.
- The diff changes only string literals inside existing expressions and one comment; no YAML structure changed.

## Related PRs

Companion rename fixes: prisma/orm#30179 (`main` publish notification), prisma/engines-wrapper#539 (workflow dispatch target), prisma/prisma-engines#5859 (Makefile clone URL).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflows to reference the current repository.
  - Benchmarking and build metrics uploads now run under the correct repository context.
  - Release notifications now identify the correct repository.
  - Updated integration-testing workflow documentation to reflect the current repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->