### PR TITLE
test(e2e): run prisma init from the local tarball in the corepack test

### DIFF
--- a/packages/client/tests/e2e/prisma-init-corepack/_steps.ts
+++ b/packages/client/tests/e2e/prisma-init-corepack/_steps.ts
@@ -8,7 +8,7 @@ void executeSteps({
     await $`pnpm install`
   },
   test: async () => {
-    await $`pnpm dlx prisma init`
+    await $`pnpm exec prisma init`
   },
   finish: async () => {
     await $`echo "done"`


### PR DESCRIPTION
## Summary

The `prisma-init-corepack` e2e test fails on every CI run (for example, [this shard on #30180](https://github.com/prisma/orm/actions/runs/33404519109/job/99528741843), and the same shard on the `v7` tip's own CI run from 2026-08-27, before that PR existed).

Cause: the test runs `pnpm dlx prisma init`. `dlx` ignores the locally installed package and fetches `prisma@latest` from the registry — and `latest` is Prisma 8 (`8.0.0-rc.12` today; Prisma 7 moved to the `prev` dist-tag). The v8 CLI rejects the fixture's Prisma 7 `prisma.config.ts` with `CLI.CONFIG_MISSING_MARKER`. The test was green on 2026-08-17 and red by 2026-08-27, matching the dist-tag transition, and can never be green again in this form.

Fix: run `pnpm exec prisma init` instead. The fixture already installs the `prisma` tarball under test as a devDependency, so `exec` makes the test hermetic and exercises the v7 CLI this branch builds. This matches the sibling `prisma-init-bun` test, which also runs the locally installed CLI.

The corepack regression coverage this test exists for (#28504) is unchanged: `prisma init` still executes in a `corepack enable`d container through a corepack-managed pnpm (`packageManager: pnpm@10.15.1`).

## Testing performed

- Read the failing job log: the error envelope comes from the v8 CLI (`CLI.CONFIG_MISSING_MARKER`, "most likely a Prisma 7 config"), immediately after `dlx` downloads `prisma` from the registry.
- Verified registry state: `prisma` dist-tags are `latest: 8.0.0-rc.12`, `prev: 7.10.0`.
- The e2e shard on this PR's CI is the verification that the test passes again.

## Related PRs

- prisma/orm#30180 (v7 `github.repository` guards) — its failing e2e check is this same pre-existing test failure, plus a `pnpm audit` Lint failure that is advisory-driven and unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the Prisma initialization end-to-end test to run the locally installed Prisma package.
  * Improved test reliability by avoiding unexpected package retrieval during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->