### PR TITLE
fix(cli): report contract source diagnostics in the emit failure

### DIFF
--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/contract-emit.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/contract-emit.ts
@@ -128,14 +128,18 @@ function validateProviderResult(providerResult: unknown): ValidatedProviderResul
       ),
     };
   }
+  const issues = mapDiagnosticsToIssues(failure['diagnostics']);
+  const summary = String(failure['summary']);
   return {
     ok: false,
     error: failedToResolveContractSource(
-      String(failure['summary']),
+      issues.length === 0
+        ? summary
+        : `${summary}: ${issues.map((issue) => issue.message).join('; ')}`,
       'Fix contract source diagnostics and return ok(Contract).',
       {
         diagnostics: failure['diagnostics'],
-        issues: mapDiagnosticsToIssues(failure['diagnostics']),
+        issues,
         ...ifDefined('providerMeta', failure['meta']),
       },
     ),

--- a/packages/1-framework/3-tooling/cli/src/control-api/operations/contract-emit.ts
+++ b/packages/1-framework/3-tooling/cli/src/control-api/operations/contract-emit.ts
@@ -130,12 +130,11 @@ function validateProviderResult(providerResult: unknown): ValidatedProviderResul
   }
   const issues = mapDiagnosticsToIssues(failure['diagnostics']);
   const summary = String(failure['summary']);
