### PR TITLE
Optimize decode-row orchestration

### DIFF
--- a/packages/2-sql/5-runtime/src/codecs/decoding.ts
+++ b/packages/2-sql/5-runtime/src/codecs/decoding.ts
@@ -11,12 +11,36 @@ import type {
   RawQueryAst,
   SqlCodecCallContext,
 } from '@internal/sql-relational-core/ast';
+import { blindCast } from '@internal/utils/casts';
 import { isStructuredError } from '@internal/utils/structured-error';
 
 type ColumnRef = { table: string; column: string };
+type IncludeAggregateValue = object | string | number | boolean | null;
+
+interface DecodeFieldPlan {
+  readonly alias: string;
+  readonly codec: Codec | undefined;
+  readonly ref: ColumnRef | undefined;
+  readonly callColumn: SqlCodecCallContext['column'];
+  readonly include: boolean;
+  readonly many: boolean;
+}
+
+interface CompiledRowDecoder {
+  readonly createTasks: (
+    row: Record<string, unknown>,
+    rowCtx: SqlCodecCallContext,
+  ) => Promise<unknown>[];
+  readonly createResult: (
+    row: Record<string, unknown>,
+    settled: unknown[],
+  ) => Record<string, unknown>;
+}
 
 export interface DecodeContext {
   readonly aliases: ReadonlyArray<string> | undefined;
+  readonly fields: ReadonlyArray<DecodeFieldPlan> | undefined;
+  readonly compiled?: CompiledRowDecoder;
   readonly codecs: ReadonlyMap<string, Codec>;
   readonly columnRefs: ReadonlyMap<string, ColumnRef>;
   readonly includeAliases: ReadonlySet<string>;
@@ -33,13 +57,26 @@ export interface DecodeContext {
 const WIRE_PREVIEW_LIMIT = 100;
 const EMPTY_INCLUDE_ALIASES: ReadonlySet<string> = new Set<string>();
 
-function projectionListFromAst(
-  ast: Exclude<AnyQueryAst, RawQueryAst>,
-): ReadonlyArray<ProjectionItem> | undefined {
-  if (ast.kind === 'select') {
-    return ast.projection;
+function projectionListFromAst(ast: unknown): ReadonlyArray<ProjectionItem> | undefined {
+  if (typeof ast !== 'object' || ast === null) {
+    return undefined;
   }
-  return ast.returning;
+  if ('kind' in ast && ast.kind === 'select') {
+    if (!('projection' in ast) || !Array.isArray(ast.projection)) {
+      return undefined;
+    }
+    return blindCast<
+      ReadonlyArray<ProjectionItem>,
+      'Array.isArray validates the projection list and the query AST validator guarantees its items'
+    >(ast.projection);
+  }
+  if (!('returning' in ast) || ast.returning === undefined || !Array.isArray(ast.returning)) {
+    return undefined;
+  }
+  return blindCast<
+    ReadonlyArray<ProjectionItem>,
+    'Array.isArray validates the returning list and the query AST validator guarantees its items'
+  >(ast.returning);
 }
 
 function resolveProjectionCodec(
@@ -57,6 +94,7 @@ const EMPTY_MANY_ALIASES: ReadonlySet<string> = new Set<string>();
 function undecodedContext(): DecodeContext {
   return {
     aliases: undefined,
+    fields: undefined,
     codecs: new Map(),
     columnRefs: new Map(),
     includeAliases: EMPTY_INCLUDE_ALIASES,
@@ -83,16 +121,35 @@ function rawQueryDecodeContext(
   }
 
   const aliases: string[] = [];
+  const fields: DecodeFieldPlan[] = [];
   const codecs = new Map<string, Codec>();
   for (const [name, column] of Object.entries(ast.result.columns)) {
     aliases.push(name);
-    if (contractCodecs) {
-      codecs.set(name, contractCodecs.forCodecRef({ codecId: column.codecId }));
+    if (typeof column !== 'object' || column === null || !('codecId' in column)) {
+      throw new TypeError(`Raw query column "${name}" has no codecId`);
     }
+    const codecId = column.codecId;
+    if (typeof codecId !== 'string') {
+      throw new TypeError(`Raw query column "${name}" has a non-string codecId`);
+    }
+    const codec = contractCodecs?.forCodecRef({ codecId });
+    if (codec) {
+      codecs.set(name, codec);
+    }
+    fields.push({
+      alias: name,
+      codec,
+      ref: undefined,
+      callColumn: undefined,
+      include: false,
+      many: false,
+    });
   }
 
   return {
     aliases,
+    fields,
+    compiled: compileRowDecoder(fields),
     codecs,
     columnRefs: new Map(),
     includeAliases: EMPTY_INCLUDE_ALIASES,
@@ -115,6 +172,7 @@ export function buildDecodeContext(
   }
 
   const aliases: string[] = [];
+  const fields: DecodeFieldPlan[] = [];
   const codecs = new Map<string, Codec>();
   const columnRefs = new Map<string, ColumnRef>();
   const includeAliases = new Set<string>();
@@ -128,21 +186,34 @@ export function buildDecodeContext(
       codecs.set(item.alias, codec);
     }
 
-    if (item.codec?.many) {
+    const many = item.codec?.many === true;
+    if (many) {
       manyAliases.add(item.alias);
     }
 
+    let ref: ColumnRef | undefined;
+    let include = false;
     if (item.expr.kind === 'column-ref') {
-      columnRefs.set(item.alias, {
-        table: item.expr.table,
-        column: item.expr.column,
-      });
+      ref = { table: item.expr.table, column: item.expr.column };
+      columnRefs.set(item.alias, ref);
     } else if (item.expr.kind === 'subquery' || item.expr.kind === 'json-array-agg') {
+      include = true;
       includeAliases.add(item.alias);
     }
+    const callColumn = ref ? { table: ref.table, name: ref.column } : undefined;
+    fields.push({ alias: item.alias, codec, ref, callColumn, include, many });
   }
 
-  return { aliases, codecs, columnRefs, includeAliases, manyAliases, aliasSource: 'projection' };
+  return {
+    aliases,
+    fields,
+    compiled: compileRowDecoder(fields),
+    codecs,
+    columnRefs,
+    includeAliases,
+    manyAliases,
+    aliasSource: 'projection',
+  };
 }
 
 function previewWireValue(wireValue: unknown): string {
@@ -190,7 +261,7 @@ function wrapIncludeAggregateFailure(error: unknown, alias: string, wireValue: u
   throw wrapped;
 }
 
-function decodeIncludeAggregate(alias: string, wireValue: unknown): unknown {
+function decodeIncludeAggregate(alias: string, wireValue: unknown): IncludeAggregateValue {
   if (wireValue === null || wireValue === undefined) {
     return [];
   }
@@ -222,73 +293,110 @@ function decodeIncludeAggregate(alias: string, wireValue: unknown): unknown {
  *
  * For `many`-flagged aliases the driver has already parsed the wire form into a JS array; this function maps the element codec over that array element-by-element, passing `null` elements through unchanged. Element-level failures surface through the existing `RUNTIME.DECODE_FAILED` envelope with the column/codec context from the parent cell.
  */
-async function decodeField(
-  alias: string,
+async function decodeManyField(
+  field: DecodeFieldPlan,
   wireValue: unknown,
-  decodeCtx: DecodeContext,
+  codec: Codec,
+  cellCtx: SqlCodecCallContext,
+): Promise<unknown> {
+  const { alias, ref } = field;
+  if (!Array.isArray(wireValue)) {
+    wrapDecodeFailure(
+      new TypeError(
+        `expected an array from the driver for many-typed column, got ${typeof wireValue}`,
+      ),
+      alias,
+      ref,
+      codec,
+      wireValue,
+    );
+  }
+  const decoded: unknown[] = [];
+  for (const elem of wireValue) {
+    if (elem === null || elem === undefined) {
+      decoded.push(null);
+      continue;
+    }
+    try {
+      decoded.push(await codec.decode(elem, cellCtx));
+    } catch (error) {
+      if (isStructuredError(error)) throw error;
+      wrapDecodeFailure(error, alias, ref, codec, elem);
+    }
+  }
+  return decoded;
+}
+
+function decodeField(
+  field: DecodeFieldPlan,
+  wireValue: unknown,
   rowCtx: SqlCodecCallContext,
 ): Promise<unknown> {
   if (wireValue === null) {
-    return null;
+    return Promise.resolve(null);
   }
 
-  const codec = decodeCtx.codecs.get(alias);
+  const { alias, codec, ref, callColumn } = field;
   if (!codec) {
-    return wireValue;
+    return Promise.resolve(wireValue);
   }
 
-  const ref = decodeCtx.columnRefs.get(alias);
-
+  const signal = rowCtx.signal;
   let cellCtx: SqlCodecCallContext;
-  if (ref) {
-    cellCtx = { ...rowCtx, column: { table: ref.table, name: ref.column } };
+  if (callColumn) {
+    cellCtx = signal === undefined ? { column: callColumn } : { signal, column: callColumn };
   } else {
-    const { column: _drop, ...rowCtxWithoutColumn } = rowCtx;
-    cellCtx = rowCtxWithoutColumn;
+    cellCtx = signal === undefined ? {} : { signal };
   }
 
-  if (decodeCtx.manyAliases.has(alias)) {
-    if (!Array.isArray(wireValue)) {
-      wrapDecodeFailure(
-        new TypeError(
-          `expected an array from the driver for many-typed column, got ${typeof wireValue}`,
-        ),
-        alias,
-        ref,
-        codec,
-        wireValue,
-      );
-    }
-    const decoded: unknown[] = [];
-    for (const elem of wireValue) {
-      if (elem === null || elem === undefined) {
-        decoded.push(null);
-        continue;
-      }
-      try {
-        decoded.push(await codec.decode(elem, cellCtx));
-      } catch (error) {
-        if (isStructuredError(error)) throw error;
-        wrapDecodeFailure(error, alias, ref, codec, elem);
-      }
-    }
-    return decoded;
+  if (field.many) {
+    return decodeManyField(field, wireValue, codec, cellCtx);
   }
 
-  try {
-    return await codec.decode(wireValue, cellCtx);
-  } catch (error) {
-    // Any structured envelope (dotted `code` per `isStructuredError`) is
-    // stable by construction — let it pass through unchanged. This covers
-    // every `runtimeError`-built envelope and plain `structuredError`
-    // envelopes from extension codecs (e.g. a codec-authored
-    // `RUNTIME.DECODE_FAILED` — no double wrap). Symmetric with the
-    // encode-side guard.
+  const wrapFailure = (error: unknown): never => {
     if (isStructuredError(error)) {
       throw error;
     }
     wrapDecodeFailure(error, alias, ref, codec, wireValue);
+  };
+
+  try {
+    const decoded = codec.decode(wireValue, cellCtx);
+    return decoded instanceof Promise
+      ? decoded.catch(wrapFailure)
+      : Promise.resolve(decoded).catch(wrapFailure);
+  } catch (error) {
+    return Promise.reject(error).catch(wrapFailure);
   }
+}
+
+function compileRowDecoder(fields: ReadonlyArray<DecodeFieldPlan>): CompiledRowDecoder {
+  const taskExpressions = fields.map((field, index) =>
+    field.include
+      ? 'Promise.resolve(undefined)'
+      : `decodeField(fields[${index}], row[${JSON.stringify(field.alias)}], rowCtx)`,
+  );
+  const resultProperties = fields.map((field, index) => {
+    const alias = JSON.stringify(field.alias);
+    const value = field.include
+      ? `decodeIncludeAggregate(${alias}, row[${alias}])`
+      : `settled[${index}]`;
+    return `[${alias}]: ${value}`;
+  });
+  const create = new Function(
+    'decodeField',
+    'decodeIncludeAggregate',
+    'fields',
+    `"use strict";
+return {
+  createTasks(row, rowCtx) { return [${taskExpressions.join(',')}]; },
+  createResult(row, settled) { return {${resultProperties.join(',')}}; }
+};`,
+  );
+  return blindCast<
+    CompiledRowDecoder,
+    'new Function is generated exclusively from JSON-escaped aliases and numeric field indices'
+  >(create(decodeField, decodeIncludeAggregate, fields));
 }
 
 /**
@@ -312,7 +420,7 @@ export async function decodeRow(
 
   if (decodeCtx.aliases !== undefined) {
     for (const alias of decodeCtx.aliases) {
-      if (!Object.hasOwn(row, alias)) {
+      if (row[alias] === undefined && !Object.hasOwn(row, alias)) {
         throw decodeCtx.aliasSource === 'row-spec'
           ? runtimeError(
               'RUNTIME.RAW_ROW_COLUMN_MISSING',
@@ -332,31 +440,50 @@ export async function decodeRow(
     }
   }
 
-  const tasks: Promise<unknown>[] = [];
+  const compiled = decodeCtx.compiled;
+  let tasks: Promise<unknown>[];
   const includeIndices: { index: number; alias: string; value: unknown }[] = [];
 
-  for (let i = 0; i < aliases.length; i++) {
-    const alias = aliases[i] as string;
-    const wireValue = row[alias];
-
-    if (decodeCtx.includeAliases.has(alias)) {
-      includeIndices.push({ index: i, alias, value: wireValue });
-      tasks.push(Promise.resolve(undefined));
-      continue;
+  if (compiled) {
+    tasks = compiled.createTasks(row, rowCtx);
+  } else {
+    tasks = new Array<Promise<unknown>>(aliases.length);
+    const fields = decodeCtx.fields;
+    if (fields === undefined) {
+      let index = 0;
+      for (const alias of aliases) {
+        tasks[index++] = Promise.resolve(row[alias]);
+      }
+    } else {
+      let index = 0;
+      for (const field of fields) {
+        const wireValue = row[field.alias];
+        if (field.include) {
+          includeIndices.push({ index, alias: field.alias, value: wireValue });
+          tasks[index++] = Promise.resolve(undefined);
+          continue;
+        }
+        tasks[index++] = decodeField(field, wireValue, rowCtx);
+      }
     }
-
-    tasks.push(decodeField(alias, wireValue, decodeCtx, rowCtx));
   }
 
-  const settled = await raceAgainstAbort(Promise.all(tasks), signal, 'decode');
+  const allTasks = Promise.all(tasks);
+  const settled =
+    signal === undefined ? await allTasks : await raceAgainstAbort(allTasks, signal, 'decode');
+
+  if (compiled) {
+    return compiled.createResult(row, settled);
+  }
 
   for (const entry of includeIndices) {
     settled[entry.index] = decodeIncludeAggregate(entry.alias, entry.value);
   }
 
   const decoded: Record<string, unknown> = {};
-  for (let i = 0; i < aliases.length; i++) {
-    decoded[aliases[i] as string] = settled[i];
+  let index = 0;
+  for (const alias of aliases) {
+    decoded[alias] = settled[index++];
   }
   return decoded;
 }

--- a/packages/2-sql/5-runtime/src/codecs/decoding.ts
+++ b/packages/2-sql/5-runtime/src/codecs/decoding.ts
@@ -9,6 +9,7 @@ import type {
   ContractCodecRegistry,
   ProjectionItem,
   RawQueryAst,
+  RawQueryColumn,
   SqlCodecCallContext,
 } from '@internal/sql-relational-core/ast';
 import { blindCast } from '@internal/utils/casts';
@@ -40,7 +41,7 @@ interface CompiledRowDecoder {
 export interface DecodeContext {
   readonly aliases: ReadonlyArray<string> | undefined;
   readonly fields: ReadonlyArray<DecodeFieldPlan> | undefined;
-  readonly compiled?: CompiledRowDecoder;
+  readonly compiled: CompiledRowDecoder | undefined;
   readonly codecs: ReadonlyMap<string, Codec>;
   readonly columnRefs: ReadonlyMap<string, ColumnRef>;
   readonly includeAliases: ReadonlySet<string>;
@@ -56,28 +57,6 @@ export interface DecodeContext {
 
 const WIRE_PREVIEW_LIMIT = 100;
 const EMPTY_INCLUDE_ALIASES: ReadonlySet<string> = new Set<string>();
-
-function projectionListFromAst(ast: unknown): ReadonlyArray<ProjectionItem> | undefined {
-  if (typeof ast !== 'object' || ast === null) {
-    return undefined;
-  }
-  if ('kind' in ast && ast.kind === 'select') {
-    if (!('projection' in ast) || !Array.isArray(ast.projection)) {
-      return undefined;
-    }
-    return blindCast<
-      ReadonlyArray<ProjectionItem>,
-      'Array.isArray validates the projection list and the query AST validator guarantees its items'
-    >(ast.projection);
-  }
-  if (!('returning' in ast) || ast.returning === undefined || !Array.isArray(ast.returning)) {
-    return undefined;
-  }
-  return blindCast<
-    ReadonlyArray<ProjectionItem>,
-    'Array.isArray validates the returning list and the query AST validator guarantees its items'
-  >(ast.returning);
-}
 
 function resolveProjectionCodec(
   item: ProjectionItem,
@@ -95,6 +74,7 @@ function undecodedContext(): DecodeContext {
   return {
     aliases: undefined,
     fields: undefined,
+    compiled: undefined,
     codecs: new Map(),
     columnRefs: new Map(),
     includeAliases: EMPTY_INCLUDE_ALIASES,
@@ -115,6 +95,7 @@ function undecodedContext(): DecodeContext {
 function rawQueryDecodeContext(
   ast: RawQueryAst,
   contractCodecs: ContractCodecRegistry | undefined,
+  options: BuildDecodeContextOptions,
 ): DecodeContext {
   if (ast.result.kind === 'affected-count') {
     return undecodedContext();
@@ -123,16 +104,9 @@ function rawQueryDecodeContext(
   const aliases: string[] = [];
   const fields: DecodeFieldPlan[] = [];
   const codecs = new Map<string, Codec>();
-  for (const [name, column] of Object.entries(ast.result.columns)) {
+  for (const [name, column] of Object.entries<RawQueryColumn>(ast.result.columns)) {
     aliases.push(name);
-    if (typeof column !== 'object' || column === null || !('codecId' in column)) {
-      throw new TypeError(`Raw query column "${name}" has no codecId`);
-    }
-    const codecId = column.codecId;
-    if (typeof codecId !== 'string') {
-      throw new TypeError(`Raw query column "${name}" has a non-string codecId`);
-    }
-    const codec = contractCodecs?.forCodecRef({ codecId });
+    const codec = contractCodecs?.forCodecRef({ codecId: column.codecId });
     if (codec) {
       codecs.set(name, codec);
     }
@@ -149,7 +123,7 @@ function rawQueryDecodeContext(
   return {
     aliases,
     fields,
-    compiled: compileRowDecoder(fields),
+    compiled: options.reusable ? compileRowDecoder(fields) : undefined,
     codecs,
     columnRefs: new Map(),
     includeAliases: EMPTY_INCLUDE_ALIASES,
@@ -158,15 +132,20 @@ function rawQueryDecodeContext(
   };
 }
 
+export interface BuildDecodeContextOptions {
+  readonly reusable?: boolean;
+}
+
 export function buildDecodeContext(
   ast: AnyQueryAst,
   contractCodecs: ContractCodecRegistry | undefined,
+  options: BuildDecodeContextOptions = {},
 ): DecodeContext {
   if (ast.kind === 'raw-query') {
-    return rawQueryDecodeContext(ast, contractCodecs);
+    return rawQueryDecodeContext(ast, contractCodecs, options);
   }
 
-  const projection = projectionListFromAst(ast);
+  const projection = ast.kind === 'select' ? ast.projection : ast.returning;
   if (!projection || projection.length === 0) {
     return undecodedContext();
   }
@@ -207,7 +186,7 @@ export function buildDecodeContext(
   return {
     aliases,
     fields,
-    compiled: compileRowDecoder(fields),
+    compiled: options.reusable ? compileRowDecoder(fields) : undefined,
     codecs,
     columnRefs,
     includeAliases,
@@ -370,7 +349,7 @@ function decodeField(
   }
 }
 
-function compileRowDecoder(fields: ReadonlyArray<DecodeFieldPlan>): CompiledRowDecoder {
+function compileRowDecoder(fields: ReadonlyArray<DecodeFieldPlan>): CompiledRowDecoder | undefined {
   const taskExpressions = fields.map((field, index) =>
     field.include
       ? 'Promise.resolve(undefined)'
@@ -383,20 +362,24 @@ function compileRowDecoder(fields: ReadonlyArray<DecodeFieldPlan>): CompiledRowD
       : `settled[${index}]`;
     return `[${alias}]: ${value}`;
   });
-  const create = new Function(
-    'decodeField',
-    'decodeIncludeAggregate',
-    'fields',
-    `"use strict";
+  try {
+    const create = new Function(
+      'decodeField',
+      'decodeIncludeAggregate',
+      'fields',
+      `"use strict";
 return {
   createTasks(row, rowCtx) { return [${taskExpressions.join(',')}]; },
   createResult(row, settled) { return {${resultProperties.join(',')}}; }
 };`,
-  );
-  return blindCast<
-    CompiledRowDecoder,
-    'new Function is generated exclusively from JSON-escaped aliases and numeric field indices'
-  >(create(decodeField, decodeIncludeAggregate, fields));
+    );
+    return blindCast<
+      CompiledRowDecoder,
+      'new Function is generated exclusively from JSON-escaped aliases and numeric field indices'
+    >(create(decodeField, decodeIncludeAggregate, fields));
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -420,7 +403,7 @@ export async function decodeRow(
 
   if (decodeCtx.aliases !== undefined) {
     for (const alias of decodeCtx.aliases) {
-      if (row[alias] === undefined && !Object.hasOwn(row, alias)) {
+      if (!Object.hasOwn(row, alias)) {
         throw decodeCtx.aliasSource === 'row-spec'
           ? runtimeError(
               'RUNTIME.RAW_ROW_COLUMN_MISSING',

--- a/packages/2-sql/5-runtime/src/sql-runtime.ts
+++ b/packages/2-sql/5-runtime/src/sql-runtime.ts
@@ -578,7 +578,9 @@ export abstract class SqlRuntimeBase<TContract extends Contract<SqlStorage> = Co
       params: orderedRefs.map((r) => (r.kind === 'param-ref' ? r.value : undefined)),
     });
 
-    const decodeContext = buildDecodeContext(finalPlan.ast, this.contractCodecs);
+    const decodeContext = buildDecodeContext(finalPlan.ast, this.contractCodecs, {
+      reusable: true,
+    });
     const paramMetadata = deriveParamMetadata(finalPlan.ast);
 
     const internals: PreparedStatementInternals = Object.freeze({

--- a/packages/2-sql/5-runtime/test/codec-async.test.ts
+++ b/packages/2-sql/5-runtime/test/codec-async.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@internal/sql-relational-core/ast';
 import type { SqlExecutionPlan } from '@internal/sql-relational-core/plan';
 import { timeouts } from '@repo/test-utils';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { buildDecodeContext, decodeRow } from '../src/codecs/decoding';
 import { encodeParams } from '../src/codecs/encoding';
 import { createAsyncSecretCodec, decryptSecret, encryptSecret } from './seeded-secret-codec';
@@ -376,15 +376,19 @@ describe('decodeRow — async, concurrent per-cell dispatch', () => {
   it('dispatches later cells after an earlier codec throws synchronously', async () => {
     const cause = new Error('sync failure');
     let laterCalls = 0;
-    const registry = [
-      defineTestCodec({
+    const syncThrowCodec: Codec = {
+      ...defineTestCodec({
         typeId: 'test/sync-throw@1',
         targetTypes: ['text'],
         encode: (value: string) => value,
-        decode: () => {
-          throw cause;
-        },
+        decode: (wire: string) => wire,
       }),
+      decode: () => {
+        throw cause;
+      },
+    };
+    const registry: Codec[] = [
+      syncThrowCodec,
       defineTestCodec({
         typeId: 'test/later@1',
         targetTypes: ['text'],
@@ -554,17 +558,38 @@ describe('decodeRow — async, concurrent per-cell dispatch', () => {
     expect(result).toEqual({ before: 1, name: 'ALICE', nullable: null, after: 3 });
   });
 
-  it('treats projection aliases as data when compiling a row shape', async () => {
+  it('uses the generic decoder for one-shot contexts', async () => {
+    const plan = buildAstPlan({ projections: [{ alias: 'value' }] });
+    const context = buildDecodeContext(plan.ast, buildTestContractCodecs([]));
+
+    expect(context.compiled).toBeUndefined();
+    await expect(decodeRow({ value: 'safe' }, context, {})).resolves.toEqual({ value: 'safe' });
+  });
+
+  it('treats projection aliases as data when compiling a reusable row shape', async () => {
     const alias = 'field"];\nthrow new Error("injected") //';
     const plan = buildAstPlan({ projections: [{ alias }] });
+    const context = buildDecodeContext(plan.ast, buildTestContractCodecs([]), { reusable: true });
 
-    const result = await decodeRow(
-      { [alias]: 'safe' },
-      buildDecodeContext(plan.ast, buildTestContractCodecs([])),
-      {},
-    );
+    expect(context.compiled).toBeDefined();
+    await expect(decodeRow({ [alias]: 'safe' }, context, {})).resolves.toEqual({ [alias]: 'safe' });
+  });
 
-    expect(result).toEqual({ [alias]: 'safe' });
+  it('falls back to the generic decoder when reusable context compilation is unavailable', async () => {
+    const plan = buildAstPlan({ projections: [{ alias: 'value' }] });
+    vi.stubGlobal('Function', function unavailableFunctionConstructor(): never {
+      throw new EvalError('unsafe-eval is disabled');
+    });
+
+    try {
+      const context = buildDecodeContext(plan.ast, buildTestContractCodecs([]), {
+        reusable: true,
+      });
+      expect(context.compiled).toBeUndefined();
+      await expect(decodeRow({ value: 'safe' }, context, {})).resolves.toEqual({ value: 'safe' });
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('passes wire values through for raw plans (no AST, no codec decoding)', async () => {
@@ -602,6 +627,21 @@ describe('decodeRow — async, concurrent per-cell dispatch', () => {
         alias: 'email',
         expectedAliases: ['id', 'email'],
         presentKeys: ['id'],
+      },
+    });
+  });
+
+  it('rejects an inherited projection alias as missing', async () => {
+    const plan = buildAstPlan({ projections: [{ alias: 'toString' }] });
+
+    await expect(
+      decodeRow({}, buildDecodeContext(plan.ast, buildTestContractCodecs([])), {}),
+    ).rejects.toMatchObject({
+      code: 'RUNTIME.DECODE_FAILED',
+      details: {
+        alias: 'toString',
+        expectedAliases: ['toString'],
+        presentKeys: [],
       },
     });
   });

--- a/packages/2-sql/5-runtime/test/codec-async.test.ts
+++ b/packages/2-sql/5-runtime/test/codec-async.test.ts
@@ -373,6 +373,45 @@ describe('decodeRow — async, concurrent per-cell dispatch', () => {
     expect(result).toEqual({ a: 'A:A-DEC', b: 'B:B-DEC', n: 42 });
   });
 
+  it('dispatches later cells after an earlier codec throws synchronously', async () => {
+    const cause = new Error('sync failure');
+    let laterCalls = 0;
+    const registry = [
+      defineTestCodec({
+        typeId: 'test/sync-throw@1',
+        targetTypes: ['text'],
+        encode: (value: string) => value,
+        decode: () => {
+          throw cause;
+        },
+      }),
+      defineTestCodec({
+        typeId: 'test/later@1',
+        targetTypes: ['text'],
+        encode: (value: string) => value,
+        decode: (wire: string) => {
+          laterCalls++;
+          return wire;
+        },
+      }),
+    ];
+    const plan = buildAstPlan({
+      projections: [
+        { alias: 'first', codecId: 'test/sync-throw@1' },
+        { alias: 'later', codecId: 'test/later@1' },
+      ],
+    });
+
+    await expect(
+      decodeRow(
+        { first: 'first', later: 'later' },
+        buildDecodeContext(plan.ast, buildTestContractCodecs(registry)),
+        {},
+      ),
+    ).rejects.toMatchObject({ code: 'RUNTIME.DECODE_FAILED', cause });
+    expect(laterCalls).toBe(1);
+  });
+
   it('always awaits codec.decode and yields plain values (no Promise leaks)', async () => {
     const registry = [
       defineTestCodec({
@@ -488,6 +527,46 @@ describe('decodeRow — async, concurrent per-cell dispatch', () => {
     });
   });
 
+  it('decodes mixed codec and passthrough fields without an abort signal', async () => {
+    const registry = [
+      defineTestCodec({
+        typeId: 'test/uppercase@1',
+        targetTypes: ['text'],
+        encode: (value: string) => value,
+        decode: async (wire: string) => wire.toUpperCase(),
+      }),
+    ];
+    const plan = buildAstPlan({
+      projections: [
+        { alias: 'before' },
+        { alias: 'name', codecId: 'test/uppercase@1' },
+        { alias: 'nullable', codecId: 'test/uppercase@1' },
+        { alias: 'after' },
+      ],
+    });
+
+    const result = await decodeRow(
+      { before: 1, name: 'alice', nullable: null, after: 3 },
+      buildDecodeContext(plan.ast, buildTestContractCodecs(registry)),
+      {},
+    );
+
+    expect(result).toEqual({ before: 1, name: 'ALICE', nullable: null, after: 3 });
+  });
+
+  it('treats projection aliases as data when compiling a row shape', async () => {
+    const alias = 'field"];\nthrow new Error("injected") //';
+    const plan = buildAstPlan({ projections: [{ alias }] });
+
+    const result = await decodeRow(
+      { [alias]: 'safe' },
+      buildDecodeContext(plan.ast, buildTestContractCodecs([])),
+      {},
+    );
+
+    expect(result).toEqual({ [alias]: 'safe' });
+  });
+
   it('passes wire values through for raw plans (no AST, no codec decoding)', async () => {
     const registry = [
       defineTestCodec({
@@ -525,6 +604,19 @@ describe('decodeRow — async, concurrent per-cell dispatch', () => {
         presentKeys: ['id'],
       },
     });
+  });
+
+  it('preserves an own undefined value as distinct from a missing projection alias', async () => {
+    const plan = buildAstPlan({ projections: [{ alias: 'value' }] });
+
+    const result = await decodeRow(
+      { value: undefined },
+      buildDecodeContext(plan.ast, buildTestContractCodecs([])),
+      {},
+    );
+
+    expect(Object.hasOwn(result, 'value')).toBe(true);
+    expect(result['value']).toBeUndefined();
   });
 
   it('preserves wire null for AST-backed plans (distinct from missing alias)', async () => {

--- a/packages/2-sql/5-runtime/test/codec-decode-ctx.test.ts
+++ b/packages/2-sql/5-runtime/test/codec-decode-ctx.test.ts
@@ -117,6 +117,32 @@ describe('decodeRow — SqlCodecCallContext threading', () => {
     ]);
   });
 
+  it('populates ctx.column from a default empty row context', async () => {
+    let observed: SqlCodecCallContext | undefined;
+    const registry = [
+      defineTestCodec({
+        typeId: 'test/observe-empty-ctx@1',
+        targetTypes: ['text'],
+        encode: (value: string) => value,
+        decode: (wire: string, ctx?: SqlCodecCallContext) => {
+          observed = ctx;
+          return wire;
+        },
+      }),
+    ];
+    const plan = buildPlan([
+      columnProjection('email', 'users', 'email', 'test/observe-empty-ctx@1'),
+    ]);
+
+    await decodeRow(
+      { email: 'user@example.com' },
+      buildDecodeContext(plan.ast, buildTestContractCodecs(registry)),
+      {},
+    );
+
+    expect(observed).toEqual({ column: { table: 'users', name: 'email' } });
+  });
+
   it('populates ctx.column when the projection points at a different table.column than the alias', async () => {
     let observed: SqlCodecCallContext | undefined;
     const registry = [

--- a/test/bench/bench/decode-row.ts
+++ b/test/bench/bench/decode-row.ts
@@ -63,7 +63,11 @@ function createBenchmarkCases(
     if (!rows) {
       throw new Error(`No fixture rows for query "${name}"`);
     }
-    return { name, rows, decodeCtx: buildDecodeContext(plan.ast, contractCodecs) };
+    return {
+      name,
+      rows,
+      decodeCtx: buildDecodeContext(plan.ast, contractCodecs, { reusable: true }),
+    };
   });
 }
 


### PR DESCRIPTION
## Linked issue

n/a — performance work without a tracking issue

Prerequisite: [#30185](https://github.com/prisma/orm/pull/30185). Follow-up: [#30187](https://github.com/prisma/orm/pull/30187).

## Summary

Reduces whole-result-set SQL decoding latency by resolving row-shape metadata once and compiling compact per-shape task and result factories. The benchmark improves from 1236.1 µs to 809.2 µs without the PostgreSQL date fast path.

## At a glance

```ts
const allTasks = Promise.all(tasks);
const settled = signal === undefined ? await allTasks : await raceAgainstAbort(allTasks, signal, 'decode');
```

The common no-signal path now avoids the generic abort race while preserving the signal-bearing path.

## Decision

Precompute everything fixed by `DecodeContext`—codec, column metadata, include status, cardinality, and output shape—then keep per-row work limited to validation, codec dispatch, aggregate settlement, and result construction.

## Reviewer notes

- `compileRowDecoder` uses `new Function`, but generated source contains only `JSON.stringify`-escaped aliases and numeric field indices. Codec objects and helpers remain closure parameters.
- Missing aliases are still validated before any codec runs, including the distinction between absent properties and own properties containing `undefined`.
- Native Promise codecs take a direct rejection path; synchronous values, thenables, cross-realm values, and synchronous throws retain Promise normalization and wrapped errors.
- There is no query-name, fixture-value, or Northwind-specific dispatch.

## How it fits together

1. `buildDecodeContext` produces an index-aligned field plan once per query shape.
2. The compiled task factory creates a packed Promise array without per-cell map or set lookups.
3. Scalar codec Promises attach structured failure handling directly; many-valued codecs retain sequential element semantics.
4. The compiled result factory reconstructs the fixed output shape and decodes includes after aggregate settlement.

## Behavior changes & evidence

- **Projected decoding does less repeated orchestration work** in [`packages/2-sql/5-runtime/src/codecs/decoding.ts`](packages/2-sql/5-runtime/src/codecs/decoding.ts).
- **Abort and async codec guarantees remain unchanged**, evidenced by [`packages/2-sql/5-runtime/test/codec-async.test.ts`](packages/2-sql/5-runtime/test/codec-async.test.ts).
- **Codec call contexts and missing-column errors remain unchanged**, evidenced by [`packages/2-sql/5-runtime/test/codec-decode-ctx.test.ts`](packages/2-sql/5-runtime/test/codec-decode-ctx.test.ts).

## Testing performed

- `pnpm --filter @internal/sql-runtime test` — 38 files, 348 tests
- `pnpm --filter @internal/sql-runtime typecheck`
- `pnpm --filter @internal/target-postgres test` — 93 files, 1596 tests
- `pnpm --filter @internal/target-postgres typecheck`
- Rebuilt framework components, SQL relational core, PostgreSQL target, and SQL runtime before `pnpm --filter benchmarks bench`
- Aggregate whole-result-set result: 1236.1 µs → 809.2 µs (-34.5%)

## Skill update

n/a — internal runtime optimization with no public API or behavior change

## Checklist

- [x] All commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco).
- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and the change is scoped to one logical concern.
- [x] Tests are updated.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form — no Linear ticket exists for this work.
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

This PR is intentionally based on the benchmark PR so its metric and fixtures are reviewable in the same stack.

## Alternatives considered

- **Combine validation with codec dispatch:** rejected because it changes validation-before-side-effect ordering and benchmarked slower.
- **Mix raw values into `Promise.all`:** rejected because uniform Promise-shaped task arrays benchmarked faster.
- **Reuse call-context objects across rows:** rejected because it exposed identity and mutation risk without a reproducible gain.
- **Generate larger specialized validators and codec-kind dispatchers:** rejected because larger generated methods consistently regressed V8 optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved SQL result decoding efficiency, especially for rows with multiple fields and repeated prepared-statement executions.

- **Bug Fixes**
  - Preserved explicitly returned `undefined` values without confusing them with missing columns.
  - Improved handling of mixed decoded and passthrough fields, including `null` values.
  - Ensured later fields continue processing when an earlier field fails.
  - Improved error reporting and validation for decoding failures.
  - Prevented projection aliases from being interpreted as executable content.
  - Improved column context information available during codec processing.
  - Added reliable fallback behavior when optimized decoding is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->