### PR TITLE
fix(schema-ir): match int8 decimal-text defaults against their safe-integer number

### DIFF
--- a/packages/2-sql/1-core/schema-ir/src/ir/resolved-default-equality.ts
+++ b/packages/2-sql/1-core/schema-ir/src/ir/resolved-default-equality.ts
@@ -5,12 +5,13 @@ import { canonicalStringify } from '@internal/utils/canonical-stringify';
  * Structural equality for two resolved column defaults, ported from the
  * relational walk's `columnDefaultsEqual` normalized branch: kinds must
  * match; literal values are normalized (Date and temporal-typed strings to
- * ISO instants) then compared canonically (JSON objects match their
- * canonical string form); function expressions compare case- and
+ * ISO instants, and a 64-bit-integer native type's safe-integer number to
+ * its decimal-text spelling) then compared canonically (JSON objects match
+ * their canonical string form); function expressions compare case- and
  * whitespace-insensitively.
  *
- * `nativeType` provides the temporal-normalization context (the actual
- * side's resolved native type in a diff comparison).
+ * `nativeType` provides the temporal- and int64-normalization context (the
+ * actual side's resolved native type in a diff comparison).
  */
 export function resolvedDefaultsEqual(
   expected: ColumnDefault,
@@ -43,6 +44,12 @@ function isTemporalNativeType(nativeType?: string): boolean {
   return normalized.includes('timestamp') || normalized === 'date';
 }
 
+function isInt64NativeType(nativeType?: string): boolean {
+  if (!nativeType) return false;
+  const normalized = nativeType.toLowerCase();
+  return normalized === 'int8' || normalized === 'bigint';
+}
+
 function normalizeLiteralValue(value: unknown, nativeType?: string): unknown {
   if (value instanceof Date) {
     return value.toISOString();
@@ -52,6 +59,9 @@ function normalizeLiteralValue(value: unknown, nativeType?: string): unknown {
     if (!Number.isNaN(parsed.getTime())) {
       return parsed.toISOString();
     }
+  }
+  if (typeof value === 'number' && Number.isSafeInteger(value) && isInt64NativeType(nativeType)) {
+    return String(value);
   }
   return value;
 }

--- a/packages/2-sql/1-core/schema-ir/test/resolved-default-equality.test.ts
+++ b/packages/2-sql/1-core/schema-ir/test/resolved-default-equality.test.ts
@@ -103,4 +103,48 @@ describe('resolvedDefaultsEqual', () => {
       );
     });
   });
+
+  describe('int64 literals', () => {
+    it('matches a safe-integer number against the decimal text it denotes, under int8', () => {
+      expect({
+        numberFirst: resolvedDefaultsEqual(literal(0), literal('0'), 'int8'),
+        textFirst: resolvedDefaultsEqual(literal('0'), literal(0), 'int8'),
+      }).toEqual({ numberFirst: true, textFirst: true });
+    });
+
+    it('matches a safe-integer number against the decimal text it denotes, under bigint', () => {
+      expect(resolvedDefaultsEqual(literal(42), literal('42'), 'bigint')).toBe(true);
+    });
+
+    it('matches a negative safe integer against its decimal text', () => {
+      expect(resolvedDefaultsEqual(literal(-7), literal('-7'), 'int8')).toBe(true);
+    });
+
+    it('fires when the decimal text denotes a different number', () => {
+      expect(resolvedDefaultsEqual(literal(1), literal('2'), 'int8')).toBe(false);
+    });
+
+    it('leaves a number against its decimal text alone without an int8/bigint native type', () => {
+      expect(resolvedDefaultsEqual(literal(0), literal('0'), 'int4')).toBe(false);
+      expect(resolvedDefaultsEqual(literal(0), literal('0'))).toBe(false);
+    });
+
+    it('declines to match a rounded number against the exact decimal text it lost', () => {
+      expect(
+        resolvedDefaultsEqual(literal('9007199254740993'), literal(9007199254740992), 'int8'),
+      ).toBe(false);
+    });
+
+    it('declines to match outside the safe-integer range, even when the text is exact', () => {
+      expect(resolvedDefaultsEqual(literal(1e17), literal('100000000000000000'), 'int8')).toBe(
+        false,
+      );
+    });
+
+    it('still compares two decimal-text strings by identity past the safe integer range', () => {
+      expect(
+        resolvedDefaultsEqual(literal('9007199254740993'), literal('9007199254740993'), 'int8'),
+      ).toBe(true);
+    });
+  });
 });

