### PR TITLE
fix(sql-orm-client): createAndCount returns affected rows

### DIFF
--- a/packages/3-extensions/sql-orm-client/src/collection.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection.ts
@@ -1683,18 +1683,20 @@ class CollectionImpl<
         this.tableName,
         mappedRows,
       ).map((plan) => mergeAnnotations(plan, annotationsMap));
+      let affectedRows = 0;
       for (const plan of plans) {
-        await this.ctx.runtime.execute(plan);
+        const stats = await this.ctx.runtime.execute(plan);
+        affectedRows += stats.affectedRows;
       }
-      return data.length;
+      return affectedRows;
     }
 
     const compiled = mergeAnnotations(
       compileInsertCount(this.contract, this.namespaceId, this.tableName, mappedRows),
       annotationsMap,
     );
-    await this.ctx.runtime.execute(compiled);
-    return data.length;
+    const stats = await this.ctx.runtime.execute(compiled);
+    return stats.affectedRows;
   }
 
   /**

--- a/packages/3-extensions/sql-orm-client/test/collection.state.test.ts
+++ b/packages/3-extensions/sql-orm-client/test/collection.state.test.ts
@@ -323,6 +323,15 @@ describe('Collection', () => {
       await expect(collection.createAndCount([])).resolves.toBe(0);
     });
 
+    it('createAndCount() returns the executor affected-row count, not the input length', async () => {
+      const { collection, runtime } = createCollection();
+      runtime.setNextStats([{ affectedRows: 0 }]);
+
+      await expect(
+        collection.createAndCount([{ id: 1, name: 'Alice', email: 'alice@example.com' }]),
+      ).resolves.toBe(0);
+    });
+
     it('create() nested mutation throws when reload by primary key returns no row', async () => {
       const { collection, runtime } = createReturningCollectionFor('User');
       runtime.setNextResults([
@@ -368,7 +377,7 @@ describe('Collection', () => {
 
     it('createAndCount() uses split insert when defaultInInsert is absent', async () => {
       const { collection, runtime } = createReturningCollectionWithoutDefaultInInsert('User');
-      runtime.setNextResults([[], []]);
+      runtime.setNextStats([{ affectedRows: 1 }, { affectedRows: 1 }]);
 
       const count = await collection.createAndCount([
         { id: 1, name: 'Alice', email: 'alice@example.com' },

--- a/packages/3-extensions/sql-orm-client/test/orm-namespace-crud.test.ts
+++ b/packages/3-extensions/sql-orm-client/test/orm-namespace-crud.test.ts
@@ -116,10 +116,12 @@ describe('namespaced orm CRUD execution', () => {
 
   it('inserts within the namespace target table', async () => {
     const { db, runtime } = setup();
+    runtime.setNextStats([{ affectedRows: 1 }]);
     expect(await db.public.User.createAndCount([{ email: 'a@example.com' }])).toBe(1);
     expect(lastPlanTable(runtime).namespaceId).toBe('public');
     expect(lastPlanTable(runtime).name).toBe('users');
 
+    runtime.setNextStats([{ affectedRows: 1 }]);
     expect(await db.auth.User.createAndCount([{ token: 'tok' }])).toBe(1);
     expect(lastPlanTable(runtime).name).toBe('auth_users');
   });


### PR DESCRIPTION
## Linked issue

Fixes #30210

## At a glance

```ts
const inserted = await db.orm.Post.createAndCount([
  { id: 'absent', title: 'absent' },
]);
// inserted === 1 even when the insert affected 0 rows
```

`createAndCount()` echoed back `data.length` no matter what the runtime actually did, so a rejected or partial insert still reported the full input count as if every row landed.

## Decision

`createAndCount()` now returns the runtime's `affectedRows` from the executed insert plan instead of the input length. The split-insert path (used when the contract's `sql.defaultInInsert` capability is absent) sums `affectedRows` across its per-group inserts, since that path issues more than one statement per call.

## Testing performed

- `pnpm typecheck` and `pnpm test` in `packages/3-extensions/sql-orm-client` — 70 files, 773 tests, no type errors
- `pnpm lint` in `packages/3-extensions/sql-orm-client` — 15 pre-existing informational bare-cast findings, none new
- `pnpm typecheck`, `pnpm lint`, and `pnpm test:packages` at the repo root — all green aside from two pre-existing timeouts in unrelated postgres-adapter suites

## Skill update

n/a — internal only

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [x] The PR title follows the conventional-commit format; no Linear ticket is attached to this small fix.
- [x] The Skill update section above is filled in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `createAndCount()` to return the database-reported number of affected rows instead of the number of input records.
  * Ensured accurate counts for both single and split insert operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->