### PR TITLE
fix(sql-contract-ts): anchor inverse relations on the owning belongsTo's referenced field

### DIFF
--- a/packages/2-sql/2-authoring/contract-ts/src/contract-lowering.ts
+++ b/packages/2-sql/2-authoring/contract-ts/src/contract-lowering.ts
@@ -476,6 +476,32 @@ function lowerBelongsToRelation(
   };
 }
 
+function resolveOwningRelationAnchorFields(
+  targetSpec: RuntimeModelSpec,
+  currentModelName: string,
+  childFields: readonly string[],
+): readonly string[] | undefined {
+  for (const relationBuilder of Object.values(targetSpec.relations)) {
+    const owningRelation = relationBuilder.build();
+    if (owningRelation.kind !== 'belongsTo') {
+      continue;
+    }
+    if (resolveRelationModelName(owningRelation.toModel) !== currentModelName) {
+      continue;
+    }
+
+    const owningFromFields = normalizeRelationFieldNames(owningRelation.from);
+    if (
+      owningFromFields.length === childFields.length &&
+      owningFromFields.every((fieldName, index) => fieldName === childFields[index])
+    ) {
+      return normalizeRelationFieldNames(owningRelation.to);
+    }
+  }
+
+  return undefined;
+}
+
 function lowerHasOwnershipRelation(
   relationName: string,
   relation: Extract<RelationState, { kind: 'hasMany' | 'hasOne' }>,
@@ -492,8 +518,10 @@ function lowerHasOwnershipRelation(
     );
   }
 
-  const parentFields = resolveRelationAnchorFields(currentSpec);
   const childFields = normalizeRelationFieldNames(relation.by);
