### PR TITLE
fix(postgres-adapter): keep table alias on UPDATE and DELETE

### DIFF
--- a/packages/2-sql/4-lanes/sql-builder/src/runtime/mutation-impl.ts
+++ b/packages/2-sql/4-lanes/sql-builder/src/runtime/mutation-impl.ts
@@ -287,6 +287,10 @@ export class InsertQueryImpl<
   }
 }
 
+function returningTableRef(tableSource: TableSource, tableName: string): string {
+  return tableSource.alias ?? tableName;
+}
+
 export class UpdateQueryImpl<
     QC extends QueryContext = QueryContext,
     AvailableScope extends Scope = Scope,
@@ -397,7 +401,11 @@ export class UpdateQueryImpl<
 
     if (this.#returningColumns.length > 0) {
       ast = ast.withReturning(
-        buildReturningProjections(this.#tableName, this.#returningColumns, this.#rowFields),
+        buildReturningProjections(
+          returningTableRef(this.#tableSource, this.#tableName),
+          this.#returningColumns,
+          this.#rowFields,
+        ),
       );
     }
 
@@ -513,7 +521,11 @@ export class DeleteQueryImpl<
 
     if (this.#returningColumns.length > 0) {
       ast = ast.withReturning(
-        buildReturningProjections(this.#tableName, this.#returningColumns, this.#rowFields),
+        buildReturningProjections(
+          returningTableRef(this.#tableSource, this.#tableName),
+          this.#returningColumns,
+          this.#rowFields,
+        ),
       );
     }
 

--- a/packages/2-sql/4-lanes/sql-builder/test/runtime/builders.test.ts
+++ b/packages/2-sql/4-lanes/sql-builder/test/runtime/builders.test.ts
@@ -671,3 +671,28 @@ describe('UPDATE callback overload', () => {
     expect(callbackAst.returning).toEqual(objectAst.returning);
   });
 });
+
+describe('aliased UPDATE and DELETE returning', () => {
+  it('update returning references the alias, not the table name', () => {
+    const plan = db()
+      .public.users.as('u')
+      .update({ name: 'x' })
+      .where((f, fns) => fns.eq(f.id, 42))
+      .returning('id')
+      .build();
+    const ast = plan.ast;
+    if (ast.kind !== 'update') throw new Error('expected update');
+    const projection = ast.returning?.[0];
+    if (!projection) throw new Error('expected returning projection');
+    expect((projection.expr as ColumnRef).table).toBe('u');
+  });
+
+  it('delete returning references the alias, not the table name', () => {
+    const plan = db().public.users.as('u').delete().returning('id').build();
+    const ast = plan.ast;
+    if (ast.kind !== 'delete') throw new Error('expected delete');
+    const projection = ast.returning?.[0];
+    if (!projection) throw new Error('expected returning projection');
+    expect((projection.expr as ColumnRef).table).toBe('u');
+  });
+});

--- a/packages/3-targets/6-adapters/postgres/src/core/sql-renderer.ts
+++ b/packages/3-targets/6-adapters/postgres/src/core/sql-renderer.ts
@@ -1109,7 +1109,7 @@ function renderInsert(ast: InsertAst, contract: PostgresContract, pim: ParamInde
 }
 
 function renderUpdate(ast: UpdateAst, contract: PostgresContract, pim: ParamIndexMap): string {
-  const table = qualifyTableFromNamespaceCoordinate(ast.table, contract);
+  const table = renderTableSource(ast.table, contract);
   const setEntries = Object.entries(ast.set);
   if (setEntries.length === 0) {
     throw adapterError('RUNTIME.AST_INVALID', 'UPDATE requires at least one SET assignment', {
@@ -1130,7 +1130,7 @@ function renderUpdate(ast: UpdateAst, contract: PostgresContract, pim: ParamInde
 }
 
 function renderDelete(ast: DeleteAst, contract: PostgresContract, pim: ParamIndexMap): string {
-  const table = qualifyTableFromNamespaceCoordinate(ast.table, contract);
+  const table = renderTableSource(ast.table, contract);
   const whereClause = ast.where ? ` WHERE ${renderWhere(ast.where, contract, pim)}` : '';
   const returningClause = ast.returning?.length
     ? ` RETURNING ${renderReturning(ast.returning, contract, pim)}`

--- a/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
@@ -422,6 +422,33 @@ describe('Postgres adapter', () => {
     expect(sql).toContain('FROM "user" AS "u"');
   });
 
+  it('renders UPDATE and DELETE table aliases', () => {
+    const updateAst = UpdateAst.table(TableSource.named('post', 'p'))
+      .withSet({
+        title: ParamRef.of('alias', { name: 'title', codec: { codecId: 'pg/text@1' } }),
+      })
+      .withWhere(
+        BinaryExpr.eq(
+          ColumnRef.of('p', 'id'),
+          ParamRef.of('base', { name: 'id', codec: { codecId: 'pg/int4@1' } }),
+        ),
+      )
+      .withReturning([ProjectionItem.of('id', ColumnRef.of('p', 'id'))]);
+    const deleteAst = DeleteAst.from(TableSource.named('post', 'p')).withWhere(
+      BinaryExpr.eq(
+        ColumnRef.of('p', 'id'),
+        ParamRef.of('base', { name: 'id', codec: { codecId: 'pg/int4@1' } }),
+      ),
+    );
+
+    expect(adapter.lower(updateAst, { contract }).sql).toBe(
+      'UPDATE "post" AS "p" SET "title" = $1 WHERE "p"."id" = $2 RETURNING "p"."id"',
+    );
+    expect(adapter.lower(deleteAst, { contract }).sql).toBe(
+      'DELETE FROM "post" AS "p" WHERE "p"."id" = $1',
+    );
+  });
+
   it.each([
     {
       name: 'without arguments or alias',

--- a/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
+++ b/packages/3-targets/6-adapters/postgres/test/adapter.test.ts
@@ -425,27 +425,29 @@ describe('Postgres adapter', () => {
   it('renders UPDATE and DELETE table aliases', () => {
     const updateAst = UpdateAst.table(TableSource.named('post', 'p'))
       .withSet({
-        title: ParamRef.of('alias', { name: 'title', codec: { codecId: 'pg/text@1' } }),
+        title: ParamRef.of('hello', { name: 'title', codec: { codecId: 'pg/text@1' } }),
       })
       .withWhere(
         BinaryExpr.eq(
           ColumnRef.of('p', 'id'),
-          ParamRef.of('base', { name: 'id', codec: { codecId: 'pg/int4@1' } }),
+          ParamRef.of(1, { name: 'id', codec: { codecId: 'pg/int4@1' } }),
         ),
       )
       .withReturning([ProjectionItem.of('id', ColumnRef.of('p', 'id'))]);
-    const deleteAst = DeleteAst.from(TableSource.named('post', 'p')).withWhere(
-      BinaryExpr.eq(
-        ColumnRef.of('p', 'id'),
-        ParamRef.of('base', { name: 'id', codec: { codecId: 'pg/int4@1' } }),
-      ),
-    );
+    const deleteAst = DeleteAst.from(TableSource.named('post', 'p'))
+      .withWhere(
+        BinaryExpr.eq(
+          ColumnRef.of('p', 'id'),
+          ParamRef.of(1, { name: 'id', codec: { codecId: 'pg/int4@1' } }),
+        ),
+      )
+      .withReturning([ProjectionItem.of('id', ColumnRef.of('p', 'id'))]);
 
     expect(adapter.lower(updateAst, { contract }).sql).toBe(
       'UPDATE "post" AS "p" SET "title" = $1 WHERE "p"."id" = $2 RETURNING "p"."id"',
     );
     expect(adapter.lower(deleteAst, { contract }).sql).toBe(
-      'DELETE FROM "post" AS "p" WHERE "p"."id" = $1',
+      'DELETE FROM "post" AS "p" WHERE "p"."id" = $1 RETURNING "p"."id"',
     );
   });
 


### PR DESCRIPTION
## Linked issue

Fixes #30211

## Summary

The Postgres renderer qualified an UPDATE/DELETE target through `qualifyTableFromNamespaceCoordinate` directly, which only resolves the bare table name and ignores `TableSource.alias`. SELECT already went through `renderTableSource`, which appends `AS alias` when present, so an aliased UPDATE or DELETE rendered a WHERE/RETURNING clause referencing the alias against a FROM target that never declared it, and Postgres rejected the statement. Both statements now render through `renderTableSource` so the target keeps its alias.

**Follow-up (self-review):** the renderer-level fix alone didn't cover the query builder path. `UpdateQueryImpl`/`DeleteQueryImpl` in `sql-builder` always built their `RETURNING` projection from the table's physical name, not from `TableSource.alias`. An aliased `UPDATE`/`DELETE` built via `.as('p').update(...).returning(...)` (not just the raw-AST path from the issue's repro) still produced `RETURNING "table"."col"` against a `FROM "table" AS "p"` target — the same class of Postgres error. Added a small `returningTableRef()` helper so `RETURNING` prefers the alias when present, with regression tests in `builders.test.ts` (verified fail-then-pass). `INSERT` was left unchanged in both passes: it never renders a target alias (its `ON CONFLICT ... excluded` semantics don't need one), so there was nothing for its `RETURNING` to get wrong.

## Testing performed

- `pnpm --filter @internal/adapter-postgres test` (added a case asserting `UPDATE "post" AS "p" ...` and `DELETE FROM "post" AS "p" ...` with realistic literals and `RETURNING` on both statements; fails against the pre-fix code with the alias silently dropped, passes after)
- `pnpm --filter @internal/sql-builder test` (added builder-level regression tests asserting `RETURNING` projections use the alias, not the table name, for both UPDATE and DELETE; verified fail-then-pass)
- `pnpm test:packages` (full suite): 15715 passed, 3 expected fail, 3 skipped; one unrelated `pnpm pack`/module-identity environment flake, reproduced identically on pristine main
- `pnpm typecheck && pnpm lint`

## Skill update

n/a — internal only

## Checklist

- [x] All commits are signed off (`git commit -s`)
- [x] Read CONTRIBUTING.md; scoped to one logical concern
- [x] Tests are updated
- [x] PR title is in conventional-commit form
- [x] Skill update section filled in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - PostgreSQL `UPDATE` and `DELETE` statements now correctly preserve explicit table aliases in generated SQL.
  - `RETURNING` clauses now reference the correct table alias when one is provided.

- **Tests**
  - Added coverage for aliased `UPDATE` and `DELETE` statements, including `RETURNING` clauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->