--- a/packages/3-targets/6-adapters/postgres/test/migrations/schema-verify.int8-literal-default.integration.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/migrations/schema-verify.int8-literal-default.integration.test.ts
@@ -1,0 +1,171 @@
+import { type Contract, coreHash, profileHash } from '@internal/contract/types';
+import { INIT_ADDITIVE_POLICY } from '@internal/family-sql/control';
+import { APP_SPACE_ID } from '@internal/framework-components/control';
+import { UNBOUND_NAMESPACE_ID } from '@internal/framework-components/ir';
+import { SqlStorage } from '@internal/sql-contract/types';
+import {
+  PostgresDatabaseSchemaNode,
+  postgresCreateNamespace,
+} from '@internal/target-postgres/types';
+import { applicationDomainOf } from '@repo/test-utils';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  controlAdapter,
+  createDriver,
+  createTestDatabase,
+  emptySchema,
+  familyInstance,
+  formatRunnerFailure,
+  frameworkComponents,
+  type PostgresControlDriver,
+  postgresTargetDescriptor,
+  resetDatabase,
+  synthEdges,
+  testTimeout,
+} from './fixtures/runner-fixtures';
+
+const PAST_SAFE_INTEGER_TEXT = '9007199254740993';
+
+function moneyContract(): Contract<SqlStorage> {
+  return {
+    target: 'postgres',
+    targetFamily: 'sql',
+    profileHash: profileHash('int8-literal-default'),
+    storage: new SqlStorage({
+      storageHash: coreHash('int8-literal-default'),
+      namespaces: {
+        [UNBOUND_NAMESPACE_ID]: postgresCreateNamespace({
+          id: UNBOUND_NAMESPACE_ID,
+          entries: {
+            table: {
+              ps: {
+                columns: {
+                  id: { nativeType: 'text', codecId: 'pg/text@1', nullable: false },
+                  v: {
+                    nativeType: 'int8',
+                    codecId: 'pg/int8number@1',
+                    nullable: false,
+                    default: { kind: 'literal', value: 0 },
+                  },
+                  w: {
+                    nativeType: 'int4',
+                    codecId: 'pg/int4@1',
+                    nullable: false,
+                    default: { kind: 'literal', value: 0 },
+                  },
+                  bigIntSmall: {
+                    nativeType: 'int8',
+                    codecId: 'pg/int8@1',
+                    nullable: false,
+                    default: { kind: 'literal', value: '0' },
+                  },
+                  bigIntPastSafeInteger: {
+                    nativeType: 'int8',
+                    codecId: 'pg/int8@1',
+                    nullable: false,
+                    default: { kind: 'literal', value: PAST_SAFE_INTEGER_TEXT },
+                  },
+                },
+                primaryKey: { columns: ['id'] },
+                uniques: [],
+                indexes: [],
+                foreignKeys: [],
+              },
+            },
+          },
+        }),
+      },
+    }),
+    roots: {},
+    domain: applicationDomainOf({ models: {} }),
+    capabilities: {},
+    extensions: {},
+    meta: {},
+  };
+}
+
+describe('Schema verification after runner - int8 literal default (issue #30174)', {
+  concurrent: false,
+}, () => {
+  let database: Awaited<ReturnType<typeof createTestDatabase>>;
+  let driver: PostgresControlDriver | undefined;
+
+  beforeAll(async () => {
+    database = await createTestDatabase();
+  }, testTimeout);
+
+  afterAll(async () => {
+    if (database) {
+      await database.close();
+    }
+  }, testTimeout);
+
+  beforeEach(async () => {
+    driver = await createDriver(database.connectionString);
+    await resetDatabase(driver);
+  }, testTimeout);
+
+  afterEach(async () => {
+    if (driver) {
+      await driver.close();
+      driver = undefined;
+    }
+  }, testTimeout);
+
+  it('applies and verifies literal defaults on int8 (BigIntNumber, BigInt) and int4 columns', {
+    timeout: testTimeout,
+  }, async () => {
+    const contract = moneyContract();
+    const planner = postgresTargetDescriptor.createPlanner(controlAdapter);
+    const runner = postgresTargetDescriptor.createRunner(familyInstance);
+
+    const planResult = planner.plan({
+      contract,
+      schema: emptySchema,
+      policy: INIT_ADDITIVE_POLICY,
+      fromContract: null,
+      frameworkComponents,
+      spaceId: APP_SPACE_ID,
+      snapshotsImportPath: '../../snapshots',
+    });
+    if (planResult.kind !== 'success') {
+      throw new Error(`Planner failed: ${planResult.kind}`);
+    }
+
+    const executeResult = await runner.execute({
+      driver: driver!,
+      perSpaceOptions: [
+        {
+          space: planResult.plan.spaceId ?? APP_SPACE_ID,
+          plan: planResult.plan,
+          migrationEdges: synthEdges(planResult.plan),
+          driver: driver!,
+          destinationContract: contract,
+          policy: INIT_ADDITIVE_POLICY,
+          frameworkComponents,
+        },
+      ],
+    });
+
+    if (!executeResult.ok) {
+      throw new Error(
+        `db migrate failed on its own post-apply verification:\n${formatRunnerFailure(executeResult.failure)}`,
+      );
+    }
+
+    const schema = await familyInstance.introspect({ driver: driver!, contract });
+    const verifyResult = familyInstance.verifySchema({
+      contract,
+      schema,
+      strict: false,
+      frameworkComponents,
+    });
+
+    expect(verifyResult.ok).toBe(true);
+    expect(verifyResult.schema.issues).toHaveLength(0);
+
+    PostgresDatabaseSchemaNode.assert(schema);
+    const column = schema.namespaces['public']?.tables['ps']?.columns['bigIntPastSafeInteger'];
+    expect(column?.resolvedDefault).toEqual({ kind: 'literal', value: PAST_SAFE_INTEGER_TEXT });
+  });
+});


