### PR TITLE
Order RLS policy drops before column drops

### DIFF
--- a/packages/3-targets/3-targets/postgres/src/core/migrations/planner.ts
+++ b/packages/3-targets/3-targets/postgres/src/core/migrations/planner.ts
@@ -55,7 +55,9 @@ import {
 import type { PostgresOpFactoryCall } from './op-factory-call';
 import {
   CreatePostgresRlsPolicyCall,
+  DropColumnCall,
   DropPostgresRlsPolicyCall,
+  DropTableCall,
   RenameCheckConstraintCall,
   RenameIndexCall,
   RenamePostgresRlsPolicyCall,
@@ -351,9 +353,8 @@ export class PostgresMigrationPlanner implements MigrationPlanner<'sql', 'postgr
       resolveFactoryName: (call) => call.factoryName,
     });
     const calls = [
-      ...result.value.calls,
+      ...splicePolicyDropsBeforeEntityDrops(result.value.calls, schemaDiffPartition.kept),
       ...indexRenamePartition.kept,
-      ...schemaDiffPartition.kept,
       ...fieldEventPartition.kept,
     ];
     // Byte-identical suppression warnings (the same subject suppressed by
@@ -863,6 +864,34 @@ export class PostgresMigrationPlanner implements MigrationPlanner<'sql', 'postgr
 function isPolicyDiffIssue(issue: SchemaDiffIssue<SqlSchemaDiffNode>): boolean {
   const node = issue.expected ?? issue.actual;
   return node !== undefined && PostgresPolicySchemaNode.is(node);
+}
+
+/**
+ * Splices RLS policy drops ahead of structural entity drops. Postgres refuses
+ * to drop a column (or table) while a policy still references it (2BP01), so
+ * a `dropColumn` planned before its `dropPolicy` fails at apply time. Policy
+ * creates and renames stay after the structural block: creates must see the
+ * columns they reference, and renames preserve policies rather than removing
+ * them. With no entity drop present the input order is kept untouched.
+ */
+function splicePolicyDropsBeforeEntityDrops(
+  structural: readonly PostgresOpFactoryCall[],
+  schemaDiff: readonly PostgresOpFactoryCall[],
+): readonly PostgresOpFactoryCall[] {
+  const policyDrops = schemaDiff.filter(
+    (call): call is DropPostgresRlsPolicyCall => call instanceof DropPostgresRlsPolicyCall,
+  );
+  const anchor =
+    policyDrops.length === 0
+      ? -1
+      : structural.findIndex(
+          (call) => call instanceof DropTableCall || call instanceof DropColumnCall,
+        );
+  if (anchor === -1) {
+    return [...structural, ...schemaDiff];
+  }
+  const rest = schemaDiff.filter((call) => !(call instanceof DropPostgresRlsPolicyCall));
+  return [...structural.slice(0, anchor), ...policyDrops, ...structural.slice(anchor), ...rest];
 }
 
 /**

--- a/packages/3-targets/3-targets/postgres/test/migrations/rls-planner.test.ts
+++ b/packages/3-targets/3-targets/postgres/test/migrations/rls-planner.test.ts
@@ -391,6 +391,66 @@ describe('RLS planner policy edit (missing + extra via generic pipeline)', () =>
   });
 });
 
+describe('RLS planner drop ordering against column drops', () => {
+  function schemaWithPublishedColumn(policies: readonly PostgresRlsPolicy[]) {
+    return new PostgresDatabaseSchemaNode({
+      namespaces: {
+        public: new PostgresNamespaceSchemaNode({
+          schemaName: 'public',
+          tables: {
+            [TABLE_NAME]: new PostgresTableSchemaNode({
+              name: TABLE_NAME,
+              columns: {
+                id: { name: 'id', nativeType: 'int4', nullable: false },
+                user_id: { name: 'user_id', nativeType: 'int4', nullable: false },
+                published: { name: 'published', nativeType: 'bool', nullable: false },
+              },
+              foreignKeys: [],
+              uniques: [],
+              indexes: [],
+              policies: policies.map(policyNode),
+              rlsEnabled: true,
+            }),
+          },
+        }),
+      },
+      roles: [],
+      existingSchemas: ['public'],
+      pgVersion: 'unknown',
+    });
+  }
+
+  it('emits DROP POLICY before DROP COLUMN when the policy references the column', async () => {
+    const contract = buildContractWith([makePolicy('p_read_11111111')]);
+    const planner = createPostgresMigrationPlanner(stubLowerer);
+    const schema = schemaWithPublishedColumn([
+      makeActualPolicy('p_read_11111111'),
+      makeActualPolicy('p_pub_22222222', TABLE_NAME, '(published = true)'),
+    ]);
+
+    const result = planner.plan({
+      contract,
+      schema,
+      policy: DB_UPDATE_POLICY,
+      fromContract: null,
+      frameworkComponents: [],
+      spaceId: APP_SPACE_ID,
+      snapshotsImportPath: '../../snapshots',
+    });
+
+    expect(result.kind).toBe('success');
+    if (result.kind !== 'success') return;
+
+    const ops = await Promise.all(result.plan.operations);
+    const opIds = ops.map((op) => op.id);
+    const dropPolicyId = `rlsPolicy.public.${TABLE_NAME}.p_pub_22222222.drop`;
+    const dropColumnId = `dropColumn.${TABLE_NAME}.published`;
+    expect(opIds).toContain(dropPolicyId);
+    expect(opIds).toContain(dropColumnId);
+    expect(opIds.indexOf(dropPolicyId)).toBeLessThan(opIds.indexOf(dropColumnId));
+  });
+});
+
 describe('RLS planner roles produce zero ops (AC-6)', () => {
   // Roles are existence-verify only (provisioning is a project non-goal), so a
   // role diff issue must add NO migration op — never CREATE/DROP ROLE, and


### PR DESCRIPTION
## Linked issue

Fixes #30226

## Summary

When one contract change removes both a column and an RLS policy referencing it, the planner emits `dropColumn` before `dropPolicy`, and Postgres rejects the migration with 2BP01. Policy drops are now spliced ahead of the first structural table/column drop, so the generated plan applies cleanly.

## Testing performed

- New regression test in `test/migrations/rls-planner.test.ts` (drops a `published` column together with a policy on `(published = true)`, asserts drop-policy-before-drop-column): fails before the fix (`dropColumn` at index 0, `dropPolicy` at 2), passes after.
- `pnpm vitest run test/migrations` in `@internal/target-postgres`: 30 files / 413 tests pass.
- Full `@internal/target-postgres` suite: 94 files / 1607 tests pass.
- `pnpm typecheck` in the package: clean. `pnpm lint:deps` from repo root: no violations. `biome check` on the two touched files: no new findings (only the two pre-existing ones).
- Not verified against a live database; ordering is covered at planner level only.

## Skill update

n/a, internal only. No CLI, API, config or error-code surface changes, only the emission order of already-planned operations.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [ ] The PR title is in `TML-NNNN: <sentence-case title>` form (no Linear ticket on my side, happy for a maintainer to add the prefix).
- [x] The **Skill update** section above is filled in.

## Notes for the reviewer

The spot I was unsure about: policy drops now move as a group, so for a *changed* (not removed) policy the replacement drop separates from its create, which stays late in the plan. That split is still correct (the old policy must go before any column drop, the new one must see the final columns), but flagging it in case you'd rather keep replacement pairs adjacent. Also, when there is no table/column drop in the plan the order is byte-identical to before, which the rename-planner tests pin down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL migration ordering so row-level security policy removals occur before dropping referenced tables or columns.
  - Preserved existing operation ordering when no related policy or structural removals are involved.

- **Tests**
  - Added coverage for migrations that remove a policy and its referenced column together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->