### PR TITLE
test: add coverage for StorageTable.is and StorageTable.assert

### DIFF
--- a/packages/2-sql/1-core/contract/test/storage-table.test.ts
+++ b/packages/2-sql/1-core/contract/test/storage-table.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { StorageTable } from '../src/ir/storage-table';
+
+function makeValidTable(): StorageTable {
+  return new StorageTable({
+    columns: {
+      id: { codecId: 'pg/int4@1', nativeType: 'int4', nullable: false },
+    },
+    uniques: [],
+    indexes: [],
+    foreignKeys: [],
+  });
+}
+
+describe('StorageTable.is', () => {
+  it('returns true for a real StorageTable instance', () => {
+    expect(StorageTable.is(makeValidTable())).toBe(true);
+  });
+
+  it('returns true for a duck-typed plain object with all required keys', () => {
+    const ducked = {
+      columns: {},
+      uniques: [],
+      indexes: [],
+      foreignKeys: [],
+    } as unknown as StorageTable;
+    expect(StorageTable.is(ducked)).toBe(true);
+  });
+
+  it('returns false for undefined', () => {
+    expect(StorageTable.is(undefined)).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(StorageTable.is(null as unknown as StorageTable)).toBe(false);
+  });
+
+  it('returns false for a non-object primitive', () => {
+    expect(StorageTable.is('not-a-table' as unknown as StorageTable)).toBe(false);
+  });
+
+  it('returns false when columns is missing', () => {
+    const missingColumns = {
+      uniques: [],
+      indexes: [],
+      foreignKeys: [],
+    } as unknown as StorageTable;
+    expect(StorageTable.is(missingColumns)).toBe(false);
+  });
+
+  it('returns false when uniques is missing', () => {
+    const missingUniques = {
+      columns: {},
+      indexes: [],
+      foreignKeys: [],
+    } as unknown as StorageTable;
+    expect(StorageTable.is(missingUniques)).toBe(false);
+  });
+
+  it('returns false when indexes is missing', () => {
+    const missingIndexes = {
+      columns: {},
+      uniques: [],
+      foreignKeys: [],
+    } as unknown as StorageTable;
+    expect(StorageTable.is(missingIndexes)).toBe(false);
+  });
+
+  it('returns false when foreignKeys is missing', () => {
+    const missingForeignKeys = {
+      columns: {},
+      uniques: [],
+      indexes: [],
+    } as unknown as StorageTable;
+    expect(StorageTable.is(missingForeignKeys)).toBe(false);
+  });
+});
+
+describe('StorageTable.assert', () => {
+  it('does not throw for a real StorageTable instance', () => {
+    expect(() => StorageTable.assert(makeValidTable(), 'test.coordinate')).not.toThrow();
+  });
+
+  it('throws InternalError naming the coordinate when the value is not a StorageTable', () => {
+    expect(() => StorageTable.assert(undefined, 'namespaces.public.table.users')).toThrow(
+      /Expected a StorageTable at namespaces\.public\.table\.users/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds test coverage for the `StorageTable.is` runtime type guard and `StorageTable.assert` assertion helper in `packages/2-sql/1-core/contract/src/ir/storage-table.ts`.

- `storage-table.ts`: 100% statements/branches/functions/lines (up from 72%/44%/100%/75%)

Related to the M9 target-extensible-IR coverage gap noted in `coverage.config.json` (TML-2521).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for storage table type validation.
  - Verified acceptance of valid instances and compatible objects.
  - Added checks for invalid values, including null, undefined, primitive values, and objects missing required properties.
  - Confirmed validation errors identify the relevant location and use the expected error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->