+  const why = [summary, ...issues.map((issue) => `  - ${issue.message}`)].join('\n');
   return {
     ok: false,
     error: failedToResolveContractSource(
-      issues.length === 0
-        ? summary
-        : `${summary}: ${issues.map((issue) => issue.message).join('; ')}`,
+      why,
       'Fix contract source diagnostics and return ok(Contract).',
       {
         diagnostics: failure['diagnostics'],

--- a/packages/1-framework/3-tooling/cli/test/control-api/contract-emit.test.ts
+++ b/packages/1-framework/3-tooling/cli/test/control-api/contract-emit.test.ts
@@ -162,7 +162,26 @@ describe('executeContractEmit', () => {
         },
       })),
       expectedCode: 'CONTRACT.SOURCE_LOAD_FAILED',
-      expectedSubstring: 'Provider parse failed',
+      expectedSubstring: 'Provider parse failed\n  - Unexpected token',
+    },
+    {
+      label: 'includes the diagnostic position when the provider reports a span',
+      source: createSourceProvider(async () => ({
+        ok: false,
+        failure: {
+          summary: 'Provider parse failed',
+          diagnostics: [
+            {
+              code: 'PSL_PARSE_ERROR',
+              message: 'Unexpected token',
+              sourceId: 'schema.prisma',
+              span: { start: { offset: 24, line: 3, column: 8 } },
+            },
+          ],
+        },
+      })),
+      expectedCode: 'CONTRACT.SOURCE_LOAD_FAILED',
+      expectedSubstring: 'Unexpected token (schema.prisma:3:8)',
     },
     {
       label: 'rejects malformed failure result',

--- a/test/integration/test/authoring/cli.emit-parity-fixtures.test.ts
+++ b/test/integration/test/authoring/cli.emit-parity-fixtures.test.ts
@@ -286,7 +286,10 @@ describe('emit parity fixture diagnostics', () => {
         expect(run.exitCode).toBe(2);
         expect(envelope).toMatchObject({
           ok: false,
-          error: { code: 'CONTRACT.SOURCE_LOAD_FAILED', why: expectedFixture.failureSummary },
+          error: {
+            code: 'CONTRACT.SOURCE_LOAD_FAILED',
+            why: expect.stringContaining(expectedFixture.failureSummary),
+          },
         });
         const reported = JSON.stringify(envelope);
         for (const diagnostic of expectedFixture.diagnostics) {

--- a/test/integration/test/cli.emit-command.test.ts
+++ b/test/integration/test/cli.emit-command.test.ts
@@ -4,6 +4,7 @@ import { loadConfig } from '@internal/config-loader';
 import { createControlStack } from '@internal/framework-components/control';
 import type { CompletedEnvelope, ErroredEnvelope } from '@prisma/cli-engine';
 import { timeouts } from '@repo/test-utils';
+import stripAnsi from 'strip-ansi';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   type EngineRunResult,
@@ -608,13 +609,43 @@ describe('emit command: additional fixtures', () => {
         ok: false,
         error: {
           code: 'CONTRACT.SOURCE_LOAD_FAILED',
-          why: 'PSL to SQL contract interpretation failed',
+          why: expect.stringContaining('PSL to SQL contract interpretation failed'),
         },
       });
 
       const reported = JSON.stringify(envelope);
       expect(reported).toContain('PSL_UNSUPPORTED_FIELD_TYPE');
       expect(reported).toContain('schema.prisma');
+    } finally {
+      testSetup.cleanup();
+    }
+  });
+
+  it('names the offending field in the human-mode provider failure', {
+    timeout: timeouts.typeScriptCompilation,
+  }, async () => {
+    const testSetup = setupIntegrationTestDirectoryFromFixtures(
+      fixtureSubdir,
+      'prisma.config.parity-psl.ts',
+    );
+
+    try {
+      writeFileSync(
+        join(testSetup.testDir, 'schema.prisma'),
+        `model User {
+  id        Int @id
+  updatedAt DateTime @updatedAt
+}
+`,
+        'utf-8',
+      );
+
+      const run = await runOnEngine(testSetup, ['contract', 'emit']);
+      expect(run.exitCode).toBe(2);
+
+      const reported = stripAnsi(run.stderr);
+      expect(reported).toContain('unsupported attribute "@updatedAt"');
+      expect(reported).toContain('schema.prisma:3:22');
     } finally {
       testSetup.cleanup();
     }

--- a/test/integration/test/cli.emit-command.test.ts
+++ b/test/integration/test/cli.emit-command.test.ts
@@ -621,7 +621,7 @@ describe('emit command: additional fixtures', () => {
     }
   });
 
-  it('names the offending field in the human-mode provider failure', {
+  it('names the offending field and its position in human mode', {
     timeout: timeouts.typeScriptCompilation,
   }, async () => {
     const testSetup = setupIntegrationTestDirectoryFromFixtures(
@@ -644,8 +644,9 @@ describe('emit command: additional fixtures', () => {
       expect(run.exitCode).toBe(2);
 
       const reported = stripAnsi(run.stderr);
-      expect(reported).toContain('unsupported attribute "@updatedAt"');
-      expect(reported).toContain('schema.prisma:3:22');
+      expect(reported).toContain('Field "User.updatedAt" uses unsupported attribute "@updatedAt"');
+      expect(reported).toContain('temporal.updatedAt()');
+      expect(reported).toMatch(/schema\.prisma:3:\d+/);
     } finally {
       testSetup.cleanup();
     }


### PR DESCRIPTION
## Linked issue

Fixes #30243

## Summary

`prisma contract emit` fails on a schema that uses `@updatedAt`, and the output says nothing about the field:

```
✘ [CONTRACT.SOURCE_LOAD_FAILED] Failed to resolve contract source
  why: PSL to SQL contract interpretation failed
→ Fix contract source diagnostics and return ok(Contract).
```

The PSL interpreter had already produced the message the user needed, telling them to swap the attribute for a `temporal.updatedAt()` field preset. But `validateProviderResult` put the provider's diagnostics into `meta`, and `writeDiagnostic` renders `why`, `nextActions` and `docsUrl` — never `meta`. So the one thing that made the failure actionable was dropped on the floor, and the reporter had to find the field by deleting lines.

The failure's `why` now lists them, one per line:

```
✘ [CONTRACT.SOURCE_LOAD_FAILED] Failed to resolve contract source
  why: PSL to SQL contract interpretation failed
  - Field "User.updatedAt" uses unsupported attribute "@updatedAt". Use `temporal.updatedAt()` as a field-preset call instead. (./schema.prisma:3:22)
→ Fix contract source diagnostics and return ok(Contract).
```

`why` is part of the error envelope, so `--json` consumers see the same longer string; `meta.diagnostics` and `meta.issues` are unchanged. One diagnostic per line rather than one joined line, because a schema with several mistakes otherwise produces several hundred characters on one physical line, and at least one PSL message already contains a semicolon of its own.

## Testing performed

- `packages/1-framework/3-tooling/cli`: two rows added to the `source provider validation` table in `contract-emit.test.ts` pin the composed `why`, one of them through a diagnostic carrying a span so the `(file:line:column)` suffix is covered.
- `test/integration/test/cli.emit-command.test.ts`: new case runs `contract emit` in human mode against the issue's `@updatedAt` schema and asserts stderr names the field, the replacement, and the position.
- Checked out the pre-change `contract-emit.ts`, rebuilt, and reran both: all three assertions fail. (`test/integration` resolves `@internal/cli` through `dist/`, so the rebuild is what makes the revert bite.)
- `pnpm --filter @internal/cli typecheck` and `lint` — clean
- `pnpm --filter @internal/cli test` — 1430 passed. The 6 remaining failures are `init-emit.test.ts`, which spawns the project-local `prisma` bin, and one `format.test.ts` write-back case; both fail the same way on an unmodified tree here.
- `test/integration`: `cli.emit-command`, `cli.emit-parity-fixtures`, `cli.emit`, `cli.emit-contract`, `cli.emit-output-path` — 57 tests passed

Two `--json` assertions moved from an exact `why` match to `expect.stringContaining`: one in `cli.emit-command.test.ts`, and the six fixture-driven cases in `authoring/cli.emit-parity-fixtures.test.ts`. Both still pin the summary, and both already check the diagnostics separately.

## Skill update

n/a — no CLI surface, flag, or error code changed. Only the prose of an existing failure.

## Checklist

- [x] All commits are signed off (`git commit -s`) per the DCO.
- [x] I read CONTRIBUTING.md and the change is scoped to one logical concern.
- [x] Tests are updated.
- [ ] PR title in `TML-NNNN: ...` form — no Linear access as an external contributor, so a conventional-commit title instead.
- [x] The Skill update section above is filled in.

## Notes for the reviewer

I put the diagnostics in `why` rather than in the structured error's `diagnostics` array. The array is the richer mechanism and `emitErrored` does render it, but each entry needs an ADR 239 dotted code while the PSL vocabulary is `PSL_UNSUPPORTED_FIELD_ATTRIBUTE`-shaped; `withDocsUrl` would then hand users a docs link per diagnostic for pages that don't exist, and `writeDiagnostic` walks `nextActions` unguarded, which a raw PSL diagnostic doesn't carry. Renaming that vocabulary is a much bigger change than this bug warrants. Happy to go that way instead if you'd prefer it.

Two things I deliberately left alone. `vite-plugin-contract-emit` builds its overlay from `error.message`, which is the summary, so the plugin still shows nothing about the field — same gap, different surface, and it predates this change. And `cli.emit-command.test.ts` is over the 500-line limit in `test-file-organization.mdc`; it was already, and splitting it felt out of scope here. Say the word on either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provider contract resolution errors now present diagnostic details in a clearer, multi-line format, including the affected field, actionable guidance, and source location when available.
  - Error messages retain the overall failure summary while making individual provider diagnostics easier to identify and understand.

- **Tests**
  - Added coverage for human-readable provider failure messages, diagnostic positions, and actionable replacement guidance.
  - Updated assertions to accommodate expanded diagnostic context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->