### PR TITLE
fix(postgres): accept DSNs missing user/host for local dev

### DIFF
--- a/packages/3-extensions/postgres/src/runtime/binding.ts
+++ b/packages/3-extensions/postgres/src/runtime/binding.ts
@@ -1,6 +1,7 @@
 import { InternalError } from '@internal/utils/internal-error';
 import type { Client, Pool } from 'pg';
 import { postgresError } from '../errors';
+import { userInfo } from 'node:os';
 
 export const isPgPool = (pg: Pool | Client): pg is Pool =>
   'totalCount' in pg && 'idleCount' in pg && 'waitingCount' in pg;
@@ -36,6 +37,43 @@ type PostgresBindingFields = {
   readonly pg?: Pool | Client;
 };
 
+function normalizePostgresUrlIfNeeded(trimmed: string): string {
+  // Fast-path: nothing to do if nothing missing
+  try {
+    const parsed = new URL(trimmed);
+    let changed = false;
+
+    // If username is not present in the URL *and* the original string did not
+    // include an explicit userinfo (`@`), default to the OS username. This
+    // mirrors libpq/psql behaviour where an omitted user falls back to the
+    // current user. We avoid overriding an explicitly empty user (`postgresql://@host/...`).
+    if (!parsed.username && !trimmed.includes('@')) {
+      try {
+        const defaultUser = userInfo().username;
+        if (defaultUser) {
+          parsed.username = defaultUser;
+          changed = true;
+        }
+      } catch {
+        // If userInfo fails for any reason, skip defaulting the username.
+      }
+    }
+
+    // If no hostname is provided, fall back to localhost so node-postgres
+    // connects over TCP to the local server (common local-dev setup).
+    // This also prevents printing `undefined` for the host in diagnostics.
+    if (!parsed.hostname) {
+      parsed.hostname = 'localhost';
+      changed = true;
+    }
+
+    return changed ? parsed.toString() : trimmed;
+  } catch {
+    // If parsing fails here, let the caller handle the parse error path.
+    return trimmed;
+  }
+}
+
 function validatePostgresUrl(url: string): string {
   const trimmed = url.trim();
   if (trimmed.length === 0) {
@@ -61,7 +99,9 @@ function validatePostgresUrl(url: string): string {
     );
   }
 
-  return trimmed;
+  // Normalize missing user/host to sensible defaults so `postgresql:///db`
+  // and `postgresql://localhost/db` behave like libpq/psql on local dev.
+  return normalizePostgresUrlIfNeeded(trimmed);
 }
 
 export function resolvePostgresBinding(options: PostgresBindingInput): PostgresBinding {

--- a/packages/3-extensions/postgres/src/runtime/binding.ts
+++ b/packages/3-extensions/postgres/src/runtime/binding.ts
@@ -47,7 +47,13 @@ function normalizePostgresUrlIfNeeded(trimmed: string): string {
     // include an explicit userinfo (`@`), default to the OS username. This
     // mirrors libpq/psql behaviour where an omitted user falls back to the
     // current user. We avoid overriding an explicitly empty user (`postgresql://@host/...`).
-    if (!parsed.username && !trimmed.includes('@')) {
+    const authorityStart = trimmed.indexOf('//') + 2;
+    const authorityTail = trimmed.slice(authorityStart);
+    const authorityEnd = authorityTail.search(/[/?#]/);
+    const authority =
+      authorityEnd === -1 ? authorityTail : authorityTail.slice(0, authorityEnd);
+
+    if (!parsed.username && !authority.includes('@')) {
       try {
         const defaultUser = userInfo().username;
         if (defaultUser) {


### PR DESCRIPTION
This change normalizes Postgres connection URLs that omit the username or hostname so that local development connection strings like `postgresql:///mydb` behave like libpq/psql and other ORMs. If the DSN omits the userinfo entirely, we default to the OS username; if the hostname is missing, we default to `localhost`.

- Normalize missing username to OS user when original DSN did not include `@`.
- Normalize missing hostname to `localhost`.
- Preserve parsing and validation errors as before.

This fixes issue #8230 where Prisma reported `Datasource "db": PostgreSQL database "mydb"... at "undefined:5432"` and Postgres received an empty username.

/claim #8230

Closes #8230

/claim #8230

_Enviado por un agente Monexa; revisión humana: sí._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL connection URLs now automatically fill in a missing username using the current system user.
  * URLs with an empty hostname now default to `localhost`.
  * Username detection now correctly handles `@` characters in paths, queries, and fragments.
  * Invalid URLs or unavailable system user information continue to be handled gracefully without preventing connections from using the original URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->