### PR DESCRIPTION
## Summary

A literal `@default` on an `int8` column made `db migrate` fail its own post-apply verification with `MIGRATION.SCHEMA_VERIFY_FAILED`. An `int4` column with the same default verified fine.

Fixes #30174

## The true root cause

`parsePostgresDefault`'s `isBigInt` branch (`packages/3-targets/3-targets/postgres/src/core/default-normalizer.ts:225-228`) returns decimal text for *every* `int8` default, regardless of DDL spelling. So even a bare `DEFAULT 0` introspects back as `"0"` (string) against the contract's `0` (number) for `pg/int8number@1`. It is a string/number type asymmetry, not a syntax one.

Postgres does **not** re-derive a quoted cast for small `bigint` defaults: `bigint DEFAULT 0` comes back as `0` — bare within `int4` range, quoted+cast only beyond it. Verified on PostgreSQL 17.11 and PGlite 18.3, byte-identical:

```
bigint DEFAULT 0                              -> 0
bigint DEFAULT 9223372036854775807            -> '9223372036854775807'::bigint
```

The `'0'::int8` our own DDL renders is ours, not Postgres's: `pgRenderDdlColumnDefault` runs the value through `codec.encode`, `pgInt8NumberEncode` returns a string, and `pgInlineLiteral` quotes and casts any string wire.

## Why the fix cannot live on the render path or in `postgresResolveDefault`

`postgresResolveDefault`'s output becomes `resolvedDefault` (`packages/2-sql/9-family/src/core/migrations/contract-to-schema-ir.ts:127-129`), which `columnLike()` (`packages/3-targets/3-targets/postgres/src/core/migrations/column-ddl-rendering.ts:56`) maps into the `StorageColumn.default` slot that reaches `codec.decodeJson` (`packages/3-targets/6-adapters/postgres/src/core/control-adapter.ts:1770`). *"One differ drives both verify and plan"* (`packages/3-targets/3-targets/postgres/src/core/migrations/diff-database-schema.ts:214`).

