### PR TITLE
Release buffered PostgreSQL connections before result consumption

### DIFF
--- a/packages/3-extensions/sql-orm-client/README.md
+++ b/packages/3-extensions/sql-orm-client/README.md
@@ -2,7 +2,7 @@
 
 ORM client for Prisma 8 — fluent, type-safe model collections.
 
-This package provides a high-level ORM client surface on top of the runtime. Reads with includes compile to a single correlated-subquery plan; nested mutations orchestrate several statements inside one scope.
+This package provides a high-level ORM client surface on top of the runtime. Reads with includes compile to a single correlated-subquery plan and use the supplied runtime without acquiring an additional connection scope. Caller-owned connections and transactions remain caller-owned; nested mutations orchestrate several statements inside one scope.
 
 ## Responsibilities
 

--- a/packages/3-extensions/sql-orm-client/src/collection-dispatch.ts
+++ b/packages/3-extensions/sql-orm-client/src/collection-dispatch.ts
@@ -40,7 +40,6 @@ import {
   resolveRowIdentityColumns,
 } from './collection-contract';
 import {
-  acquireRuntimeScope,
   mapPolymorphicRow,
   mapResultRows,
   mapStorageRowToModelFields,
@@ -116,51 +115,44 @@ function dispatchWithIncludes<Row>(
   const { context, runtime, state, tableName, modelName, namespaceId } = options;
   const { contract } = context;
   const generator = async function* (): AsyncGenerator<Row, void, unknown> {
-    const { scope, release } = await acquireRuntimeScope(runtime);
-    try {
-      const compiled = compileSelectWithIncludes(
-        contract,
-        context.aggregateDescriptors,
-        namespaceId,
-        tableName,
-        state,
-        modelName,
-      );
+    const compiled = compileSelectWithIncludes(
+      contract,
+      context.aggregateDescriptors,
+      namespaceId,
+      tableName,
+      state,
+      modelName,
+    );
 
-      const parentRowsRaw = await queryPlanRows<Record<string, unknown>>(scope, compiled).toArray();
-      if (parentRowsRaw.length === 0) {
-        return;
-      }
+    const parentRowsRaw = await queryPlanRows<Record<string, unknown>>(runtime, compiled).toArray();
+    if (parentRowsRaw.length === 0) {
+      return;
+    }
 
-      const polyInfo = resolvePolymorphismInfo(contract, namespaceId, modelName);
-      const parentRows: RowEnvelope[] = parentRowsRaw.map((row) => {
-        const mapped = polyInfo
-          ? mapPolymorphicRow(contract, namespaceId, modelName, polyInfo, row, state.variantName)
-          : mapStorageRowToModelFields(contract, namespaceId, modelName, row);
-        return { raw: row, mapped };
-      });
+    const polyInfo = resolvePolymorphismInfo(contract, namespaceId, modelName);
+    const parentRows: RowEnvelope[] = parentRowsRaw.map((row) => {
+      const mapped = polyInfo
+        ? mapPolymorphicRow(contract, namespaceId, modelName, polyInfo, row, state.variantName)
+        : mapStorageRowToModelFields(contract, namespaceId, modelName, row);
+      return { raw: row, mapped };
+    });
 
-      for (const parent of parentRows) {
-        for (const include of state.includes) {
-          parent.mapped[include.relationName] = await decodeIncludePayload(
-            contract,
-            context,
-            include,
-            parent.raw[include.relationName],
-          );
-        }
+    for (const parent of parentRows) {
+      for (const include of state.includes) {
+        parent.mapped[include.relationName] = await decodeIncludePayload(
+          contract,
+          context,
+          include,
+          parent.raw[include.relationName],
+        );
       }
+    }
 
-      for (const row of parentRows) {
-        yield blindCast<
-          Row,
-          'collection row generic is supplied by the caller and matched to the selected model shape'
-        >(row.mapped);
-      }
-    } finally {
-      if (release) {
-        await release();
-      }
+    for (const row of parentRows) {
+      yield blindCast<
+        Row,
+        'collection row generic is supplied by the caller and matched to the selected model shape'
+      >(row.mapped);
     }
   };
 

--- a/packages/3-extensions/sql-orm-client/test/collection-dispatch.test.ts
+++ b/packages/3-extensions/sql-orm-client/test/collection-dispatch.test.ts
@@ -1,7 +1,7 @@
 import type { Contract } from '@internal/contract/types';
 import type { SqlStorage } from '@internal/sql-contract/types';
 import type { ProjectionItem, SelectAst } from '@internal/sql-relational-core/ast';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { resolveIncludeRelation } from '../src/collection-contract';
 import { dispatchCollectionRows } from '../src/collection-dispatch';
 import { type CollectionState, emptyState, type IncludeExpr } from '../src/types';
@@ -76,6 +76,7 @@ function withEmittedSqlCapabilities(contract: TestContract) {
 function addConnection(
   runtime: MockRuntime,
   onRelease: () => void,
+  onAcquire: () => void = () => {},
 ): MockRuntime & {
   connection: () => Promise<{
     query: MockRuntime['query'];
@@ -85,6 +86,7 @@ function addConnection(
 } {
   return Object.assign(runtime, {
     async connection() {
+      onAcquire();
       return {
         query: runtime.query.bind(runtime),
         execute: runtime.execute.bind(runtime),
@@ -256,16 +258,17 @@ describe('collection-dispatch', () => {
     expect(runtime.executions).toHaveLength(1);
   });
 
-  it('dispatchCollectionRows() single-query path returns empty rows and releases scope', async () => {
+  it('dispatchCollectionRows() single-query path returns empty rows without acquiring a scope', async () => {
     const contract = withSingleQueryCapabilities(getTestContract());
     const { collection, runtime } = createCollectionFor('User', contract);
-    const scoped = collection.include('posts');
+    const scoped = collection.select('name').include('posts', (posts) => posts.select('title'));
     runtime.setNextResults([[]]);
 
     let released = false;
     const runtimeWithConnection = addConnection(runtime, () => {
       released = true;
     });
+    const connection = vi.spyOn(runtimeWithConnection, 'connection');
 
     const rows = await dispatchCollectionRows<Record<string, unknown>>({
       context: collection.ctx.context,
@@ -277,7 +280,85 @@ describe('collection-dispatch', () => {
     }).toArray();
 
     expect(rows).toEqual([]);
-    expect(released).toBe(true);
+    expect(connection).not.toHaveBeenCalled();
+    expect(released).toBe(false);
+  });
+
+  it.each(['connection', 'transaction'])('uses the caller-pinned %s unchanged', async (kind) => {
+    const contract = withSingleQueryCapabilities(getTestContract());
+    const { collection, runtime } = createCollectionFor('User', contract);
+    const scoped = collection.select('name').include('posts', (posts) => posts.select('title'));
+    const release = vi.fn(async () => {});
+    const commit = vi.fn(async () => {});
+    const rollback = vi.fn(async () => {});
+    const callerScope = Object.assign(
+      createMockRuntime(),
+      kind === 'connection' ? { release } : { commit, rollback },
+    );
+    const query = vi.spyOn(callerScope, 'query');
+    callerScope.setNextResults([[{ name: 'Alice', posts: '[{"title":"Post A"}]' }]]);
+
+    const rows = await dispatchCollectionRows<Record<string, unknown>>({
+      context: collection.ctx.context,
+      runtime: callerScope,
+      state: scoped.state,
+      tableName: scoped.tableName,
+      namespaceId: 'public',
+      modelName: scoped.modelName,
+    }).toArray();
+
+    expect(rows).toEqual([{ name: 'Alice', posts: [{ title: 'Post A' }] }]);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.contexts).toEqual([callerScope]);
+    expect(runtime.executions).toEqual([]);
+    expect(release).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+    expect(rollback).not.toHaveBeenCalled();
+  });
+
+  it('does not retain an internal scope while an include consumer pauses for an independent query', async () => {
+    const contract = withSingleQueryCapabilities(getTestContract());
+    const { collection, runtime } = createCollectionFor('User', contract);
+    const scoped = collection.select('name').include('posts', (posts) => posts.select('title'));
+    let acquired = false;
+    const runtimeWithConnection = addConnection(
+      runtime,
+      () => {
+        acquired = false;
+      },
+      () => {
+        acquired = true;
+      },
+    );
+    const connection = vi.spyOn(runtimeWithConnection, 'connection');
+    runtime.setNextResults([[{ name: 'Alice', posts: '[{"title":"Post A"}]' }], [{ name: 'Bob' }]]);
+    const options = {
+      context: collection.ctx.context,
+      runtime: runtimeWithConnection,
+      state: scoped.state,
+      tableName: scoped.tableName,
+      namespaceId: 'public',
+      modelName: scoped.modelName,
+    };
+    const iterator =
+      dispatchCollectionRows<Record<string, unknown>>(options)[Symbol.asyncIterator]();
+
+    try {
+      expect(await iterator.next()).toEqual({
+        done: false,
+        value: { name: 'Alice', posts: [{ title: 'Post A' }] },
+      });
+      expect(acquired).toBe(false);
+      const independent = await dispatchCollectionRows<Record<string, unknown>>({
+        ...options,
+        state: collection.select('name').state,
+      }).toArray();
+      expect(independent).toEqual([{ name: 'Bob' }]);
+      expect(connection).not.toHaveBeenCalled();
+      expect(runtime.executions).toHaveLength(2);
+    } finally {
+      await iterator.return?.();
+    }
   });
 
   it('dispatchCollectionRows() keeps correlated parent join keys out of the projection', async () => {

--- a/packages/3-targets/7-drivers/postgres/README.md
+++ b/packages/3-targets/7-drivers/postgres/README.md
@@ -15,6 +15,7 @@ The PostgreSQL driver provides transport and connection management for PostgreSQ
 In Prisma 8, "driver" refers to the Prisma 8 interface (not the underlying `pg` library). Drivers are transport-agnostic: they own pooling, connection management, and transport protocol (TCP, HTTP, etc.), but contain no dialect-specific logic. All dialect behavior lives in adapters. Instantiation is separate from connection; `create()` returns an unbound driver, `connect(binding)` binds at the boundary ([ADR 159](../../../../docs/architecture%20docs/adrs/ADR%20159%20-%20Driver%20Terminology%20and%20Lifecycle.md)).
 
 This package spans multiple planes:
+
 - **Migration plane** (`src/exports/control.ts`): Control plane entry point for driver descriptors
 - **Runtime plane** (`src/exports/runtime.ts`): Runtime entry point for driver implementation
 
@@ -31,6 +32,7 @@ Provide PostgreSQL transport and connection management. Execute SQL statements a
 - **Transport Protocol**: Handle PostgreSQL protocol (TCP, HTTP, etc.)
 
 **Non-goals:**
+
 - Dialect-specific SQL lowering (adapters)
 - Query compilation (sql-query)
 - Runtime execution (runtime)
@@ -67,6 +69,7 @@ flowchart TD
 ## Components
 
 ### Driver (`postgres-driver.ts`)
+
 - Main driver implementation
 - Implements `SqlDriver` interface
 - Manages connections and executes statements
@@ -95,9 +98,12 @@ await driver.connect({ kind: 'url', url: process.env.DATABASE_URL });
 ```
 
 Binding variants:
+
 - `{ kind: 'url', url }`: Driver creates a Pool from the connection string
 - `{ kind: 'pgPool', pool }`: Use an existing pg Pool
 - `{ kind: 'pgClient', client }`: Use an existing pg Client (direct connection)
+
+With `cursor: { disabled: true }` (or buffered cursor fallback), driver-level pool queries return their connection after fetching, before yielding buffered rows for decoding or consumption. Cursor streams retain the connection until completion or iterator cleanup. Queries on caller-owned connections and transactions never release the caller's lease.
 
 ## Exports
 
@@ -106,4 +112,3 @@ Binding variants:
   - Types: `PostgresBinding`, `PostgresDriverCreateOptions`, `QueryResult`
 - `./control`: Control plane entry point for driver descriptors
   - Default export: `DriverDescriptor` for use in `prisma.config.ts`
-

--- a/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
+++ b/packages/3-targets/7-drivers/postgres/src/postgres-driver.ts
@@ -295,6 +295,7 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
   // normalising (the prepared-statement retry layer needs the original code).
   private async *runQuery<Row>(request: SqlExecuteRequest, name?: string): AsyncIterable<Row> {
     const client = await this.acquireClient();
+    let rows: ReadonlyArray<Record<string, unknown>>;
     try {
       if (!this.options.cursorDisabled) {
         // A cursor occupies the connection for the stream's whole lifetime,
@@ -323,11 +324,12 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
         }
       }
 
-      for await (const row of this.executeBuffered(client, request.sql, request.params, name)) {
-        yield blindCast<Row, 'postgres query rows are dynamically shaped'>(row);
-      }
+      rows = await this.executeBuffered(client, request.sql, request.params, name);
     } finally {
       await this.releaseClient(client);
+    }
+    for (const row of rows) {
+      yield blindCast<Row, 'postgres query rows are dynamically shaped'>(row);
     }
   }
 
@@ -445,15 +447,14 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     }
   }
 
-  // The lock covers only the fetch: once `client.query` resolves the client
-  // is protocol-idle, and holding the lock across the yields would hand its
-  // lifetime to the consumer (deadlocking a nested query inside `for await`).
-  private async *executeBuffered(
+  // Return buffered rows separately so runQuery can release both the query
+  // lock and its owned pool lease before handing control to the consumer.
+  private async executeBuffered(
     client: PoolClient | Client,
     sql: string,
     params: readonly unknown[] | undefined,
     name?: string,
-  ): AsyncIterable<Record<string, unknown>> {
+  ): Promise<ReadonlyArray<Record<string, unknown>>> {
     const config: QueryConfig = {
       name,
       text: sql,
@@ -470,12 +471,9 @@ abstract class PostgresQueryable<C extends PoolClient | Client = PoolClient | Cl
     } finally {
       releaseLock();
     }
-    for (const row of blindCast<
-      ReadonlyArray<Record<string, unknown>>,
-      'pg does not type query rows'
-    >(result.rows)) {
-      yield row;
-    }
+    return blindCast<ReadonlyArray<Record<string, unknown>>, 'pg does not type query rows'>(
+      result.rows,
+    );
   }
 }
 

--- a/packages/3-targets/7-drivers/postgres/test/driver.buffered-release.integration.test.ts
+++ b/packages/3-targets/7-drivers/postgres/test/driver.buffered-release.integration.test.ts
@@ -1,0 +1,156 @@
+import { PGlite } from '@electric-sql/pglite';
+import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+import { timeouts } from '@repo/test-utils';
+import { Pool } from 'pg';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import postgresRuntimeDriverDescriptor from '../src/exports/runtime';
+import { queryRows } from './sql-queryable-test-utils';
+
+let cleanup: (() => Promise<void>) | undefined;
+
+async function createHarness(cursorDisabled = true) {
+  const db = await PGlite.create();
+  const server = new PGLiteSocketServer({ db, port: 0, host: '127.0.0.1' });
+  await server.start();
+  const address = server.getServerConn();
+  const pool = new Pool({
+    host: '127.0.0.1',
+    port: Number(address.slice(address.lastIndexOf(':') + 1)),
+    database: 'postgres',
+    user: 'postgres',
+    max: 1,
+    connectionTimeoutMillis: timeouts.default,
+  });
+  const driver = postgresRuntimeDriverDescriptor.create({
+    cursor: { disabled: cursorDisabled, batchSize: 1 },
+  });
+  cleanup = async () => {
+    await driver.close();
+    await server.stop();
+    await db.close();
+  };
+  await driver.connect({ kind: 'pgPool', pool });
+  const release = vi.fn();
+  pool.on('release', release);
+  return { driver, pool, release };
+}
+
+afterEach(async () => {
+  await cleanup?.();
+  cleanup = undefined;
+}, timeouts.spinUpPpgDev);
+
+describe('buffered pool release', () => {
+  it.each([false, true])(
+    'allows another query while the buffered consumer is paused (prepared: %s)',
+    async (prepared) => {
+      const { driver, pool, release } = await createHarness();
+      let handle: unknown;
+      const iterator = driver
+        .query({
+          sql: 'select generate_series(1, 2) as id',
+          ...(prepared
+            ? {
+                preparedStatementHandle: {
+                  get: () => handle,
+                  set: (value: unknown) => {
+                    handle = value;
+                  },
+                },
+              }
+            : {}),
+        })
+        [Symbol.asyncIterator]();
+      try {
+        expect(await iterator.next()).toEqual({ done: false, value: { id: 1 } });
+        expect(pool.idleCount).toBe(1);
+        expect(release).toHaveBeenCalledTimes(1);
+        expect(await queryRows(driver, 'select 3 as id')).toEqual([{ id: 3 }]);
+        expect(await iterator.next()).toEqual({ done: false, value: { id: 2 } });
+        expect(await iterator.next()).toEqual({ done: true, value: undefined });
+        expect(release).toHaveBeenCalledTimes(2);
+      } finally {
+        await iterator.return?.();
+      }
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it.each(['return', 'throw'] as const)(
+    'releases exactly once on consumer %s',
+    async (exit) => {
+      const { driver, release } = await createHarness();
+      const iterator = driver
+        .query({ sql: 'select generate_series(1, 2) as id' })
+        [Symbol.asyncIterator]();
+      try {
+        await iterator.next();
+        expect(release).toHaveBeenCalledTimes(1);
+        if (exit === 'return') {
+          await iterator.return?.();
+        } else {
+          await expect(iterator.throw?.(new Error('consumer failed'))).rejects.toThrow(
+            'consumer failed',
+          );
+        }
+        expect(release).toHaveBeenCalledTimes(1);
+      } finally {
+        await iterator.return?.();
+      }
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'releases empty results and database errors exactly once',
+    async () => {
+      const { driver, release } = await createHarness();
+      expect(await queryRows(driver, 'select 1 where false')).toEqual([]);
+      expect(release).toHaveBeenCalledTimes(1);
+      await expect(queryRows(driver, 'select * from missing_table')).rejects.toThrow();
+      expect(release).toHaveBeenCalledTimes(2);
+      expect(await queryRows(driver, 'select 3 as id')).toEqual([{ id: 3 }]);
+      expect(release).toHaveBeenCalledTimes(3);
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it.each([false, true])(
+    'retains caller-owned connection (transaction: %s)',
+    async (transactional) => {
+      const { driver, pool, release } = await createHarness();
+      const connection = await driver.acquireConnection();
+      const transaction = transactional ? await connection.beginTransaction() : undefined;
+      try {
+        expect(await queryRows(transaction ?? connection, 'select 1 as id')).toEqual([{ id: 1 }]);
+        expect(pool.idleCount).toBe(0);
+        expect(release).not.toHaveBeenCalled();
+      } finally {
+        await transaction?.rollback();
+        await connection.release();
+      }
+      expect(release).toHaveBeenCalledTimes(1);
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'retains a real cursor lease until consumer abandonment',
+    async () => {
+      const { driver, pool, release } = await createHarness(false);
+      const iterator = driver
+        .query({ sql: 'select generate_series(1, 2) as id' })
+        [Symbol.asyncIterator]();
+      try {
+        expect(await iterator.next()).toEqual({ done: false, value: { id: 1 } });
+        expect(pool.idleCount).toBe(0);
+        expect(release).not.toHaveBeenCalled();
+      } finally {
+        await iterator.return?.();
+      }
+      expect(release).toHaveBeenCalledTimes(1);
+      expect(await queryRows(driver, 'select 3 as id')).toEqual([{ id: 3 }]);
+    },
+    timeouts.spinUpPpgDev,
+  );
+});

--- a/test/integration/test/sql-orm-client/connection-release.test.ts
+++ b/test/integration/test/sql-orm-client/connection-release.test.ts
@@ -1,0 +1,201 @@
+import { int4Column, textColumn } from '@internal/adapter-postgres/column-types';
+import postgresAdapter from '@internal/adapter-postgres/runtime';
+import postgresDriver from '@internal/driver-postgres/runtime';
+import { instantiateExecutionStack } from '@internal/framework-components/execution';
+import { defineContract, field, model, rel } from '@internal/postgres/contract-builder';
+import { PostgresRuntimeImpl } from '@internal/postgres/runtime';
+import { Collection } from '@internal/sql-orm-client';
+import { createExecutionContext, createSqlExecutionStack } from '@internal/sql-runtime';
+import postgresTarget from '@internal/target-postgres/runtime';
+import { createDevDatabase, timeouts } from '@repo/test-utils';
+import { Pool } from 'pg';
+import { describe, expect, it, vi } from 'vitest';
+
+const Parent = model('Parent', {
+  fields: {
+    id: field.column(int4Column).id(),
+    name: field.column(textColumn),
+  },
+}).sql({ table: 'parents' });
+const Child = model('Child', {
+  fields: {
+    id: field.column(int4Column).id(),
+    parentId: field.column(int4Column).column('parent_id'),
+  },
+  relations: { parent: rel.belongsTo(Parent, { from: 'parentId', to: 'id' }) },
+}).sql({ table: 'children' });
+const contract = defineContract({
+  models: {
+    Parent: Parent.relations({ children: rel.hasMany(() => Child, { by: 'parentId' }) }),
+    Child,
+  },
+});
+
+async function withPooledRuntime(
+  run: (setup: Awaited<ReturnType<typeof createPooledRuntime>>) => Promise<void>,
+): Promise<void> {
+  const database = await createDevDatabase();
+  const pool = new Pool({
+    connectionString: database.connectionString,
+    max: 1,
+    connectionTimeoutMillis: timeouts.default,
+  });
+  let runtime: PostgresRuntimeImpl | undefined;
+  try {
+    const setup = await createPooledRuntime(pool);
+    runtime = setup.runtime;
+    await run(setup);
+  } finally {
+    try {
+      if (runtime) await runtime.close();
+      else await pool.end();
+    } finally {
+      await database.close();
+    }
+  }
+}
+
+async function createPooledRuntime(pool: Pool) {
+  await pool.query(`
+    create table parents (id integer primary key, name text not null);
+    create table children (id integer primary key, parent_id integer not null);
+    insert into parents values (1, 'Alice'), (2, 'Bob');
+    insert into children values (10, 1), (20, 2);
+  `);
+  const stack = createSqlExecutionStack({
+    target: postgresTarget,
+    adapter: postgresAdapter,
+    driver: {
+      ...postgresDriver,
+      create: () => postgresDriver.create({ cursor: { disabled: true } }),
+    },
+    extensions: [],
+  });
+  const context = createExecutionContext({ contract, stack });
+  const instance = instantiateExecutionStack(stack);
+  if (!instance.adapter || !instance.driver) throw new Error('Missing adapter or driver');
+  await instance.driver.connect({ kind: 'pgPool', pool });
+  const runtime = new PostgresRuntimeImpl({
+    context,
+    adapter: instance.adapter,
+    driver: instance.driver,
+    verifyMarker: false,
+  });
+  const parents = new Collection({ runtime, context }, 'Parent', { namespaceId: 'public' });
+  const included = parents
+    .select('id', 'name')
+    .orderBy((parent) => parent.id.asc())
+    .include('children', (children) => children.select('id'));
+  const codec = context.contractCodecs.forColumn('public', 'parents', 'name');
+  if (!codec) throw new Error('Missing parent name codec');
+  return { runtime, pool, parents, included, codec };
+}
+
+function gate() {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const expected = [
+  { id: 1, name: 'Alice', children: [{ id: 10 }] },
+  { id: 2, name: 'Bob', children: [{ id: 20 }] },
+];
+
+describe('integration/ORM buffered connection release', () => {
+  it(
+    'makes the size-one pool available while an included parent is decoding',
+    async () => {
+      await withPooledRuntime(async ({ pool, parents, included, codec }) => {
+        const entered = gate();
+        const resume = gate();
+        const decode = codec.decode.bind(codec);
+        const spy = vi.spyOn(codec, 'decode').mockImplementationOnce(async (wire, context) => {
+          entered.resolve();
+          await resume.promise;
+          return decode(wire, context);
+        });
+        const first = Promise.resolve(included.all());
+        try {
+          await Promise.race([
+            entered.promise,
+            first.then(() => {
+              throw new Error('Query finished without entering the parent decoder');
+            }),
+          ]);
+          expect(pool.totalCount).toBe(1);
+          expect(pool.idleCount).toBe(1);
+          await expect(
+            parents
+              .select('id')
+              .orderBy((parent) => parent.id.asc())
+              .all(),
+          ).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+          expect(pool.waitingCount).toBe(0);
+        } finally {
+          resume.resolve();
+          try {
+            await expect(first).resolves.toEqual(expected);
+          } finally {
+            spy.mockRestore();
+          }
+        }
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'makes the size-one pool available while the include consumer is paused',
+    async () => {
+      await withPooledRuntime(async ({ pool, parents, included }) => {
+        const iterator = included.all()[Symbol.asyncIterator]();
+        try {
+          expect(await iterator.next()).toEqual({ done: false, value: expected[0] });
+          expect(pool.totalCount).toBe(1);
+          expect(pool.idleCount).toBe(1);
+          await expect(
+            parents
+              .select('id')
+              .orderBy((parent) => parent.id.asc())
+              .all(),
+          ).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+          expect(await iterator.next()).toEqual({ done: false, value: expected[1] });
+          expect((await iterator.next()).done).toBe(true);
+        } finally {
+          await iterator.return?.();
+        }
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+
+  it(
+    'leaves the pool reusable after an included parent decoder fails',
+    async () => {
+      await withPooledRuntime(async ({ pool, parents, included, codec }) => {
+        const released = vi.fn();
+        pool.on('release', released);
+        const spy = vi.spyOn(codec, 'decode').mockRejectedValueOnce(new Error('Decoder failed'));
+        try {
+          await expect(included.all()).rejects.toThrow();
+          expect(pool.idleCount).toBe(1);
+          expect(released).toHaveBeenCalledTimes(1);
+          await expect(
+            parents
+              .select('id')
+              .orderBy((parent) => parent.id.asc())
+              .all(),
+          ).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+          expect(released).toHaveBeenCalledTimes(2);
+        } finally {
+          pool.off('release', released);
+          spy.mockRestore();
+        }
+      });
+    },
+    timeouts.spinUpPpgDev,
+  );
+});


### PR DESCRIPTION
## Linked issue

n/a — focused connection-lifecycle bug fix. No Linear ticket was supplied or identified.

## At a glance

The size-one-pool regression now permits an independent query while the first buffered iterator is paused:

```ts
expect(await iterator.next()).toEqual({ done: false, value: { id: 1 } });
expect(pool.idleCount).toBe(1);
expect(await queryRows(driver, 'select 3 as id')).toEqual([{ id: 3 }]);
```

Previously, the consumer retained the internally acquired lease after PostgreSQL had buffered the result.

## Summary

Release internally owned PostgreSQL connections once buffered fetching finishes, before downstream decoding or consumption. Remove the ORM include read's redundant internal connection scope so it cannot extend that lease across result processing.

## Decision

Buffered fetching returns rows to `runQuery`, which releases its owned client in `finally` before yielding them. Single-query include reads execute against the supplied runtime rather than acquiring an additional scope.

Real cursors retain their lease until completion or iterator cleanup. Caller-owned connections and transactions remain caller-owned.

## Testing performed

Previously run in the original implementation worktree:

- PostgreSQL driver: 159 tests.
- ORM client: 801 tests.
- SQL runtime: 343 tests.
- Connection-release integration tests: 3 tests.
- Relevant package typechecks passed.

The focused PR files were copied unchanged into an isolated branch. These suites were not rerun during PR preparation; `git diff --check` passed and the remote comparison was verified to contain exactly one commit and the seven intended files.

Regression coverage includes paused buffered/prepared consumers, paused parent decoding, independent queries through a size-one pool, exact-once cleanup, failures, caller ownership and real cursor retention.

## Skill update

No skill update required: no API or authoring syntax changes. The driver and ORM package READMEs document the corrected lease ownership behavior.

## Checklist

- [x] All commits are signed off per the DCO.
- [x] CONTRIBUTING.md read; change scoped to one logical concern.
- [x] Tests updated.
- [ ] Linear-prefixed title — no ticket identified; none fabricated.
- [x] Skill update section completed.

## Notes for the reviewer

Only connection-hold fixes, regression tests and their package documentation are included. No scheduling yields, checkpoints, benchmarks, experimental instrumentation, metadata-cache prototypes or performance reports. No throughput improvement is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Buffered PostgreSQL queries now release pooled connections before rows are decoded or consumed, improving availability for concurrent queries.
  * Cursor streams retain connections until completion or cleanup.
  * Caller-owned connections and transactions remain under caller control and are not released automatically.
  * Include queries no longer acquire an additional runtime scope.
* **Documentation**
  * Clarified connection-release behavior for buffered queries, cursor streams, include queries, and caller-owned resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->