+  const parentFields =
+    resolveOwningRelationAnchorFields(targetSpec, currentSpec.modelName, childFields) ??
+    resolveRelationAnchorFields(currentSpec);
   assertRelationFieldArity({
     modelName: currentSpec.modelName,
     relationName,

--- a/packages/2-sql/2-authoring/contract-ts/src/contract-lowering.ts
+++ b/packages/2-sql/2-authoring/contract-ts/src/contract-lowering.ts
@@ -481,6 +481,8 @@ function resolveOwningRelationAnchorFields(
   currentModelName: string,
   childFields: readonly string[],
 ): readonly string[] | undefined {
+  const matchedAnchorFields: (readonly string[])[] = [];
+
   for (const relationBuilder of Object.values(targetSpec.relations)) {
     const owningRelation = relationBuilder.build();
     if (owningRelation.kind !== 'belongsTo') {
@@ -495,11 +497,41 @@ function resolveOwningRelationAnchorFields(
       owningFromFields.length === childFields.length &&
       owningFromFields.every((fieldName, index) => fieldName === childFields[index])
     ) {
-      return normalizeRelationFieldNames(owningRelation.to);
+      matchedAnchorFields.push(normalizeRelationFieldNames(owningRelation.to));
     }
   }
 
-  return undefined;
+  if (matchedAnchorFields.length === 0) {
+    return undefined;
+  }
+
+  const firstAnchorFields = matchedAnchorFields[0];
+  if (!firstAnchorFields) {
+    throw new InternalError('resolveOwningRelationAnchorFields: unreachable empty match array');
+  }
+  const restAnchorFields = matchedAnchorFields.slice(1);
+  const anchorFieldsAgree = restAnchorFields.every(
+    (anchorFields) =>
+      anchorFields.length === firstAnchorFields.length &&
+      anchorFields.every((fieldName, index) => fieldName === firstAnchorFields[index]),
+  );
+
+  if (!anchorFieldsAgree) {
+    throw contractError(
+      'CONTRACT.RELATION_INVALID',
+      `Model "${targetSpec.modelName}" has multiple belongsTo relations to "${currentModelName}" with matching from-fields [${childFields.join(', ')}] that disagree on their target fields.`,
+      {
+        meta: {
+          modelName: targetSpec.modelName,
+          targetModel: currentModelName,
+          childFields,
+          reason: 'ambiguous-owning-relation-anchor',
+        },
+      },
+    );
+  }
+
+  return firstAnchorFields;
 }
 
 function lowerHasOwnershipRelation(

--- a/packages/2-sql/2-authoring/contract-ts/test/contract-lowering.runtime.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/contract-lowering.runtime.test.ts
@@ -297,6 +297,38 @@ describe('contract definition lowering runtime checks', () => {
     ]);
   });
 
+  it('throws CONTRACT.RELATION_INVALID when multiple owning belongsTo relations with the same from-fields disagree on their target fields', () => {
+    const Child = model('Child', {
+      fields: {
+        id: field.column(int4Column).id(),
+        ownerKey: field.column(int4Column),
+      },
+      relations: {
+        ownerByExternalKey: rel.belongsTo('Parent', { from: 'ownerKey', to: 'externalKey' }),
+        ownerById: rel.belongsTo('Parent', { from: 'ownerKey', to: 'id' }),
+      },
+    });
+
+    const Parent = model('Parent', {
+      fields: {
+        id: field.column(int4Column).id(),
+        externalKey: field.column(int4Column).unique(),
+      },
+      relations: {
+        child: rel.hasOne(Child, { by: 'ownerKey' }),
+      },
+    });
+
+    expect(() =>
+      buildDefinition({
+        models: {
+          Parent,
+          Child,
+        },
+      }),
+    ).toThrow(expect.objectContaining({ code: 'CONTRACT.RELATION_INVALID' }));
+  });
+
   it('rejects non-owning relations when no anchor identity is available', () => {
     const Post = model('Post', {
       fields: {

--- a/packages/2-sql/2-authoring/contract-ts/test/contract-lowering.runtime.test.ts
+++ b/packages/2-sql/2-authoring/contract-ts/test/contract-lowering.runtime.test.ts
@@ -253,6 +253,50 @@ describe('contract definition lowering runtime checks', () => {
     ]);
   });
 
+  it('anchors the inverse relation on the referenced field of the owning belongsTo', () => {
+    const Child = model('Child', {
+      fields: {
+        id: field.column(int4Column).id(),
+        ownerKey: field.column(int4Column),
+      },
+      relations: {
+        owner: rel.belongsTo('Parent', { from: 'ownerKey', to: 'externalKey' }),
+      },
+    });
+
+    const Parent = model('Parent', {
+      fields: {
+        id: field.column(int4Column).id(),
+        externalKey: field.column(int4Column).unique(),
+      },
+      relations: {
+        child: rel.hasOne(Child, { by: 'ownerKey' }),
+      },
+    });
+
+    const definition = buildDefinition({
+      models: {
+        Parent,
+        Child,
+      },
+    });
+
+    expect(definition.models[0]?.relations).toEqual([
+      {
+        fieldName: 'child',
+        toModel: 'Child',
+        toTable: 'Child',
+        cardinality: '1:1',
+        on: {
+          parentTable: 'Parent',
+          parentColumns: ['externalKey'],
+          childTable: 'Child',
+          childColumns: ['ownerKey'],
+        },
+      },
+    ]);
+  });
+
   it('rejects non-owning relations when no anchor identity is available', () => {
     const Post = model('Post', {
       fields: {


### PR DESCRIPTION
## Linked issue

Fixes #30214

## Summary

`hasOne`/`hasMany` relations anchored their parent side on the model's primary identity no matter what the owning `belongsTo` on the child actually referenced. When a parent has both an `id` and a separate unique field that a child's `belongsTo` joins against, the contract builder still emitted the inverse relation's join against `id`, so the inverse side pointed at the wrong column whenever the two values differ for a row.

The fix looks up the owning `belongsTo` relation on the target model that matches the `hasOne`/`hasMany`'s local field(s) and reuses its referenced field(s) as the anchor, falling back to the primary identity only when no such relation exists.

## Testing performed

- `pnpm --filter @internal/sql-contract-ts test`
- `pnpm --filter @internal/sql-contract-ts typecheck`
- `pnpm lint:deps`

## Skill update

n/a - internal only, no user-facing surface changed.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] Skill update section above is filled in.

## Notes for the reviewer

Used a conventional commit title (`fix(sql-contract-ts): ...`) rather than a `TML-NNNN:` prefix since there is no Linear ticket behind this, per the external-contributor convention in CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed relation handling so inverse `hasOne` relationships use the corresponding parent-side reference field when available.
  - Improved normalization of child relationship fields before resolving parent anchors.
  - Added validation to report an error when owning relationships specify conflicting reference fields.

- **Tests**
  - Added coverage verifying correct parent-side anchor selection for inverse relationships.
  - Added coverage for conflicting relationship reference fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->