### PR TITLE
test: add coverage for UniqueConstraint.from branches

### DIFF
--- a/packages/2-sql/1-core/contract/test/unique-constraint.test.ts
+++ b/packages/2-sql/1-core/contract/test/unique-constraint.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { UniqueConstraint } from '../src/ir/unique-constraint';
+
+describe('UniqueConstraint', () => {
+  it('constructs with columns and no name', () => {
+    const uc = new UniqueConstraint({ columns: ['email'] });
+    expect(uc.columns).toEqual(['email']);
+    expect(uc.name).toBeUndefined();
+  });
+
+  it('constructs with columns and a name', () => {
+    const uc = new UniqueConstraint({ columns: ['email'], name: 'users_email_key' });
+    expect(uc.columns).toEqual(['email']);
+    expect(uc.name).toBe('users_email_key');
+  });
+
+  it('is frozen', () => {
+    const uc = new UniqueConstraint({ columns: ['email'] });
+    expect(Object.isFrozen(uc)).toBe(true);
+  });
+});
+
+describe('UniqueConstraint.from', () => {
+  it('constructs a new instance from plain input', () => {
+    const uc = UniqueConstraint.from({ columns: ['email'] });
+    expect(uc).toBeInstanceOf(UniqueConstraint);
+    expect(uc.columns).toEqual(['email']);
+  });
+
+  it('passes an existing instance through unchanged', () => {
+    const original = new UniqueConstraint({ columns: ['email'], name: 'users_email_key' });
+    const result = UniqueConstraint.from(original);
+    expect(result).toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary
Adds direct test coverage for `UniqueConstraint` in `packages/2-sql/1-core/contract/src/ir/unique-constraint.ts`, including the `static from()` factory's pass-through vs. construct branches.

- `unique-constraint.ts`: 100% statements/branches/functions/lines (up from 83%/75%/100%/100%)

Related to the M9 target-extensible-IR coverage gap noted in `coverage.config.json` (TML-2521).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for unique constraint creation, optional names, immutability, and factory conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->