### PR TITLE
fix(framework-components): call descriptor.factory as a method

### DIFF
--- a/packages/1-framework/1-core/framework-components/src/shared/resolve-codec.ts
+++ b/packages/1-framework/1-core/framework-components/src/shared/resolve-codec.ts
@@ -66,12 +66,9 @@ export function validateCodecTypeParams(descriptor: AnyCodecDescriptor, ref: Cod
 
 /**
  * Resolves a `Codec` instance: validates `ref.typeParams` via
- * {@link validateCodecTypeParams} then calls `descriptor.factory(validated)(ctx)`.
- *
- * The descriptor's `factory` is typed against its own `P`; the registry erases
- * `P` to `any`, so the factory is narrowed to `(params: unknown) => (ctx) => Codec`
- * at the call boundary. The `paramsSchema` validates the input above before we
- * forward it, so the narrowing is safe by construction.
+ * {@link validateCodecTypeParams} then calls `descriptor.factory(validated)(ctx)`
+ * as a method on `descriptor`, preserving `this` for factories that build
+ * their returned codec from the descriptor instance (e.g. `new XCodec(this)`).
  */
 export function materializeCodec(
   descriptor: AnyCodecDescriptor,
@@ -79,8 +76,5 @@ export function materializeCodec(
   ctx: CodecInstanceContext,
 ): Codec {
   const validated = validateCodecTypeParams(descriptor, ref);
-  return blindCast<
-    (params: unknown) => (ctx: CodecInstanceContext) => Codec,
-    'registry erases P to any; paramsSchema validates input before forwarding'
-  >(descriptor.factory)(validated)(ctx);
+  return descriptor.factory(validated)(ctx);
 }

--- a/packages/1-framework/1-core/framework-components/test/materialize-codec.test.ts
+++ b/packages/1-framework/1-core/framework-components/test/materialize-codec.test.ts
@@ -1,0 +1,125 @@
+import type { JsonValue } from '@internal/contract/types';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { test } from 'vitest';
+import {
+  type AnyCodecDescriptor,
+  type CodecCallContext,
+  type CodecDescriptor,
+  CodecDescriptorImpl,
+  CodecImpl,
+  type CodecInstanceContext,
+  type CodecRef,
+  type CodecTrait,
+  materializeCodec,
+  voidParamsSchema,
+} from '../src/exports/codec';
+
+class Int4FixtureCodec extends CodecImpl<'demo/int4@1', readonly ['equality'], number, number> {
+  async encode(value: number, _ctx: CodecCallContext): Promise<number> {
+    return value;
+  }
+  async decode(wire: number, _ctx: CodecCallContext): Promise<number> {
+    return wire;
+  }
+  encodeJson(value: number): JsonValue {
+    return value;
+  }
+  decodeJson(json: JsonValue): number {
+    return json as number;
+  }
+}
+
+class Int4FixtureDescriptor extends CodecDescriptorImpl<void> {
+  override readonly codecId = 'demo/int4@1' as const;
+  override readonly traits: readonly CodecTrait[] = ['equality'];
+  override readonly targetTypes: readonly string[] = ['int4'];
+  override readonly paramsSchema: StandardSchemaV1<void> = voidParamsSchema;
+  override factory(): (ctx: CodecInstanceContext) => Int4FixtureCodec {
+    return () => new Int4FixtureCodec(this);
+  }
+}
+
+const int4FixtureDescriptor = new Int4FixtureDescriptor();
+
+type VectorParams = { readonly length: number };
+const vectorFixtureParamsSchema: StandardSchemaV1<VectorParams> = {
+  '~standard': {
+    version: 1,
+    vendor: 'demo',
+    validate: (input) => ({ value: input as VectorParams }),
+  },
+};
+
+class VectorFixtureCodec<N extends number> extends CodecImpl<
+  'demo/vector@1',
+  readonly ['equality'],
+  string,
+  number[]
+> {
+  constructor(
+    descriptor: CodecDescriptor<VectorParams>,
+    public readonly dimension: N,
+  ) {
+    super(descriptor);
+  }
+  async encode(value: number[], _ctx: CodecCallContext): Promise<string> {
+    return `[${value.join(',')}]`;
+  }
+  async decode(wire: string, _ctx: CodecCallContext): Promise<number[]> {
+    return wire.slice(1, -1).split(',').map(Number);
+  }
+  encodeJson(value: number[]): JsonValue {
+    return value;
+  }
+  decodeJson(json: JsonValue): number[] {
+    return json as number[];
+  }
+}
+
+class VectorFixtureDescriptor extends CodecDescriptorImpl<VectorParams> {
+  override readonly codecId = 'demo/vector@1' as const;
+  override readonly traits: readonly CodecTrait[] = ['equality'];
+  override readonly targetTypes: readonly string[] = ['vector'];
+  override readonly paramsSchema = vectorFixtureParamsSchema;
+  override factory<N extends number>(params: {
+    readonly length: N;
+  }): (ctx: CodecInstanceContext) => VectorFixtureCodec<N> {
+    return () => new VectorFixtureCodec<N>(this, params.length);
+  }
+}
+
+const vectorFixtureDescriptor = new VectorFixtureDescriptor();
+
+const stubCtx = {} as CodecInstanceContext;
+
+function descriptorFor(ref: CodecRef): AnyCodecDescriptor {
+  if (ref.codecId === int4FixtureDescriptor.codecId) return int4FixtureDescriptor;
+  if (ref.codecId === vectorFixtureDescriptor.codecId) return vectorFixtureDescriptor;
+  throw new Error(`no fixture descriptor for ${ref.codecId}`);
+}
+
+test('materializeCodec resolves a non-parameterized codec whose id reads the descriptor codecId', ({
+  expect,
+}) => {
+  const ref: CodecRef = { codecId: 'demo/int4@1' };
+  const codec = materializeCodec(descriptorFor(ref), ref, stubCtx);
+  expect(codec.id).toBe('demo/int4@1');
+});
+
+test('materializeCodec resolves a parameterized codec whose id reads the descriptor codecId', ({
+  expect,
+}) => {
+  const ref: CodecRef = { codecId: 'demo/vector@1', typeParams: { length: 1536 } };
+  const codec = materializeCodec(descriptorFor(ref), ref, stubCtx);
+  expect(codec.id).toBe('demo/vector@1');
+});
+
+test('materializeCodec produces a codec whose encode/decode still run through the descriptor-bound factory', async ({
+  expect,
+}) => {
+  const ref: CodecRef = { codecId: 'demo/vector@1', typeParams: { length: 3 } };
+  const codec = materializeCodec(descriptorFor(ref), ref, stubCtx);
+  const wire = await codec.encode([1, 2, 3], {});
+  expect(wire).toBe('[1,2,3]');
+  expect(await codec.decode(wire, {})).toEqual([1, 2, 3]);
+});


### PR DESCRIPTION
## Summary

`materializeCodec` evaluated `descriptor.factory` to a bare value before calling it, so `this` was `undefined` inside the factory. Every codec built as `new XCodec(this)` — the standard pattern for class-based codecs — received `descriptor === undefined`.

`CodecImpl.get id()` is `this.descriptor.codecId`, so `codec.id` threw on every such codec.

## Why it went unnoticed

`id` is read almost nowhere: the decode and encode failure wrappers read it to build their message, and little else does. So the fault only surfaced on an already-failing path — and when it did, it replaced a diagnostic that names the column with one that names nothing:

```
TypeError: Cannot read properties of undefined (reading 'codecId')
```

The wrapper's real message — `Failed to decode column <table>.<column> with codec '<id>'` — already existed and never got the chance to render. Both `decoding.ts` and `encoding.ts` were affected.

## The change

```diff
-  return blindCast<
-    (params: unknown) => (ctx: CodecInstanceContext) => Codec,
-    'registry erases P to any; paramsSchema validates input before forwarding'
-  >(descriptor.factory)(validated)(ctx);
+  return descriptor.factory(validated)(ctx);
```

The `blindCast` is not needed once the call is a method call: `AnyCodecDescriptor` is `CodecDescriptor<any>`, so the validated params pass without narrowing. Net one fewer cast against the ratchet.

## Blast radius

`this.descriptor` is dereferenced at four production sites (`codec.ts:73`, the postgres and sqlite codec descriptors). None branches or memoises on it, so nothing depended on the `undefined`.

Closure-style factories were already correct — `PostgresCodecDescriptorAdapter` assigns `this.factory = (params) => descriptor.factory(params)`, an arrow that forwards regardless of receiver. So adapted extension descriptors (pgvector, postgis, arktype-json) were unaffected; only directly-declared `CodecDescriptorImpl` subclasses were broken.

## Testing

`materialize-codec.test.ts` covers a non-parameterized and a parameterized descriptor whose factories use `new XCodec(this)`, and asserts `codec.id`. Verified load-bearing: against `main`'s version 2 of the 3 cases fail with the exact `Cannot read properties of undefined (reading 'codecId')` above.

- `@internal/framework-components`: 54 files, 628 tests
- Codec consumers: `@internal/sql-runtime` 343, `@internal/target-postgres` 1596, `@internal/adapter-postgres` 867 + 3 expected-fail
- Repo `pnpm typecheck`: 166/166; package lint clean

## Provenance

Salvaged from #30195, which was closed. That PR paired this fix with an interim `::text[]` projection cast for enum-array decoding; the cast is superseded by target-owned list framing, but this defect is unrelated to framing and is worth landing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcqoY3CKfnubdZt5YQk2Rq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed codec creation so descriptor-bound factories retain the correct context.
  * Ensured both standard and parameterized codec references resolve correctly, including encoding and decoding behavior.

* **Tests**
  * Added coverage for codec materialization with non-parameterized and parameterized codecs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->