### PR TITLE
fix(contract-psl): surface invalid UTF-8 schema read failures and exit non-zero (#30198)

### DIFF
--- a/packages/2-mongo-family/2-authoring/contract-psl/src/provider.ts
+++ b/packages/2-mongo-family/2-authoring/contract-psl/src/provider.ts
@@ -63,9 +63,10 @@ export function mongoContract(schemaPath: string, options?: MongoContractOptions
       }
       let schema: string;
       try {
-        schema = await readFile(absoluteSchemaPath, 'utf-8');
+        const rawBuffer = await readFile(absoluteSchemaPath);
+        schema = new TextDecoder('utf-8', { fatal: true }).decode(rawBuffer);
       } catch (error) {
-        const message = String(error);
+        const message = error instanceof Error ? error.message : String(error);
         return notOk({
           summary: `Failed to read Prisma schema at "${schemaPath}"`,
           diagnostics: [

--- a/packages/2-sql/2-authoring/contract-psl/src/provider.ts
+++ b/packages/2-sql/2-authoring/contract-psl/src/provider.ts
@@ -102,9 +102,10 @@ export function prismaContract(schemaPath: string, options: PrismaContractOption
       }
       let schema: string;
       try {
-        schema = await readFile(absoluteSchemaPath, 'utf-8');
+        const rawBuffer = await readFile(absoluteSchemaPath);
+        schema = new TextDecoder('utf-8', { fatal: true }).decode(rawBuffer);
       } catch (error) {
-        const message = String(error);
+        const message = error instanceof Error ? error.message : String(error);
         return notOk({
           summary: `Failed to read Prisma schema at "${schemaPath}"`,
           diagnostics: [

--- a/packages/2-sql/2-authoring/contract-psl/test/provider.test.ts
+++ b/packages/2-sql/2-authoring/contract-psl/test/provider.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { applySpecifierDefaultControlPolicy } from '@internal/contract/apply-specifier-default-control-policy';
@@ -448,6 +449,38 @@ model Other {
       const codes = result.failure.diagnostics.map((d) => d.code);
       expect(codes).toContain('PSL_DUPLICATE_DECLARATION');
       expect(codes).toContain('PSL_UNSUPPORTED_FIELD_TYPE');
+    });
+
+    it('returns PSL_SCHEMA_READ_FAILED diagnostic when schema file contains invalid UTF-8 bytes', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'psl-provider-utf8-'));
+      tempDirs.push(tempDir);
+      const schemaPath = join(tempDir, 'schema.prisma');
+      await writeFile(
+        schemaPath,
+        Buffer.concat([
+          Buffer.from('model User {\n  id Int @id // comment with invalid byte: ', 'utf-8'),
+          Buffer.from([0x97]),
+          Buffer.from('\n}\n', 'utf-8'),
+        ]),
+      );
+
+      process.chdir(tempDir);
+      const contract = prismaContract('./schema.prisma', baseOptions);
+      const result = await contract.source.load(
+        createPostgresTestContext({ resolvedInputs: [schemaPath] }),
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.summary).toBe('Failed to read Prisma schema at "./schema.prisma"');
+      expect(result.failure.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'PSL_SCHEMA_READ_FAILED',
+            sourceId: './schema.prisma',
+          }),
+        ]),
+      );
     });
   });
 

--- a/test/integration/test/cli-journeys/invalid-utf8-schema.e2e.test.ts
+++ b/test/integration/test/cli-journeys/invalid-utf8-schema.e2e.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Invalid UTF-8 Schema Handling (Issue #30198)
+ *
+ * Verifies that contract emit fails with a non-zero exit code and explicit error
+ * diagnostics when contract.prisma contains invalid UTF-8 byte sequences (such as a
+ * lone Windows-1252 0x97 em-dash byte).
+ */
+
+import { Buffer } from 'node:buffer';
+import { writeFileSync } from 'node:fs';
+import { join } from 'pathe';
+import { describe, expect, it } from 'vitest';
+import { withTempDir } from '../utils/cli-test-helpers';
+import { runContractEmit, setupJourney, timeouts } from '../utils/journey-test-helpers';
+
+withTempDir(({ createTempDir }) => {
+  describe('Issue #30198: Invalid UTF-8 Schema Handling', () => {
+    it(
+      'fails with exit code 1 and outputs error when schema contains non-UTF-8 bytes',
+      async () => {
+        const ctx = setupJourney({ createTempDir, contractMode: 'psl' });
+
+        const schemaPath = join(ctx.testDir, 'contract.prisma');
+        const invalidSchemaContent = Buffer.concat([
+          Buffer.from('model User {\n  id Int @id // comment with CP-1252 em-dash: ', 'utf-8'),
+          Buffer.from([0x97]),
+          Buffer.from('\n}\n', 'utf-8'),
+        ]);
+        writeFileSync(schemaPath, invalidSchemaContent);
+
+        const result = await runContractEmit(ctx, ['--json']);
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stderr).toMatch(/PSL_SCHEMA_READ_FAILED|invalid UTF-8|Failed to decode/i);
+      },
+      timeouts.typeScriptCompilation,
+    );
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #30198

## Summary

When `schema.prisma` contains non-UTF-8 byte sequences (such as a lone Windows-1252 `0x97` byte), Node's default `readFile(path, 'utf-8')` performs lossy byte replacement (`U+FFFD`), causing JS/TS PSL parsers to treat the schema as valid while the Rust engine panics and CLI execution exits with code `0`.

This PR:
1. Replaces lossy `readFile(path, 'utf-8')` decoding in SQL and Mongo PSL contract providers ([provider.ts (SQL)](file:///media/karim/New%20Volume16/rust/orm/packages/2-sql/2-authoring/contract-psl/src/provider.ts) and [provider.ts (Mongo)](file:///media/karim/New%20Volume16/rust/orm/packages/2-mongo-family/2-authoring/contract-psl/src/provider.ts)) with strict `new TextDecoder('utf-8', { fatal: true }).decode(rawBuffer)`.
2. Returns a structured `PSL_SCHEMA_READ_FAILED` diagnostic on invalid UTF-8 byte sequences, causing CLI command execution to abort with exit code `1` and surface explicit stderr diagnostics instead of exiting `0`.
3. Adds unit coverage in `provider.test.ts` and a dedicated E2E Journey test in `invalid-utf8-schema.e2e.test.ts`.

## Testing Performed

- Added unit test in `packages/2-sql/2-authoring/contract-psl/test/provider.test.ts` asserting that non-UTF-8 byte sequences return `PSL_SCHEMA_READ_FAILED`.
- Added E2E Journey test in `test/integration/test/cli-journeys/invalid-utf8-schema.e2e.test.ts` asserting that contract emit against a non-UTF-8 schema exits with code `1` and outputs stderr diagnostics.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] Code adheres to repository layering and domain rules (`architecture.config.json`).
- [x] Unit and E2E Journey tests added for invalid UTF-8 schemas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Contract schema loading now detects malformed UTF-8 data and reports a schema-read failure.
  - Schema-loading errors now provide clearer diagnostic messages while preserving the relevant file location and details.
  - Contract emission now correctly returns a failure status and reports the diagnostic when a schema contains invalid UTF-8 bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->