The two codecs bound to the same `resolvedNativeType` are mutually incompatible: `PgInt8NumberCodec.decodeJson` requires a JSON number (`codecs.ts:723-725` — its own doc comment calls this "the deliberate exception to the decimal-text rule ... and the codec's purpose"), while `PgInt8Codec.decodeJson` requires a decimal string (`codecs.ts:660-668`). Introspection has no codec identity to consult, so it cannot pick a shape per column, and any normalization performed on the *shared* `resolvedDefault` before it reaches DDL rendering corrupts one codec or the other. Confirmed with three live-database probes:

```
PROBE A  int8number + decimal-TEXT resolvedDefault (proposed normalize-to-string fix) -> pg/int8number@1 must be a number
PROBE B  int8@1     + NUMBER       resolvedDefault (the inverse: normalize-to-number)  -> pg/int8@1 must be a decimal string
PROBE C  int8number + NUMBER       resolvedDefault (this PR's fix: unchanged)          -> ok, stage execute, no failure
```

## What the fix is

One spelling-gated branch in the module-private `normalizeLiteralValue` (`packages/2-sql/1-core/schema-ir/src/ir/resolved-default-equality.ts`), beside the existing temporal-normalization branch: a safe-integer number is compared against the decimal text it denotes, only under an `int8`/`bigint` native type. It **normalizes rather than widens**: `literalValuesEqual` is byte-for-byte unchanged, and `resolvedDefaultsEqual`'s signature is unchanged. The normalized value lives for the one comparison call and never reaches `resolvedDefault` or the DDL renderer, so it cannot corrupt the codec-typed value `pgRenderDdlColumnDefault` depends on.

## Soundness

`String(n)` is injective over safe integers, so no two distinct values collide. `pgInt8NumberGuard` (`packages/3-targets/3-targets/postgres/src/core/codec-helpers.ts:158-169`) already rejects everything outside `Number.isSafeInteger` at both encode and decode, so the gate this fix adds is exactly coextensive with the codec's own domain and can produce no reachable false negative.

## On the reporter's claim

He is right that `BigInt` and `BigIntNumber` produce byte-identical DDL. What's wrong is only the inference that the codec family causes it: `pg/int8@1` carries `"value": "0"` and round-trips text→text; `pg/int8number@1` carries `"value": 0` and is the sole reproducer.

## The layering residue, stated honestly

`int8` is a Postgres alias for the standard SQL `bigint`, and this shared SQL-core package now names it. `isTemporalNativeType` directly above already matches `timestamptz` the same way, and `bigint` itself is standard SQL accepted by MySQL/MSSQL/SQLite. The clean fix is a comparison-only target hook — see follow-up below.

## Testing

- `schema-ir`: 264 passed
- `family-sql` (`packages/2-sql/9-family`): 340 passed
- `adapter-postgres`: 867 passed, 3 expected-fail, 0 failed
- End-to-end on real PostgreSQL 17.11: applied and verified the reporter's model plus a `Number.MAX_SAFE_INTEGER`-adjacent `int8` default with no precision loss
- Unit coverage: the safe-integer match in both operand orders, a negative integer, a genuine mismatch, no effect without an `int8`/`bigint` native type, a rounded-number-vs-exact-text rejection, an outside-safe-integer-range rejection (even when the text is exact), and two huge decimal-text strings compared by identity

## Follow-ups (not opened as issues; not fixed in this PR)

- **Comparison-only normalization seam.** `DefaultResolver` (`packages/2-sql/9-family/src/core/migrations/contract-to-schema-ir.ts:62-71`) cannot carry this normalization because its output is dual-purpose (verify *and* plan/DDL). The proper home is a new comparison-only target hook alongside `DefaultResolver` / `NativeTypeExpander` / `DefaultRenderer`, so this equality file needs no `int8`/`bigint` spelling at all. That's an architecture change (Ask First) beyond this bug fix.
- **`int8`-family list-default crash.** `BigInt[] @default([1,2])` -> `CLI.UNEXPECTED: pg/int8@1 database JSON value must be a decimal string`; `BigIntNumber[] @default([1,2])` -> `... must be a number`. Cause: `pgRenderDdlColumnDefault` (`control-adapter.ts:1770`) hands the whole array to `codec.decodeJson` instead of decoding per element. Pre-existing, out of scope, and the same codec-shape constraint this fix navigates — the reporter's money model has 22 defaulted `int8` columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcqoY3CKfnubdZt5YQk2Rq
