### PR TITLE
chore(deps): bump deepmerge-ts and mariadb past audited vulnerabilities

### DIFF
--- a/packages/adapter-mariadb/package.json
+++ b/packages/adapter-mariadb/package.json
@@ -37,7 +37,7 @@
   "sideEffects": false,
   "dependencies": {
     "@prisma/driver-adapter-utils": "workspace:*",
-    "mariadb": "3.4.5"
+    "mariadb": "3.5.3"
   },
   "devDependencies": {
     "@prisma/debug": "workspace:*"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,7 +13,7 @@
   "author": "Alberto Schiabel <schiabel@prisma.io>",
   "dependencies": {
     "c12": "3.3.4",
-    "deepmerge-ts": "7.1.5",
+    "deepmerge-ts": "8.0.2",
     "effect": "3.20.0",
     "empathic": "2.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,8 +268,8 @@ importers:
         specifier: workspace:*
         version: link:../driver-adapter-utils
       mariadb:
-        specifier: 3.4.5
-        version: 3.4.5
+        specifier: 3.5.3
+        version: 3.5.3
     devDependencies:
       '@prisma/debug':
         specifier: workspace:*
@@ -1177,8 +1177,8 @@ importers:
         specifier: 3.3.4
         version: 3.3.4(magicast@0.5.2)
       deepmerge-ts:
-        specifier: 7.1.5
-        version: 7.1.5
+        specifier: 8.0.2
+        version: 8.0.2
       effect:
         specifier: 3.20.0
         version: 3.20.0
@@ -5522,9 +5522,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
+  deepmerge-ts@8.0.2:
+    resolution: {integrity: sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==}
+    engines: {node: '>=16.9.0'}
 
   deepmerge@4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
@@ -5850,6 +5850,7 @@ packages:
   eslint@9.22.0:
     resolution: {integrity: sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6375,6 +6376,10 @@ packages:
 
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   identifier-regex@1.0.0:
@@ -6970,6 +6975,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -7022,6 +7031,10 @@ packages:
   mariadb@3.4.5:
     resolution: {integrity: sha512-gThTYkhIS5rRqkVr+Y0cIdzr+GRqJ9sA2Q34e0yzmyhMCwyApf3OKAC1jnF23aSlIOqJuyaUFUcj7O1qZslmmQ==}
     engines: {node: '>= 14'}
+
+  mariadb@3.5.3:
+    resolution: {integrity: sha512-i053Kc0MgdUv/hu9mCyq67TYfPXFj3/MV8I7ZW5wvJNixIyXC0VztMPUjIVj/449nQo+BsxFD4Fdk/sA/uqKPQ==}
+    engines: {node: '>= 20.0.0'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -12639,7 +12652,7 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.2: {}
 
   deepmerge@4.2.2: {}
 
@@ -13610,6 +13623,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   identifier-regex@1.0.0:
     dependencies:
       reserved-identifiers: 1.0.0
@@ -14443,6 +14460,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -14515,6 +14534,14 @@ snapshots:
       denque: 2.1.0
       iconv-lite: 0.6.3
       lru-cache: 10.4.3
+
+  mariadb@3.5.3:
+    dependencies:
+      '@types/geojson': 7946.0.16
+      '@types/node': 20.19.37
+      denque: 2.1.0
+      iconv-lite: 0.7.3
+      lru-cache: 11.5.2
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Summary

`pnpm audit --prod` (the "Run pnpm audit (production dependencies only)" step of the Lint job) fails on every PR to this branch with four advisories:

- `deepmerge-ts` < 8.0.0 — stack exhaustion on recursive object graphs ([GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx)), high
- `mariadb` >= 3.4.0 < 3.4.6 — cleartext password leak to a MitM despite `ssl: true` ([GHSA-cqhc-2h57-wpxf](https://github.com/advisories/GHSA-cqhc-2h57-wpxf), high), cleartext transmission of sensitive information ([GHSA-42r5-vhpq-m858](https://github.com/advisories/GHSA-42r5-vhpq-m858), moderate), and possible SQL injection in Buffer parameter escaping under multibyte client charsets ([GHSA-g5xc-5w98-jfvm](https://github.com/advisories/GHSA-g5xc-5w98-jfvm), moderate)

This PR bumps:

- `deepmerge-ts` 7.1.5 → 8.0.2 in `packages/config`. The v8 breaking changes are Map deep-merging and a `deepmergeInto` mutation fix; `@prisma/config` uses neither — it only calls the basic `deepmerge` export on plain config objects (`loadConfigFromFile.ts`). v8 still ships dual CJS/ESM.
- `mariadb` 3.4.5 → 3.5.3 in `packages/adapter-mariadb`. The advisories say "patched >= 3.4.6", but npm has no 3.4.6 — the 3.4.x line ends at 3.4.5; 3.5.3 is the current release satisfying the range.

Lockfile updated with the repo-pinned pnpm 11.13.1.

## Testing performed

- `pnpm audit --prod` against the updated lockfile: "No known vulnerabilities found".
- `pnpm --filter @prisma/config test`: 4 files, 142 passed, 2 skipped — includes the config-merge tests that exercise `deepmerge`.
- `pnpm --filter @prisma/adapter-mariadb test`: 45 passed.

## Notes for the reviewer

- After this merges, the Lint job on this branch should go fully green again (its other failure mode, prettier-check, is unaffected here).
- Related branch-health PRs: prisma/orm#30180 (rename guards), prisma/orm#30183 (corepack e2e test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MariaDB integration dependency to a newer version.
  * Updated the configuration merge dependency to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->