### PR TITLE
fix(psl-parser): validate AST kinds across parser copies

### DIFF
--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/bool.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/bool.ts
@@ -9,8 +9,9 @@ export function bool(): ArgType<boolean> {
     kind: 'bool',
     label: 'boolean',
     parse: (arg, ctx): Result<boolean, readonly PslDiagnostic[]> => {
-      if (arg instanceof BooleanLiteralExprAst) {
-        const value = arg.value();
+      const literal = BooleanLiteralExprAst.cast(arg.syntax);
+      if (literal !== undefined) {
+        const value = literal.value();
         if (value !== undefined) return ok(value);
       }
       return notOk([leafDiagnostic(ctx, arg, 'Expected a boolean literal')]);

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/entity-ref.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/entity-ref.ts
@@ -11,10 +11,11 @@ export function entityRef(): ArgType<string> {
     kind: 'entityRef',
     label: 'model name',
     parse: (arg, ctx): Result<string, readonly PslDiagnostic[]> => {
-      if (!(arg instanceof IdentifierAst)) {
+      const identifier = IdentifierAst.cast(arg.syntax);
+      if (identifier === undefined) {
         return notOk([leafDiagnostic(ctx, arg, 'Expected a model name')]);
       }
-      const name = arg.name();
+      const name = identifier.name();
       if (name === undefined) {
         return notOk([leafDiagnostic(ctx, arg, 'Expected a model name')]);
       }

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/field-ref.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/field-ref.ts
@@ -16,10 +16,11 @@ export function fieldRef(scope: FieldRefScope): FieldRefArgType {
     label: 'field name',
     scope,
     parse: (arg, ctx): Result<string, readonly PslDiagnostic[]> => {
-      if (!(arg instanceof IdentifierAst)) {
+      const identifier = IdentifierAst.cast(arg.syntax);
+      if (identifier === undefined) {
         return notOk([leafDiagnostic(ctx, arg, 'Expected a field name')]);
       }
-      const name = arg.name();
+      const name = identifier.name();
       if (name === undefined) {
         return notOk([leafDiagnostic(ctx, arg, 'Expected a field name')]);
       }

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/func-call.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/func-call.ts
@@ -47,10 +47,11 @@ function matchCallee(
   name: string,
   ctx: InterpretCtx,
 ): Result<FunctionCallAst, readonly PslDiagnostic[]> {
-  if (!(arg instanceof FunctionCallAst)) {
+  const call = FunctionCallAst.cast(arg.syntax);
+  if (call === undefined) {
     return notOk([leafDiagnostic(ctx, arg, 'Expected a function call')]);
   }
-  const qname = arg.name();
+  const qname = call.name();
   if (qname === undefined || qname.dot() !== undefined || qname.colon() !== undefined) {
     return notOk([leafDiagnostic(ctx, arg, 'Expected a function call')]);
   }
@@ -61,5 +62,5 @@ function matchCallee(
   if (calleeName !== name) {
     return notOk([leafDiagnostic(ctx, arg, `Expected ${name}()`)]);
   }
-  return ok(arg);
+  return ok(call);
 }

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/identifier.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/identifier.ts
@@ -9,7 +9,8 @@ export function identifier<const N extends string>(name: N): ArgType<N> {
     kind: 'identifier',
     label: name,
     parse: (arg, ctx): Result<N, readonly PslDiagnostic[]> => {
-      if (arg instanceof IdentifierAst && arg.name() === name) return ok(name);
+      const identifier = IdentifierAst.cast(arg.syntax);
+      if (identifier !== undefined && identifier.name() === name) return ok(name);
       return notOk([leafDiagnostic(ctx, arg, `Expected ${name}`)]);
     },
   };

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/int.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/int.ts
@@ -13,8 +13,9 @@ export function int(opts?: { min?: number; max?: number }): ArgType<number> {
     kind: 'int',
     label: 'integer',
     parse: (arg, ctx): Result<number, readonly PslDiagnostic[]> => {
-      if (arg instanceof NumberLiteralExprAst) {
-        const value = arg.value();
+      const literal = NumberLiteralExprAst.cast(arg.syntax);
+      if (literal !== undefined) {
+        const value = literal.value();
         if (value !== undefined && Number.isInteger(value)) {
           if ((min === undefined || value >= min) && (max === undefined || value <= max)) {
             return ok(value);

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/json.ts
@@ -15,10 +15,11 @@ export function json(): ArgType<Record<string, unknown>> {
     kind: 'json',
     label: 'JSON object',
     parse: (arg, ctx): Result<Record<string, unknown>, readonly PslDiagnostic[]> => {
-      if (!(arg instanceof StringLiteralExprAst)) {
+      const literal = StringLiteralExprAst.cast(arg.syntax);
+      if (literal === undefined) {
         return notOk([leafDiagnostic(ctx, arg, 'Expected a JSON object string')]);
       }
-      const raw = arg.value();
+      const raw = literal.value();
       if (raw !== undefined) {
         try {
           const parsed: unknown = JSON.parse(raw);

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/list.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/list.ts
@@ -14,13 +14,14 @@ export function list<T>(of: ArgType<T>, opts?: ListOptions): ArgType<T[]> {
     kind: 'list',
     label: `${of.label}[]`,
     parse: (arg, ctx): Result<T[], readonly PslDiagnostic[]> => {
-      if (!(arg instanceof ArrayLiteralAst)) {
+      const literal = ArrayLiteralAst.cast(arg.syntax);
+      if (literal === undefined) {
         return notOk([leafDiagnostic(ctx, arg, `Expected a list of ${of.label}`)]);
       }
       const diagnostics: PslDiagnostic[] = [];
       const parsed: { node: ExpressionAst; value: T }[] = [];
       let count = 0;
-      for (const element of arg.elements()) {
+      for (const element of literal.elements()) {
         count += 1;
         const result = of.parse(element, ctx);
         if (result.ok) parsed.push({ node: element, value: result.value });

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/num.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/num.ts
@@ -12,8 +12,9 @@ export function num<const T extends number>(value?: T): ArgType<number | T> {
     kind: 'num',
     label: value === undefined ? 'number' : String(value),
     parse: (arg, ctx): Result<number | T, readonly PslDiagnostic[]> => {
-      if (arg instanceof NumberLiteralExprAst) {
-        const parsed = arg.value();
+      const literal = NumberLiteralExprAst.cast(arg.syntax);
+      if (literal !== undefined) {
+        const parsed = literal.value();
         if (parsed !== undefined) {
           if (value === undefined) return ok(parsed);
           if (parsed === value) return ok(value);

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/record.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/record.ts
@@ -9,13 +9,14 @@ export function record<T>(of: ArgType<T>): ArgType<Record<string, T>> {
     kind: 'record',
     label: `{ [key]: ${of.label} }`,
     parse: (arg, ctx): Result<Record<string, T>, readonly PslDiagnostic[]> => {
-      if (!(arg instanceof ObjectLiteralExprAst)) {
+      const literal = ObjectLiteralExprAst.cast(arg.syntax);
+      if (literal === undefined) {
         return notOk([leafDiagnostic(ctx, arg, 'Expected an object literal')]);
       }
       const diagnostics: PslDiagnostic[] = [];
       const entries: [string, T][] = [];
       const keys = new Set<string>();
-      for (const field of arg.fields()) {
+      for (const field of literal.fields()) {
         const key = field.keyName();
         if (key === undefined) {
           diagnostics.push(leafDiagnostic(ctx, field, 'Expected a key'));

--- a/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
+++ b/packages/1-framework/2-authoring/psl-parser/src/attribute-spec/combinators/str.ts
@@ -12,8 +12,9 @@ export function str<const T extends string>(value?: T): ArgType<string | T> {
     kind: 'str',
     label: value === undefined ? 'string' : JSON.stringify(value),
     parse: (arg, ctx): Result<string | T, readonly PslDiagnostic[]> => {
-      if (arg instanceof StringLiteralExprAst) {
-        const parsed = arg.value();
+      const literal = StringLiteralExprAst.cast(arg.syntax);
+      if (literal !== undefined) {
+        const parsed = literal.value();
         if (parsed !== undefined) {
           if (value === undefined) return ok(parsed);
           if (parsed === value) return ok(value);

--- a/test/integration/test/authoring/README.md
+++ b/test/integration/test/authoring/README.md
@@ -25,8 +25,6 @@ For each parity case it asserts:
 
 It also includes diagnostics coverage from invalid PSL fixture inputs.
 
-`lsp-emit-parity.integration.test.ts` compares CLI emission with the language server's diagnostic pipeline using an internal parser and a public-package interpreter. It covers the init schema, literal defaults, and invalid function calls, guarding against AST constructor-identity checks across package copies.
-
 ## Directory layout
 
 `parity/<case>/` contains one parity case:

--- a/test/integration/test/authoring/README.md
+++ b/test/integration/test/authoring/README.md
@@ -25,6 +25,8 @@ For each parity case it asserts:
 
 It also includes diagnostics coverage from invalid PSL fixture inputs.
 
+`lsp-emit-parity.integration.test.ts` compares CLI emission with the language server's diagnostic pipeline using an internal parser and a public-package interpreter. It covers the init schema, literal defaults, and invalid function calls, guarding against AST constructor-identity checks across package copies.
+
 ## Directory layout
 
 `parity/<case>/` contains one parity case:

--- a/test/integration/test/authoring/lsp-emit-parity.integration.test.ts
+++ b/test/integration/test/authoring/lsp-emit-parity.integration.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { copyFileSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { timeouts } from '@repo/test-utils';
 import { join } from 'pathe';
@@ -31,13 +31,10 @@ model Post {
 }
 `;
 
-const config = `import { defineConfig } from '@prisma/cli-engine';
-import { defineConfig as ormConfig } from '@prisma/orm-postgres/config';
-
-export default defineConfig({
-  orm: ormConfig({ contract: './contract.prisma' }),
-});
-`;
+const configPath = join(
+  import.meta.dirname,
+  '../fixtures/cli/cli-test-app/fixtures/lsp-emit-parity/prisma.config.ts',
+);
 
 withTempDir(({ createTempDir }) => {
   describe('language-server diagnostics with a project-installed interpreter', () => {
@@ -74,7 +71,7 @@ model Widget {
         const schemaPath = join(ctx.testDir, 'contract.prisma');
         const uri = pathToFileURL(schemaPath).href;
         writeFileSync(schemaPath, text);
-        writeFileSync(ctx.configPath, config);
+        copyFileSync(configPath, ctx.configPath);
 
         const emitted = await runContractEmit(ctx);
         expect(emitted.exitCode, emitted.stderr).toBe(exitCode);

--- a/test/integration/test/authoring/lsp-emit-parity.integration.test.ts
+++ b/test/integration/test/authoring/lsp-emit-parity.integration.test.ts
@@ -1,0 +1,98 @@
+import { writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { timeouts } from '@repo/test-utils';
+import { join } from 'pathe';
+import { describe, expect, it } from 'vitest';
+import { resolveConfigInputs } from '../../../../packages/1-framework/3-tooling/language-server/src/config-resolution';
+import { createProjectArtifacts } from '../../../../packages/1-framework/3-tooling/language-server/src/project-artifacts';
+import { withTempDir } from '../utils/cli-test-helpers';
+import { runContractEmit, setupJourney } from '../utils/journey-test-helpers';
+
+const schema = `// use prisma-next
+
+model User {
+  id        Int @id @default(autoincrement())
+  email     String @unique
+  username  String?
+  name      String?
+  posts     Post[]
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+
+model Post {
+  id        Int @id @default(autoincrement())
+  title     String
+  content   String?
+  author    User @relation(fields: [authorId], references: [id])
+  authorId  Int
+  createdAt TimestamptzString @default(now())
+  updatedAt temporal.updatedAtString()
+}
+`;
+
+const config = `import { defineConfig } from '@prisma/cli-engine';
+import { defineConfig as ormConfig } from '@prisma/orm-postgres/config';
+
+export default defineConfig({
+  orm: ormConfig({ contract: './contract.prisma' }),
+});
+`;
+
+withTempDir(({ createTempDir }) => {
+  describe('language-server diagnostics with a project-installed interpreter', () => {
+    it.each([
+      {
+        name: 'init schema',
+        text: schema,
+        exitCode: 0,
+        diagnosticCodes: [],
+      },
+      {
+        name: 'literal defaults and mapped names',
+        text: `// use prisma-next
+model Widget {
+  id Int @id @default(autoincrement())
+  label String @default("draft") @map("display_label")
+  count Int @default(42)
+  enabled Boolean @default(true)
+  @@map("widgets")
+}`,
+        exitCode: 0,
+        diagnosticCodes: [],
+      },
+      {
+        name: 'invalid default functions',
+        text: schema.replaceAll('autoincrement()', 'unknown()'),
+        exitCode: 2,
+        diagnosticCodes: ['PSL_INVALID_ATTRIBUTE_SYNTAX', 'PSL_INVALID_ATTRIBUTE_SYNTAX'],
+      },
+    ])(
+      'agrees with emit for $name across the internal/public parser boundary',
+      async ({ text, exitCode, diagnosticCodes }) => {
+        const ctx = setupJourney({ createTempDir, contractMode: 'psl' });
+        const schemaPath = join(ctx.testDir, 'contract.prisma');
+        const uri = pathToFileURL(schemaPath).href;
+        writeFileSync(schemaPath, text);
+        writeFileSync(ctx.configPath, config);
+
+        const emitted = await runContractEmit(ctx);
+        expect(emitted.exitCode, emitted.stderr).toBe(exitCode);
+
+        const resolution = await resolveConfigInputs(ctx.configPath);
+        expect(resolution.interpretation).toBeDefined();
+        const project = createProjectArtifacts({
+          ...resolution,
+          getText: (inputUri) => (inputUri === uri ? text : undefined),
+        });
+        const document = project.document(uri);
+        expect(document).toBeDefined();
+        expect(document?.diagnostics).toEqual([]);
+        expect(document?.interpretDiagnostics().map((diagnostic) => diagnostic.code)).toEqual(
+          diagnosticCodes,
+        );
+      },
+      timeouts.coldTransformImport,
+    );
+  });
+});

--- a/test/integration/test/fixtures/cli/cli-test-app/fixtures/lsp-emit-parity/prisma.config.ts
+++ b/test/integration/test/fixtures/cli/cli-test-app/fixtures/lsp-emit-parity/prisma.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@prisma/cli-engine';
+import { defineConfig as ormConfig } from '@prisma/orm-postgres/config';
+
+export default defineConfig({
+  orm: ormConfig({ contract: './contract.prisma' }),
+});


### PR DESCRIPTION
Fixes false language-server diagnostics for valid PSL schemas that `contract emit` accepts, including the schema generated by `prisma orm init`.

## Changes

- Replace constructor-identity checks in all 11 attribute combinators with existing kind-based AST casts.
- Add an integration regression comparing CLI emission with the LSP diagnostic pipeline across the internal-parser/public-interpreter boundary. Cover the init schema, literal defaults and mapped names, and genuine invalid-function diagnostics.

## Why

The LSP parses with its own parser and passes the artifacts to the project's interpreter. Those packages can contain separate AST class copies, so `instanceof` rejects valid function calls, arrays, and literals. Emission works because its parser and interpreter share class identities. Kind-based casts preserve validation without requiring constructor identity.

**Scope:** Attribute argument validation and regression coverage only; no schema syntax or emission behavior changes. Existing projects need updated ORM packages because the checks run in the project-loaded interpreter.

## Verification

- Confirmed the regression fails before the fix with the seven reported init-schema diagnostics.
- Three integration cases pass after the fix.
- PSL parser, language-server, SQL PSL, and Mongo PSL suites pass: 1,556 tests.
- Parser, language-server, and integration-project typechecks pass.
- Parser lint, new-test lint, and changed-file diagnostics pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing consistency for boolean, numeric, string, JSON, list, record, identifier, field, entity, and function-reference values.
  * Preserved existing validation rules and diagnostics while improving syntax handling.

* **Tests**
  * Added integration coverage confirming that language-server diagnostics match contract validation results across valid and invalid schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->